### PR TITLE
Fix to resources so Hail isn't initialized on import

### DIFF
--- a/gnomad_qc/v3/resources/variant_qc.py
+++ b/gnomad_qc/v3/resources/variant_qc.py
@@ -27,13 +27,13 @@ String representation for NA12878 truth sample
 TRUTH_SAMPLES = {
     "syndip": {
         "s": SYNDIP,
-        "truth_mt": syndip.mt(),
-        "hc_intervals": syndip_hc_intervals.ht(),
+        "truth_mt": syndip,
+        "hc_intervals": syndip_hc_intervals,
     },
     "NA12878": {
         "s": NA12878,
-        "truth_mt": na12878_giab.mt(),
-        "hc_intervals": na12878_giab_hc_intervals.ht(),
+        "truth_mt": na12878_giab,
+        "hc_intervals": na12878_giab_hc_intervals,
     },
 }
 """
@@ -41,8 +41,8 @@ Dictionary containing necessary information for truth samples
 
 Current truth samples available are syndip and NA12878. Available data for each are the following:
     - s: sample name in the callset
-    - truth_mt: truth sample MatrixTable
-    - hc_intervals: high confidence interval Table in truth sample
+    - truth_mt: truth sample MatrixTable resource
+    - hc_intervals: high confidence interval Table resource in truth sample
 """
 
 

--- a/gnomad_qc/v3/variant_qc/evaluation.py
+++ b/gnomad_qc/v3/variant_qc/evaluation.py
@@ -205,8 +205,8 @@ def main(args):
 
             # Load truth data
             mt = get_callset_truth_data(truth_sample).mt()
-            truth_hc_intervals = TRUTH_SAMPLES[truth_sample]["hc_intervals"]
-            truth_mt = TRUTH_SAMPLES[truth_sample]["truth_mt"]
+            truth_hc_intervals = TRUTH_SAMPLES[truth_sample]["hc_intervals"].ht()
+            truth_mt = TRUTH_SAMPLES[truth_sample]["truth_mt"].mt()
             truth_mt = truth_mt.key_cols_by(s=hl.str(TRUTH_SAMPLES[truth_sample]["s"]))
 
             # Remove low quality sites


### PR DESCRIPTION
Notes from Nick here: https://atgu.slack.com/archives/CNE92R265/p1620940969023300

Mike's post here https://discuss.hail.is/t/initializing-hail-with-grch38-fails/2043 raises a good point. For reusable libraries, we should avoid anything that runs at import time and uses Hail because then simply importing a module will initialize Hail. And it will potentially be initialized with a different configuration than what you want to use. For that post, I think gnomad_qc/v3/resources/variant_qc.py is the culprit. Importing anything from gnomad_qc.v3.resources causes 2 tables and 2 matrix tables to be read https://github.com/broadinstitute/gnomad_qc/blob/9fc7088c6d160f8f0e8c0aea42e18d19a62d8d5c/gnomad_qc/v3/resources/variant_qc.py#L27-L38