### PR TITLE
Add picard filters to sample_qc

### DIFF
--- a/gnomad_qc/v3/resources/sample_qc.py
+++ b/gnomad_qc/v3/resources/sample_qc.py
@@ -116,6 +116,8 @@ pca_samples_rankings = TableResource(f'{SAMPLE_QC_ROOT}/gnomad_v3_pca_samples_ra
 # Ranking of all release samples based on quality metrics. Used to remove relateds for release.
 release_samples_rankings = TableResource(f'{SAMPLE_QC_ROOT}/gnomad_v3_release_samples_ranking.ht')
 
+# Picard metrics 
+picard_metrics = TableResource(f'{SAMPLE_QC_ROOT}/gnomad_v3_picard_metrics.ht')
 
 # Duplicated (or twin) samples
 duplicates = TableResource(f'{SAMPLE_QC_ROOT}/gnomad_v3_duplicates.ht')

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -103,7 +103,6 @@ def compute_qc_mt() -> hl.MatrixTable:
 
 def compute_hard_filters(cov_threshold: int) -> hl.Table:
     ht = get_gnomad_v3_mt(remove_hard_filtered_samples=False).cols()
-
     hard_filters = dict()
 
     # Remove samples failing fingerprinting
@@ -134,6 +133,13 @@ def compute_hard_filters(cov_threshold: int) -> hl.Table:
     sex_ht = v3_sex.ht()[ht.key]
     hard_filters['ambiguous_sex'] = (sex_ht.sex_karyotype == 'Ambiguous')
     hard_filters['sex_aneuploidy'] = ~hl.set({'Ambiguous', 'XX', 'XY'}).contains(sex_ht.sex_karyotype)
+
+    # Remove samples that fail picard metric thresholds, percents are not divided by 100, e.g. 5% == 5.00, %5 != 0.05
+    picard_ht = picard_metrics.ht()[ht.key]
+    hard_filters['contamination'] = picard_ht.bam_metrics.freemix > 5.00
+    hard_filters['chimera'] = picard_ht.bam_metrics.pct_chimeras > 5.00
+    hard_filters['coverage'] = picard_ht.bam_metrics.mean_coverage < 15
+    hard_filters['insert_size'] = picard_ht.bam_metrics.median_insert_size < 250
 
     ht = ht.annotate(
         hard_filters=add_filters_expr(

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -155,7 +155,7 @@ def compute_sex() -> hl.Table:
     # Compute sex chrom poloidy
     ht = impute_sex_ploidy(
         get_gnomad_v3_mt(remove_hard_filtered_samples=False),
-        excluded_intervals=telomeres_and_centromeres.ht()
+        excluded_calling_intervals=telomeres_and_centromeres.ht()
     )
     ht = ht.checkpoint('gs://gnomad-tmp/sex_depth.ht', overwrite=True)
 


### PR DESCRIPTION
Small PR. Added picard metric filtering to sample_qc and the HT to resources. The thresholds for each metric are the same from v2. Sample callrate is not included but I can add it in. Since this would require a densify, we could use a similar approach to what KC did in UKBB: https://github.com/macarthur-lab/ukbb_qc/blob/d8fcc39342f9e203db3a7972bec688a236b1931e/ukbb_qc/utils/sparse_utils.py#L16 