### PR TITLE
Fix to basic resources to split after sample filtering of UKBB samples

### DIFF
--- a/gnomad_qc/v4/sample_qc/hard_filters.py
+++ b/gnomad_qc/v4/sample_qc/hard_filters.py
@@ -212,6 +212,7 @@ def main(args):
         default_reference="GRCh38",
         tmp_dir="gs://gnomad-tmp-4day",
     )
+    # NOTE: remove this flag when the new shuffle method is the default
     hl._set_flags(use_new_shuffle='1')
 
     calling_interval_name = args.calling_interval_name

--- a/gnomad_qc/v4/sample_qc/hard_filters.py
+++ b/gnomad_qc/v4/sample_qc/hard_filters.py
@@ -207,7 +207,11 @@ def compute_hard_filters(
 
 
 def main(args):
-    hl.init(log="/gnomad_hard_filters.log", default_reference="GRCh38")
+    hl.init(
+        log="/gnomad_hard_filters.log",
+        default_reference="GRCh38",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
     calling_interval_name = args.calling_interval_name
     calling_interval_padding = args.calling_interval_padding
     test = args.test

--- a/gnomad_qc/v4/sample_qc/hard_filters.py
+++ b/gnomad_qc/v4/sample_qc/hard_filters.py
@@ -212,6 +212,8 @@ def main(args):
         default_reference="GRCh38",
         tmp_dir="gs://gnomad-tmp-4day",
     )
+    hl._set_flags(use_new_shuffle='1')
+
     calling_interval_name = args.calling_interval_name
     calling_interval_padding = args.calling_interval_padding
     test = args.test


### PR DESCRIPTION
We need to split after the filter sample calls if we want to use the remove_dead_alleles parameter. I also removed the test return. I know there are 0 samples removed, but I would have caught the split error on testing.