### PR TITLE
Fix to filter centromeres and telomeres in sample QC

### DIFF
--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -106,7 +106,7 @@ def compute_sample_qc() -> hl.Table:
     mt = filter_ref_blocks(mt)
 
     # Remove centromeres and telomeres incase they were included
-    filter_low_conf_regions(
+    mt = filter_low_conf_regions(
         mt,
         filter_lcr=False,
         filter_decoy=False,

--- a/gnomad_qc/v3/sample_qc/sample_qc.py
+++ b/gnomad_qc/v3/sample_qc/sample_qc.py
@@ -6,7 +6,7 @@ from typing import Any, List, Tuple
 
 import hail as hl
 
-from gnomad.assessment.sanity_checks import compare_row_counts
+from gnomad.assessment.validity_checks import compare_row_counts
 from gnomad.resources.grch38.reference_data import (
     clinvar,
     lcr_intervals,


### PR DESCRIPTION
Nick identified that we forgot to save the output from `filter_low_conf_regions` and therefore in the cleaned up v3 sample QC code we are not performing the centromere and telomere filter.

Note this doesn't impact v3 or v3.1. The v3 sparse MT has no centromeres and telomeres and this was the v3.1 runtime code: https://github.com/broadinstitute/gnomad_qc/blob/efea6851a421f4bc66b73db588c0eeeb7cd27539/gnomad_qc/v3/sample_qc/sample_qc.py#L67