### PR TITLE
hard filter fixes and add options for re-annotating sex

### DIFF
--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -450,8 +450,11 @@ y_ploidy_cutoffs=hl.struct(
             **get_sex_expr(
                 sex_ht.chrX_ploidy,
                 sex_ht.chrY_ploidy,
-                (upper_x, (lower_xx, upper_xx), lower_xxx),
-                ((lower_y, upper_y), lower_yy)
+                (x_ploidy_cutoffs['upper_x'], 
+                (x_ploidy_cutoffs['lower_xx'], x_ploidy_cutoffs['upper_xx']), 
+                x_ploidy_cutoffs['lower_xxx']),
+                ((y_ploidy_cutoffs['lower_y'], y_ploidy_cutoffs['upper_y']),
+                y_ploidy_cutoffs['lower_yy'])
             )
         )
         sex_ht = sex_ht.annotate_globals(

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -458,17 +458,8 @@ y_ploidy_cutoffs=hl.struct(
             )
         )
         sex_ht = sex_ht.annotate_globals(
-            x_ploidy_cutoffs=hl.struct(
-                upper_cutoff_X=upper_x,
-                lower_cutoff_XX=lower_xx,
-                upper_cutoff_XX=upper_xx,
-                lower_cutoff_XXX=lower_xxx,
-            ),
-            y_ploidy_cutoffs=hl.struct(
-                lower_cutoff_Y=lower_y,
-                upper_cutoff_Y=upper_y,
-                lower_cutoff_YY=lower_yy,
-            ),
+            x_ploidy_cutoffs=x_ploidy_cutoffs,
+            y_ploidy_cutoffs=y_ploidy_cutoffs,
         )
         sex_ht.write(sex.path, overwrite=args.overwrite)
 

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -168,8 +168,8 @@ def compute_hard_filters(cov_threshold: int, include_sex_filter: bool = True) ->
     if include_sex_filter:
         # Remove samples with ambiguous sex assignments
         sex_ht = sex.ht()[ht.key]
-        hard_filters['ambiguous_sex'] = (sex_ht.sex_karyotype == 'Ambiguous')
-        hard_filters['sex_aneuploidy'] = ~hl.set({'Ambiguous', 'XX', 'XY'}).contains(sex_ht.sex_karyotype)
+        hard_filters['ambiguous_sex'] = (sex_ht.sex_karyotype == 'ambiguous')
+        hard_filters['sex_aneuploidy'] = ~hl.set({'ambiguous', 'XX', 'XY'}).contains(sex_ht.sex_karyotype)
 
     ht = ht.annotate(
         hard_filters=add_filters_expr(

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -435,14 +435,17 @@ def main(args):
             sex_ht.filter(hl.is_missing(hard_filter_ht[sex_ht.key])),
             f_stat_cutoff=0.5
         )
-        upper_x = args.upper_x if args.upper_x else x_ploidy_cutoff[0]
-        lower_xx = args.lower_xx if args.lower_xx else x_ploidy_cutoff[1][0]
-        upper_xx = args.upper_xx if args.upper_xx else x_ploidy_cutoff[1][1]
-        lower_xxx = args.lower_xxx if args.lower_xxx else x_ploidy_cutoff[2]
-        lower_y = args.lower_y if args.lower_y else y_ploidy_cutoff[0][0]
-        upper_y = args.upper_y if args.upper_y else y_ploidy_cutoff[0][1]
-        lower_yy = args.lower_yy if args.lower_yy else y_ploidy_cutoff[1]
-
+x_ploidy_cutoffs = hl.struct(
+    upper_x = args.upper_x if args.upper_x else x_ploidy_cutoff[0],
+    lower_xx = args.lower_xx if args.lower_xx else x_ploidy_cutoff[1][0],
+    upper_xx = args.upper_xx if args.upper_xx else x_ploidy_cutoff[1][1],
+    lower_xxx = args.lower_xxx if args.lower_xxx else x_ploidy_cutoff[2]
+)
+y_ploidy_cutoffs=hl.struct(
+    lower_y = args.lower_y if args.lower_y else y_ploidy_cutoff[0][0],
+    upper_y = args.upper_y if args.upper_y else y_ploidy_cutoff[0][1],
+    lower_yy = args.lower_yy if args.lower_yy else y_ploidy_cutoff[1]
+)
         sex_ht = sex_ht.annotate(
             **get_sex_expr(
                 sex_ht.chrX_ploidy,

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -435,17 +435,17 @@ def main(args):
             sex_ht.filter(hl.is_missing(hard_filter_ht[sex_ht.key])),
             f_stat_cutoff=0.5
         )
-x_ploidy_cutoffs = hl.struct(
-    upper_x = args.upper_x if args.upper_x else x_ploidy_cutoff[0],
-    lower_xx = args.lower_xx if args.lower_xx else x_ploidy_cutoff[1][0],
-    upper_xx = args.upper_xx if args.upper_xx else x_ploidy_cutoff[1][1],
-    lower_xxx = args.lower_xxx if args.lower_xxx else x_ploidy_cutoff[2]
-)
-y_ploidy_cutoffs=hl.struct(
-    lower_y = args.lower_y if args.lower_y else y_ploidy_cutoff[0][0],
-    upper_y = args.upper_y if args.upper_y else y_ploidy_cutoff[0][1],
-    lower_yy = args.lower_yy if args.lower_yy else y_ploidy_cutoff[1]
-)
+        x_ploidy_cutoffs = hl.struct(
+            upper_x = args.upper_x if args.upper_x else x_ploidy_cutoff[0],
+            lower_xx = args.lower_xx if args.lower_xx else x_ploidy_cutoff[1][0],
+            upper_xx = args.upper_xx if args.upper_xx else x_ploidy_cutoff[1][1],
+            lower_xxx = args.lower_xxx if args.lower_xxx else x_ploidy_cutoff[2]
+        )
+        y_ploidy_cutoffs=hl.struct(
+            lower_y = args.lower_y if args.lower_y else y_ploidy_cutoff[0][0],
+            upper_y = args.upper_y if args.upper_y else y_ploidy_cutoff[0][1],
+            lower_yy = args.lower_yy if args.lower_yy else y_ploidy_cutoff[1]
+        )
         sex_ht = sex_ht.annotate(
             **get_sex_expr(
                 sex_ht.chrX_ploidy,
@@ -473,7 +473,7 @@ y_ploidy_cutoffs=hl.struct(
 
     if args.run_pc_relate:
         logger.info('Running PC-Relate')
-        logger.warn("PC-relate requires SSDs and doesn't work with preemptible workers!")
+        logger.warning("PC-relate requires SSDs and doesn't work with preemptible workers!")
         qc_mt = qc.mt()
         eig, scores, _ = hl.hwe_normalized_pca(qc_mt.GT, k=10, compute_loadings=False)
         scores = scores.checkpoint(pc_relate_pca_scores.path, overwrite=args.overwrite, _read_if_exists=not args.overwrite)

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -149,12 +149,12 @@ def compute_hard_filters(cov_threshold: int, include_sex_filter: bool = True) ->
 
     # Remove extreme raw bi-allelic sample QC outliers
     # These were determined by visual inspection of the metrics in gs://gnomad/sample_qc/  v3_genomes_sample_qc.ipynb
-    bi_allelic_qc_ht = hl.read_table(f'{get_sample_qc().path[:-3]}_bi_allelic.ht')[ht.key]
+    bi_allelic_qc_struct = get_sample_qc('bi-allelic').ht()[ht.key]
     hard_filters['bad_qc_metrics'] = (
-            (bi_allelic_qc_ht.sample_qc.n_snp > 3.75e6) |
-            (bi_allelic_qc_ht.sample_qc.n_snp < 2.4e6) |
-            (bi_allelic_qc_ht.sample_qc.n_singleton > 1e5) |
-            (bi_allelic_qc_ht.sample_qc.r_het_hom_var > 3.3)
+            (bi_allelic_qc_struct.sample_qc.n_snp > 3.75e6) |
+            (bi_allelic_qc_struct.sample_qc.n_snp < 2.4e6) |
+            (bi_allelic_qc_struct.sample_qc.n_singleton > 1e5) |
+            (bi_allelic_qc_struct.sample_qc.r_het_hom_var > 3.3)
     )
 
     # Remove samples that fail picard metric thresholds, percents are not divided by 100, e.g. 5% == 5.00, %5 != 0.05

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -100,7 +100,7 @@ def compute_qc_mt() -> hl.MatrixTable:
     mt = mt.filter_rows(
         (hl.len(mt.alleles) == 2) &
         hl.is_snp(mt.alleles[0], mt.alleles[1]) &
-        (qc_sites[mt.row_key].alleles == mt.alleles)
+        (qc_sites[mt.locus].alleles == mt.alleles)
 
     )
     mt = mt.checkpoint('gs://gnomad-tmp/gnomad_v3_qc_mt_v2_sites_dense.mt', overwrite=True)


### PR DESCRIPTION
Modified hard filters to remove picard coverage and allow for an option to include sex hard filters. Also modified sex annotation to redo ploidy estimates after removing hard filtered samples (from all other hard filters, can't do at impute_sex step because we use coverage on chr20 determined from that step as a hard filter) and add any other changes to automated cutoffs. 