### PR TITLE
Fix info ht

### DIFF
--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -41,8 +41,8 @@ logger.setLevel(logging.INFO)
 
 def compute_info() -> hl.Table:
     """
-    Computes a HT with the typical GATK AS and site-level info fields
-    as well as ACs and lowqual fields.
+    Computes a HT with the typical GATK AS and site-level info fields as well as ACs and lowqual fields.
+
     Note that this table doesn't split multi-allelic sites.
 
     :return: Table with info fields
@@ -131,8 +131,7 @@ def compute_info() -> hl.Table:
 
 def split_info() -> hl.Table:
     """
-    Generates an info table that splits multi-allelic sites from
-    the multi-allelic info table.
+    Generates an info table that splits multi-allelic sites from the multi-allelic info table.
 
     :return: Info table with split multi-allelics
     :rtype: Table
@@ -185,9 +184,9 @@ def generate_allele_data(ht: hl.Table) -> hl.Table:
 
 def generate_ac(mt: hl.MatrixTable) -> hl.Table:
     """
-    Creates Table with QC samples, QC samples removing children and release samples raw and adj ACs.
+    Creates Table containing allele counts per variant.
 
-    Returned table contains the following annotations:
+    Returns table containing the following annotations:
         - `ac_qc_samples_raw`: Allele count of high quality samples
         - `ac_qc_samples_unrelated_raw`: Allele count of high quality unrelated samples
         - `ac_release_samples_raw`: Allele count of release samples
@@ -217,7 +216,7 @@ def generate_fam_stats(
         fam_file: str
 ) -> hl.Table:
     """
-    Calculate transmission and de novo mutation statistics using trios in the dataset
+    Calculate transmission and de novo mutation statistics using trios in the dataset.
 
     :param mt: Input MatrixTable
     :param fam_file: path to text file containing trio pedigree
@@ -265,7 +264,7 @@ def generate_fam_stats(
 
 def export_transmitted_singletons_vcf():
     """
-    Exports the transmitted singleton Table to a VCF
+    Exports the transmitted singleton Table to a VCF.
 
     :return: None
     """
@@ -288,7 +287,7 @@ def export_transmitted_singletons_vcf():
 
 def run_vep(vep_version: str = "101") -> hl.Table:
     """
-    Returns a table with a VEP annotation for each variant in the raw MatrixTable
+    Returns a table with a VEP annotation for each variant in the raw MatrixTable.
 
     :param vep_version: Version of VEPed context Table to use in `vep_or_lookup_vep`
     :return: VEPed Table

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -155,6 +155,7 @@ def generate_allele_data(ht: hl.Table) -> hl.Table:
     """
     Returns bi-allelic sites HT with the following annotations:
      - allele_data (nonsplit_alleles, has_star, variant_type, and n_alt_alleles)
+
     :param Table ht: Full unsplit HT
     :return: Table with allele data annotations
     :rtype: Table
@@ -185,6 +186,17 @@ def generate_allele_data(ht: hl.Table) -> hl.Table:
 def generate_ac(mt: hl.MatrixTable) -> hl.Table:
     """
     Creates Table with QC samples, QC samples removing children and release samples raw and adj ACs.
+
+    Returned table contains the following annotations:
+        - `ac_qc_samples_raw`: Allele count of high quality samples
+        - `ac_qc_samples_unrelated_raw`: Allele count of high quality unrelated samples
+        - `ac_release_samples_raw`: Allele count of release samples
+        - `ac_qc_samples_adj`: Allele count of high quality samples after adj filtering
+        - `ac_qc_samples_unrelated_adj`: Allele count of high quality unrelated samples after adj filtering
+        - `ac_release_samples_adj`: Allele count of release samples after adj filtering
+
+    :param mt: Input MatrixTable
+    :return: Table containing allele counts
     """
     mt = mt.filter_cols(mt.meta.high_quality)
     mt = mt.filter_rows(hl.len(mt.alleles) > 1)
@@ -204,6 +216,13 @@ def generate_fam_stats(
         mt: hl.MatrixTable,
         fam_file: str
 ) -> hl.Table:
+    """
+    Calculate transmission and de novo mutation statistics using trios in the dataset
+
+    :param mt: Input MatrixTable
+    :param fam_file: path to text file containing trio pedigree
+    :return: Table containing trio stats
+    """
     # Load Pedigree data and filter MT to samples present in any of the trios
     ped = hl.Pedigree.read(fam_file, delimiter="\t")
     fam_ht = hl.import_fam(fam_file, delimiter="\t")
@@ -245,6 +264,11 @@ def generate_fam_stats(
 
 
 def export_transmitted_singletons_vcf():
+    """
+    Exports the transmitted singleton Table to a VCF
+
+    :return: None
+    """
     qc_ac_ht = qc_ac.ht()
 
     for transmission_confidence in ['raw', 'adj']:

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -2,11 +2,10 @@ import argparse
 import logging
 from typing import List
 
-
 import hail as hl
 
 from gnomad.sample_qc.relatedness import generate_trio_stats_expr
-from gnomad.utils.annotations import annotate_adj, get_adj_expr, get_lowqual_expr
+from gnomad.utils.annotations import add_variant_type, annotate_adj, get_adj_expr, get_lowqual_expr
 from gnomad.utils.filtering import filter_to_autosomes
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.sparse_mt import (
@@ -21,6 +20,7 @@ from gnomad.utils.vcf import ht_to_vcf_mt
 from gnomad.utils.vep import vep_or_lookup_vep
 from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v3.resources.annotations import (
+    allele_data,
     fam_stats,
     get_info,
     info_vcf_path,
@@ -151,21 +151,50 @@ def split_info() -> hl.Table:
     return info_ht
 
 
-def generate_ac(mt: hl.MatrixTable, fam_file: str) -> hl.Table:
+def generate_allele_data(mt: hl.MatrixTable) -> hl.Table:
+    """
+    Writes bi-allelic sites MT with the following annotations:
+     - allele_data (nonsplit_alleles, has_star, variant_type, and n_alt_alleles)
+    :param MatrixTable mt: Full unsplit MT
+    :return: Table with allele data annotations
+    :rtype: Table
+    """
+    ht = mt.rows().select()
+    allele_data = hl.struct(
+        nonsplit_alleles=ht.alleles, has_star=hl.any(lambda a: a == "*", ht.alleles)
+    )
+    ht = ht.annotate(allele_data=allele_data.annotate(**add_variant_type(ht.alleles)))
+
+    ht = hl.split_multi_hts(ht)
+    ht = ht.filter(hl.len(ht.alleles) > 1)
+    allele_type = (
+        hl.case()
+        .when(hl.is_snp(ht.alleles[0], ht.alleles[1]), "snv")
+        .when(hl.is_insertion(ht.alleles[0], ht.alleles[1]), "ins")
+        .when(hl.is_deletion(ht.alleles[0], ht.alleles[1]), "del")
+        .default("complex")
+    )
+    ht = ht.annotate(
+        allele_data=ht.allele_data.annotate(
+            allele_type=allele_type, was_mixed=ht.allele_data.variant_type == "mixed"
+        )
+    )
+    return ht
+
+
+def generate_ac(mt: hl.MatrixTable) -> hl.Table:
     """
     Creates Table with QC samples, QC samples removing children and release samples raw and adj ACs.
     """
     mt = mt.filter_cols(mt.meta.high_quality)
-    fam_ht = hl.import_fam(fam_file, delimiter="\t")
-    mt = mt.annotate_cols(unrelated_sample=hl.is_missing(fam_ht[mt.s]))
     mt = mt.filter_rows(hl.len(mt.alleles) > 1)
     mt = annotate_adj(mt)
     mt = mt.annotate_rows(
         ac_qc_samples_raw=hl.agg.sum(mt.GT.n_alt_alleles()),
-        ac_qc_samples_unrelated_raw=hl.agg.filter(~mt.meta.all_samples_related, hl.agg.sum(mt.GT.n_alt_alleles())),
+        ac_qc_samples_unrelated_raw=hl.agg.filter(~mt.meta.sample_filters.all_samples_related, hl.agg.sum(mt.GT.n_alt_alleles())),
         ac_release_samples_raw=hl.agg.filter(mt.meta.release, hl.agg.sum(mt.GT.n_alt_alleles())),
         ac_qc_samples_adj=hl.agg.filter(mt.adj, hl.agg.sum(mt.GT.n_alt_alleles())),
-        ac_qc_samples_unrelated_adj=hl.agg.filter(~mt.meta.all_samples_related & mt.adj, hl.agg.sum(mt.GT.n_alt_alleles())),
+        ac_qc_samples_unrelated_adj=hl.agg.filter(~mt.meta.sample_filters.all_samples_related & mt.adj, hl.agg.sum(mt.GT.n_alt_alleles())),
         ac_release_samples_adj=hl.agg.filter(mt.meta.release & mt.adj, hl.agg.sum(mt.GT.n_alt_alleles())),
     )
     return mt.rows()
@@ -194,21 +223,17 @@ def generate_fam_stats(
     mt = mt.filter_rows(hl.len(mt.alleles) == 2)
     mt = hl.trio_matrix(mt, pedigree=ped, complete_trios=True)
     trio_adj = (mt.proband_entry.adj & mt.father_entry.adj & mt.mother_entry.adj)
-    parents_no_alt = (mt.mother_entry.AD[1] == 0) & (mt.father_entry.AD[1] == 0)
-    parents_high_depth = (mt.mother_entry.AD[0] + mt.mother_entry.AD[1] > 20) & (mt.father_entry.AD[0] + mt.father_entry.AD[1] > 20)
-    parents_high_gq = (mt.mother_entry.GQ >= 30) & (mt.father_entry.GQ >= 30)
 
     ht = mt.select_rows(
         **generate_trio_stats_expr(
             mt,
             transmitted_strata={
-                'raw': None,
+                'raw': True,
                 'adj': trio_adj
             },
             de_novo_strata={
-                'raw': None,
+                'raw': True,
                 'adj': trio_adj,
-                'hq': trio_adj & parents_high_gq & parents_high_depth & parents_no_alt
             },
             proband_is_female_expr=mt.is_female
         )
@@ -234,7 +259,7 @@ def export_transmitted_singletons_vcf():
 
         ts_mt = ts_ht.to_matrix_table_row_major(columns=['s'], entry_field_name='s')
         ts_mt = ts_mt.filter_cols(False)
-        hl.export_vcf(ts_mt, get_transmitted_singleton_vcf_path(transmission_confidence))
+        hl.export_vcf(ts_mt, get_transmitted_singleton_vcf_path(transmission_confidence), tabix=True)
 
 
 def run_vep() -> hl.Table:
@@ -256,10 +281,13 @@ def run_vep() -> hl.Table:
             intervals_json = json.load(f)['jRangeBounds']
             return hl.tarray(hl.tinterval(hl.tstruct(locus=mt.locus.dtype)))._convert_from_json(intervals_json)
 
-    ht = get_gnomad_v3_mt(key_by_locus_and_alleles=True).rows()
+    ht = get_gnomad_v3_mt(key_by_locus_and_alleles=True, remove_hard_filtered_samples=False).rows()
     ht = ht.filter(hl.len(ht.alleles) > 1)
+    ht = hl.split_multi_hts(ht)
+    ht = hl.vep(ht)
+    ht = ht.annotate_globals(version='v101')
 
-    return vep_or_lookup_vep(ht, reference='GRCh38')
+    return ht
 
 
 def main(args):
@@ -275,18 +303,22 @@ def main(args):
         info_ht = get_info(split=False).ht()
         hl.export_vcf(ht_to_vcf_mt(info_ht), info_vcf_path())
 
-    # if args.generate_ac: # TODO: compute AC and qc_AC as part of compute_info
-    # mt = get_gnomad_v3_mt(key_by_locus_and_alleles=True, samples_meta=True)
-    # mt = hl.experimental.sparse_split_multi(mt, filter_changed_loci=True)
-    #
-    # ht = generate_ac(mt, ).checkpoint('gs://gnomad-tmp/v3_ac_tmp.ht', overwrite=args.overwrite, _read_if_exists=not args.overwrite)
-    # ht.repartition(10000, shuffle=False).write(ac_ht_path, overwrite=args.overwrite)
+    if args.generate_allele_data:
+        mt = get_gnomad_v3_mt(key_by_locus_and_alleles=True)
+        generate_allele_data(mt).write(allele_data.path, overwrite=args.overwrite)
+
+    if args.generate_ac:  # TODO: compute AC and qc_AC as part of compute_info
+        mt = get_gnomad_v3_mt(key_by_locus_and_alleles=True, samples_meta=True)
+        mt = hl.experimental.sparse_split_multi(mt, filter_changed_loci=True)
+
+        ht = generate_ac(mt).checkpoint('gs://gnomad-tmp/ac_tmp.ht', overwrite=args.overwrite, _read_if_exists=not args.overwrite)
+        ht.repartition(10000, shuffle=False).write(qc_ac.path, overwrite=args.overwrite)
 
     if args.generate_fam_stats:
         mt = get_gnomad_v3_mt(key_by_locus_and_alleles=True, samples_meta=True)
         mt = hl.experimental.sparse_split_multi(mt, filter_changed_loci=True)
         fam_stats_ht = generate_fam_stats(mt, trios.path)
-        fam_stats_ht = fam_stats_ht.checkpoint('gs://gnomad-tmp/v3_fam_stats_tmp.ht', overwrite=args.overwrite, _read_if_exists=not args.overwrite)
+        fam_stats_ht = fam_stats_ht.checkpoint('gs://gnomad-tmp/fam_stats_tmp.ht', overwrite=args.overwrite, _read_if_exists=not args.overwrite)
         fam_stats_ht = fam_stats_ht.repartition(10000, shuffle=False)
         fam_stats_ht.write(fam_stats.path, overwrite=args.overwrite)
 
@@ -302,6 +334,7 @@ if __name__ == '__main__':
     parser.add_argument('--compute_info', help='Computes info HT', action='store_true')
     parser.add_argument('--split_info', help='Splits info HT', action='store_true')
     parser.add_argument('--export_info_vcf', help='Export info as VCF', action='store_true')
+    parser.add_argument("--generate_allele_data", help="Calculates allele data", action="store_true")
     parser.add_argument('--generate_ac', help='Creates a table with ACs for QC, unrelated QC and release samples (raw and adj)', action='store_true')
     parser.add_argument('--generate_fam_stats', help='Creates a table with transmitted allele counts and de novo counts.', action='store_true')
     parser.add_argument('--vep', help='Generates vep annotations.', action='store_true')

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -1,10 +1,17 @@
 import argparse
 
 from gnomad.sample_qc.relatedness import generate_trio_stats_expr
-from gnomad.utils.annotations import annotate_adj
+from gnomad.utils.annotations import annotate_adj, get_adj_expr, get_lowqual_expr
 from gnomad.utils.filtering import filter_to_autosomes
 from gnomad.utils.slack import slack_notifications
-from gnomad.utils.sparse_mt import *
+from gnomad.utils.sparse_mt import (
+    get_as_info_expr,
+    get_site_info_expr,
+    INFO_INT32_SUM_AGG_FIELDS,
+    INFO_SUM_AGG_FIELDS,
+    split_info_annotation,
+    split_lowqual_annotation
+)
 from gnomad.utils.vcf import ht_to_vcf_mt
 from gnomad.utils.vep import vep_or_lookup_vep
 from gnomad_qc.slack_creds import slack_token
@@ -13,8 +20,6 @@ from gnomad_qc.v3.resources.annotations import (
     get_info,
     info_vcf_path,
     qc_ac,
-    split_info_annotation,
-    split_lowqual_annotation,
     vep
 )
 from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt
@@ -122,7 +127,7 @@ def split_info() -> hl.Table:
     """
     info_ht = get_info(split=False).ht()
 
-    # Create split version
+    # Create split versiosplit_info_annotationn
     info_ht = hl.split_multi(info_ht)
 
     info_ht = info_ht.annotate(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -1,4 +1,7 @@
 import argparse
+import logging
+from typing import List
+
 
 import hail as hl
 
@@ -27,6 +30,13 @@ from gnomad_qc.v3.resources.annotations import (
 from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt
 from gnomad_qc.v3.resources.meta import trios
 from gnomad_qc.v3.resources.variant_qc import get_transmitted_singleton_vcf_path
+
+logging.basicConfig(
+    format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def compute_info() -> hl.Table:

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -296,7 +296,7 @@ def run_vep(vep_version: str = "101") -> hl.Table:
     ht = get_gnomad_v3_mt(key_by_locus_and_alleles=True, remove_hard_filtered_samples=False).rows()
     ht = ht.filter(hl.len(ht.alleles) > 1)
     ht = hl.split_multi_hts(ht)
-    ht = hl.vep_or_lookup_vep(ht, vep_version=vep_version)
+    ht = vep_or_lookup_vep(ht, vep_version=vep_version)
     ht = ht.annotate_globals(version=f'v{vep_version}')
 
     return ht

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -3,11 +3,11 @@ import argparse
 from gnomad.sample_qc.relatedness import generate_trio_stats_expr
 from gnomad.utils.annotations import annotate_adj
 from gnomad.utils.filtering import filter_to_autosomes
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad.utils.sparse_mt import *
 from gnomad.utils.vcf import ht_to_vcf_mt
 from gnomad.utils.vep import vep_or_lookup_vep
-
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v3.resources.annotations import (fam_stats, get_info,
                                                 info_vcf_path, qc_ac, vep)
 from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt
@@ -272,6 +272,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -104,7 +104,7 @@ def compute_info() -> hl.Table:
         AS_pab_max=hl.agg.array_agg(
             lambda ai: hl.agg.filter(
                 mt.LA.contains(ai) & mt.LGT.is_het(),
-                hl.agg.max(hl.binom_test(mt.LAD[1], hl.sum(mt.LAD), 0.5, "two-sided")),
+                hl.agg.max(hl.binom_test(mt.LAD[mt.LA.index(ai)], hl.sum(mt.LAD), 0.5, "two-sided")),
             ),
             mt.alt_alleles_range_array,
         )

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -153,7 +153,7 @@ def split_info() -> hl.Table:
 
 def generate_allele_data(mt: hl.MatrixTable) -> hl.Table:
     """
-    Returns bi-allelic sites MT with the following annotations:
+    Returns bi-allelic sites HT with the following annotations:
      - allele_data (nonsplit_alleles, has_star, variant_type, and n_alt_alleles)
     :param MatrixTable mt: Full unsplit MT
     :return: Table with allele data annotations

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -153,7 +153,7 @@ def split_info() -> hl.Table:
 
 def generate_allele_data(mt: hl.MatrixTable) -> hl.Table:
     """
-    Writes bi-allelic sites MT with the following annotations:
+    Returns bi-allelic sites MT with the following annotations:
      - allele_data (nonsplit_alleles, has_star, variant_type, and n_alt_alleles)
     :param MatrixTable mt: Full unsplit MT
     :return: Table with allele data annotations

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -1,5 +1,7 @@
 import argparse
 
+import hail as hl
+
 from gnomad.sample_qc.relatedness import generate_trio_stats_expr
 from gnomad.utils.annotations import annotate_adj, get_adj_expr, get_lowqual_expr
 from gnomad.utils.filtering import filter_to_autosomes
@@ -127,7 +129,7 @@ def split_info() -> hl.Table:
     """
     info_ht = get_info(split=False).ht()
 
-    # Create split versiosplit_info_annotationn
+    # Create split version
     info_ht = hl.split_multi(info_ht)
 
     info_ht = info_ht.annotate(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -151,15 +151,15 @@ def split_info() -> hl.Table:
     return info_ht
 
 
-def generate_allele_data(mt: hl.MatrixTable) -> hl.Table:
+def generate_allele_data(ht: hl.Table) -> hl.Table:
     """
     Returns bi-allelic sites HT with the following annotations:
      - allele_data (nonsplit_alleles, has_star, variant_type, and n_alt_alleles)
-    :param MatrixTable mt: Full unsplit MT
+    :param Table ht: Full unsplit HT
     :return: Table with allele data annotations
     :rtype: Table
     """
-    ht = mt.rows().select()
+    ht = ht.select()
     allele_data = hl.struct(
         nonsplit_alleles=ht.alleles, has_star=hl.any(lambda a: a == "*", ht.alleles)
     )
@@ -305,7 +305,7 @@ def main(args):
 
     if args.generate_allele_data:
         mt = get_gnomad_v3_mt(key_by_locus_and_alleles=True)
-        generate_allele_data(mt).write(allele_data.path, overwrite=args.overwrite)
+        generate_allele_data(mt.rows()).write(allele_data.path, overwrite=args.overwrite)
 
     if args.generate_ac:  # TODO: compute AC and qc_AC as part of compute_info
         mt = get_gnomad_v3_mt(key_by_locus_and_alleles=True, samples_meta=True)


### PR DESCRIPTION
Added changes to info creation including adding pab_max and AS_lowqual, fixing error Tim found, and using the common repo for info splitting. It is still failing pylint because there is no `slack_creds` so `from gnomad_qc.slack_creds import slack_token` doesn't work. This was the way that KC and I added in for UKBB to use the new `slack_notifications` module. I'm not sure of the best option, maybe add a `slack_creds.py` with an empty string for `slack_token` then each of us can modify it and print an error message if it's empty. 