### PR TITLE
Replace try_slack function in v2 scripts

### DIFF
--- a/gnomad_qc/v2/annotations/generate_frequency_data.py
+++ b/gnomad_qc/v2/annotations/generate_frequency_data.py
@@ -1,6 +1,7 @@
 from gnomad.utils.file_utils import write_temp_gcs
-from  gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad_qc.v2.resources import *
+from gnomad_qc.slack_creds import slack_token
 from collections import Counter
 from gnomad.utils.annotations import pop_max_expr, project_max_expr
 import argparse
@@ -219,6 +220,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/annotations/generate_ld_data.py
+++ b/gnomad_qc/v2/annotations/generate_ld_data.py
@@ -1,11 +1,12 @@
 import gnomad.resources.grch37.gnomad_ld as ld_resources
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 from hail.utils import new_temp_file
 from hail.utils.java import Env
 from hail.linalg import BlockMatrix
 import sys
 import argparse
-from gnomad.utils.slack import try_slack
 
 COMMON_FREQ = 0.005
 RARE_FREQ = 0.0005
@@ -257,6 +258,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v2/annotations/generate_qc_annotations.py
@@ -2,8 +2,9 @@ import argparse
 import sys
 from gnomad.utils.annotations import unphase_call_expr, add_variant_type
 from gnomad.utils.filtering import filter_to_adj
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad.utils.file_utils import write_temp_gcs
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 
 
@@ -300,6 +301,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/load_data/import_gnomad_sv.py
+++ b/gnomad_qc/v2/load_data/import_gnomad_sv.py
@@ -1,4 +1,5 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 import argparse
 import logging
@@ -182,6 +183,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/load_data/import_resources.py
+++ b/gnomad_qc/v2/load_data/import_resources.py
@@ -1,4 +1,5 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 import argparse
 
@@ -95,7 +96,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)
 

--- a/gnomad_qc/v2/load_data/import_vcf.py
+++ b/gnomad_qc/v2/load_data/import_vcf.py
@@ -1,4 +1,5 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 import argparse
 import sys
@@ -42,6 +43,7 @@ if __name__ == '__main__':
         sys.exit("Exome VCFs aren't cloudable :(")
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/load_data/load_coverage.py
+++ b/gnomad_qc/v2/load_data/load_coverage.py
@@ -1,5 +1,5 @@
-
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 import sys
 import argparse
@@ -167,6 +167,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified.')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/apply_hard_filters.py
+++ b/gnomad_qc/v2/sample_qc/apply_hard_filters.py
@@ -1,4 +1,5 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.sample_qc import *
 from gnomad_qc.v2.resources import get_gnomad_data
 import argparse
@@ -171,6 +172,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/assign_subpops.py
+++ b/gnomad_qc/v2/sample_qc/assign_subpops.py
@@ -1,5 +1,6 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad.sample_qc.ancestry import pc_project
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.sample_qc import *
 from gnomad_qc.v2.sample_qc.joint_sample_qc import split_mt_by_relatedness, run_assign_population_pcs
 import argparse
@@ -181,6 +182,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/create_fam.py
+++ b/gnomad_qc/v2/sample_qc/create_fam.py
@@ -1,5 +1,6 @@
 from gnomad.sample_qc.relatedness import get_duplicated_samples, infer_families
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.sample_qc import *
 from gnomad_qc.v2.resources import CURRENT_FAM, fam_path, get_gnomad_data
 import numpy as np
@@ -616,7 +617,8 @@ if __name__ == '__main__':
         sys.exit('Error: At least one of --exomes or --genomes must be specified.')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)
 

--- a/gnomad_qc/v2/sample_qc/exomes_platform_pca.py
+++ b/gnomad_qc/v2/sample_qc/exomes_platform_pca.py
@@ -1,6 +1,7 @@
 from gnomad.utils.filtering import filter_to_autosomes
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 import numpy as np
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.sample_qc import *
 from gnomad_qc.v2.resources import get_gnomad_data, evaluation_intervals_path
 import argparse
@@ -92,6 +93,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/finalize_sample_qc.py
+++ b/gnomad_qc/v2/sample_qc/finalize_sample_qc.py
@@ -1,4 +1,5 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.sample_qc import *
 from gnomad_qc.v2.resources import SUBPOPS, metadata_exomes_tsv_path, metadata_exomes_ht_path, metadata_genomes_ht_path, metadata_genomes_tsv_path
 import argparse
@@ -119,6 +120,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/generate_hardcalls.py
+++ b/gnomad_qc/v2/sample_qc/generate_hardcalls.py
@@ -1,6 +1,7 @@
 from gnomad.utils.annotations import annotate_adj
 from gnomad.sample_qc.sex import adjust_sex_ploidy
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.sample_qc import *
 from gnomad_qc.v2.resources import get_gnomad_data, get_gnomad_data_path
 import sys
@@ -62,6 +63,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/get_topmed_dups.py
+++ b/gnomad_qc/v2/sample_qc/get_topmed_dups.py
@@ -1,5 +1,6 @@
 from gnomad.utils.filtering import filter_to_autosomes
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.variant_qc import *
 from gnomad_qc.v2.resources.sample_qc import *
 import argparse
@@ -63,6 +64,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified.')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/sample_qc/joint_sample_qc.py
+++ b/gnomad_qc/v2/sample_qc/joint_sample_qc.py
@@ -16,9 +16,10 @@ from sklearn.ensemble import RandomForestClassifier
 import pandas as pd
 import pickle
 import hail as hl
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad.utils.filtering import filter_to_autosomes, filter_low_conf_regions
 from gnomad.sample_qc.ancestry import pc_project, assign_population_pcs
+from gnomad_qc.slack_creds import slack_token
 import logging
 from typing import List, Tuple
 import argparse
@@ -417,6 +418,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/variant_qc/calculate_concordance.py
+++ b/gnomad_qc/v2/variant_qc/calculate_concordance.py
@@ -2,7 +2,8 @@ from gnomad.sample_qc.relatedness import get_duplicated_samples
 from gnomad.utils.filtering import filter_to_autosomes
 from gnomad.utils.annotations import unphase_call_expr
 from gnomad.variant_qc.evaluation import add_rank
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import sample_qc
 from gnomad_qc.v2.resources.variant_qc import *
 import pandas as pd
@@ -361,6 +362,7 @@ if __name__ == '__main__':
         sys.exit("Error: Computing --omes_by_platform requires computing --omes first. Please run --omes first (you can run with both options in a single run)")
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/variant_qc/correct_fafs.py
+++ b/gnomad_qc/v2/variant_qc/correct_fafs.py
@@ -1,5 +1,6 @@
 from gnomad_qc.v2.variant_qc.prepare_data_release import make_index_dict, make_faf_index_dict
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources import *
 import argparse
 import sys
@@ -75,6 +76,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/variant_qc/create_ranked_scores.py
+++ b/gnomad_qc/v2/variant_qc/create_ranked_scores.py
@@ -1,6 +1,7 @@
 from gnomad.variant_qc.evaluation import add_rank
 from gnomad.utils.annotations import add_variant_type
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.variant_qc import *
 import argparse
 import sys
@@ -420,6 +421,7 @@ if __name__ == '__main__':
         sys.exit('Error: At least one of --create_rank_file, --run_sanity_checks or --create_binned_file must be specified.')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/variant_qc/make_var_annot_hists.py
+++ b/gnomad_qc/v2/variant_qc/make_var_annot_hists.py
@@ -1,4 +1,5 @@
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.variant_qc import *
 import argparse
 import sys
@@ -96,6 +97,7 @@ if __name__ == '__main__':
         sys.exit('Error: One and only one of --exomes or --genomes must be specified')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/variant_qc/select_qc_set.py
+++ b/gnomad_qc/v2/variant_qc/select_qc_set.py
@@ -2,8 +2,9 @@
 # This script is kept here only for archiving purpose.
 # It was used for a one-time analysis to assess variant QC, but is not used as a regular part of gnomAD production
 
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad.variant_qc.evaluation import add_rank
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.variant_qc import *
 import argparse
 import logging
@@ -120,6 +121,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)

--- a/gnomad_qc/v2/variant_qc/variantqc.py
+++ b/gnomad_qc/v2/variant_qc/variantqc.py
@@ -1,6 +1,7 @@
 from gnomad.variant_qc.evaluation import add_rank
-from gnomad.utils.slack import try_slack
+from gnomad.utils.slack import slack_notifications
 from gnomad.variant_qc import random_forest
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v2.resources.variant_qc import *
 from pprint import pformat
 import json
@@ -659,6 +660,7 @@ if __name__ == '__main__':
         sys.exit('Error: --run_hash and --train_rf are mutually exclusive. --train_rf will generate a run hash.')
 
     if args.slack_channel:
-        try_slack(args.slack_channel, main, args)
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
     else:
         main(args)


### PR DESCRIPTION
After https://github.com/broadinstitute/gnomad_methods/pull/404, Pylint now notices these broken imports.

This replaces the old `try_slack` function with the newer [`slack_notifications`](https://broadinstitute.github.io/gnomad_methods/api_reference/utils/slack.html#gnomad.utils.slack.slack_notifications).