### PR TITLE
Split out interval coverage and interval QC for sex inference from the main `compute_sex` function

### DIFF
--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -344,6 +344,28 @@ relatedness = VersionedTableResource(
     },
 )
 
+# Sex imputation coverage aggregate stats MT
+sex_imputation_coverage = VersionedMatrixTableResource(
+    CURRENT_VERSION,
+    {
+        version: MatrixTableResource(
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.sex_imputation_coverage.mt"
+        )
+        for version in VERSIONS
+    },
+)
+
+# Sex imputation coverage aggregate stats per platform MT
+sex_imputation_platform_coverage = VersionedMatrixTableResource(
+    CURRENT_VERSION,
+    {
+        version: MatrixTableResource(
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.sex_imputation_coverage.per_platform.mt"
+        )
+        for version in VERSIONS
+    },
+)
+
 # Sex imputation results
 sex = VersionedTableResource(
     CURRENT_VERSION,

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -596,7 +596,7 @@ def main(args):
                 get_checkpoint_path("test_sex_imputation_cov", mt=True)
                 if test
                 else sex_imputation_coverage.path,
-                overwrite=args.overwrite,
+                overwrite=overwrite,
             )
 
         if args.sex_imputation_interval_qc:
@@ -621,7 +621,7 @@ def main(args):
                 get_checkpoint_path("test_sex_imputation_cov.per_platform", mt=True)
                 if test
                 else sex_imputation_platform_coverage.path,
-                overwrite=args.overwrite,
+                overwrite=overwrite,
             )
 
         if args.impute_sex:

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -625,7 +625,11 @@ def main(args):
             )
 
         if args.impute_sex:
-            vds = get_gnomad_v4_vds(remove_hard_filtered_samples=True, test=args.test)
+            vds = get_gnomad_v4_vds(
+                remove_hard_filtered_samples=False,
+                remove_hard_filtered_samples_no_sex=True,
+                test=test,
+            )
             if args.f_stat_ukb_var:
                 # The UK Biobank f-stat table contains only variants that were high callrate (0.99) and common
                 # (AF >0.001) within the UK Biobank 200K Regeneron exome dataset and it includes the UK Biobank 200K
@@ -635,7 +639,7 @@ def main(args):
             else:
                 freq_ht = (
                     hl.read_table(get_checkpoint_path("test_f_stat_sites"))
-                    if args.test
+                    if test
                     else f_stat_sites.ht()
                 )
 

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -376,7 +376,9 @@ def compute_sex(
             )
             | (
                 (interval_qc_mt.interval.start.contig == "chr20")
-                & agg_func(interval_qc_mt[f"{prefix}over_{norm_cov}x"] > prop_samples_norm)
+                & agg_func(
+                    interval_qc_mt[f"{prefix}over_{norm_cov}x"] > prop_samples_norm
+                )
             )
         ).rows()
 
@@ -462,12 +464,17 @@ def compute_sex(
                 (interval_qc_mt.n_samples >= min_platform_size)
                 & (interval_qc_mt.platform != "platform_-1")
             )
-            sex_ht = _annotate_sex(vds, _get_high_coverage_intervals_ht(interval_qc_mt, prefix="platform_"))
+            sex_ht = _annotate_sex(
+                vds, _get_high_coverage_intervals_ht(interval_qc_mt, prefix="platform_")
+            )
         else:
             logger.info(
                 "Running sex ploidy and sex karyotype estimation using high coverage intervals across the full sample set..."
             )
-            sex_ht = _annotate_sex(vds, _get_high_coverage_intervals_ht(interval_qc_mt, agg_func=lambda x: x))
+            sex_ht = _annotate_sex(
+                vds,
+                _get_high_coverage_intervals_ht(interval_qc_mt, agg_func=lambda x: x),
+            )
     else:
         calling_intervals_ht = interval_qc_mt.rows()
         if per_platform:
@@ -486,7 +493,7 @@ def compute_sex(
                     hl.vds.filter_samples(
                         vds, platform_ht.filter(platform_ht.qc_platform == platform)
                     ),
-                    calling_intervals_ht
+                    calling_intervals_ht,
                 )
                 sex_ht = sex_ht.annotate(platform=platform)
                 per_platform_sex_hts.append(sex_ht)
@@ -550,7 +557,9 @@ def main(args):
                 min_callrate=args.min_callrate,
             )
             ht.naive_coalesce(args.fstat_n_partitions).write(
-                get_checkpoint_path("test_f_stat_sites") if args.test else f_stat_sites.path,
+                get_checkpoint_path("test_f_stat_sites")
+                if args.test
+                else f_stat_sites.path,
                 overwrite=args.overwrite,
             )
 
@@ -624,7 +633,9 @@ def main(args):
                     else f_stat_sites.ht()
                 )
 
-            sex_ht_path = get_checkpoint_path("sex_imputation") if args.test else sex.path
+            sex_ht_path = (
+                get_checkpoint_path("sex_imputation") if args.test else sex.path
+            )
             # Added because without this impute_sex_chromosome_ploidy will still run even with overwrite=False
             if args.overwrite or not file_exists(sex_ht_path):
                 interval_qc_mt = (
@@ -637,7 +648,9 @@ def main(args):
                     else sex_imputation_platform_coverage.mt()
                 )
                 if args.per_platform or args.high_cov_all_platforms:
-                    platform_ht = load_platform_ht(test, calling_interval_name, calling_interval_padding)
+                    platform_ht = load_platform_ht(
+                        test, calling_interval_name, calling_interval_padding
+                    )
                 else:
                     platform_ht = None
 

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -786,6 +786,75 @@ if __name__ == "__main__":
         default=1000,
         type=int,
     )
+
+    sex_coverage_args = parser.add_argument_group(
+        "Sex imputation interval coverage",
+        "Arguments used for computing interval coverage for sex imputation.",
+    )
+    sex_coverage_args.add_argument(
+        "--sex-imputation-interval-coverage",
+        help=(
+            "Create a MatrixTable of interval-by-sample coverage on a specified list of contigs with PAR regions "
+            "excluded."
+        ),
+        action="store_true",
+    )
+    sex_coverage_args.add_argument(
+        "--normalization-contig",
+        help="Which autosomal chromosome to use for normalizing the coverage of chromosomes X and Y.",
+        type=str,
+        default="chr20",
+    )
+    sex_coverage_args.add_argument(
+        "--calling-interval-name",
+        help=(
+            "Name of calling intervals to use for interval coverage. One of: 'ukb', 'broad', or 'intersection'. Only "
+            "used if '--test' is set."
+        ),
+        type=str,
+        choices=["ukb", "broad", "intersection"],
+        default="intersection",
+    )
+    sex_coverage_args.add_argument(
+        "--calling-interval-padding",
+        help=(
+            "Number of base pair padding to use on the calling intervals. One of 0 or 50 bp. Only used if '--test' is "
+            "set."
+        ),
+        type=int,
+        choices=[0, 50],
+        default=50,
+    )
+
+    sex_interval_qc_args = parser.add_argument_group(
+        "Sex chromosome interval QC",
+        "Arguments used for making an interval QC HT from the sex imputation interval coverage MT.",
+    )
+    sex_interval_qc_args.add_argument(
+        "--sex-imputation-interval-qc",
+        help=(
+            "Create a Table of the fraction of samples per interval and per platform with mean DP over thresholds "
+            "specified by '--mean-dp-thresholds'."
+        ),
+        action="store_true",
+    )
+    sex_interval_qc_args.add_argument(
+        "--mean-dp-thresholds",
+        help=(
+            "List of mean DP cutoffs to determining the fraction of samples with mean coverage >= the cutoff for each "
+            "interval."
+        ),
+        type=int,
+        nargs="+",
+        default=[5, 10, 15, 20, 25],
+    )
+    sex_interval_qc_args.add_argument(
+        "--interval-qc-n-partitions",
+        help="Number of desired partitions for the sex imputation interval QC output Table.",
+        default=500,
+        type=int,
+    )
+
     sex_ploidy_args = parser.add_argument_group(
         "Impute sex ploidy", "Arguments used for imputing sex chromosome ploidy."
     )
@@ -845,12 +914,6 @@ if __name__ == "__main__":
         ),
         type=int,
         default=100,
-    )
-    sex_ploidy_args.add_argument(
-        "--normalization-contig",
-        help="Which autosomal chromosome to use for normalizing the coverage of chromosomes X and Y.",
-        type=str,
-        default="chr20",
     )
     sex_ploidy_args.add_argument(
         "--variant-depth-only-x-ploidy",
@@ -915,26 +978,6 @@ if __name__ == "__main__":
         ),
         type=float,
         default=0.85,
-    )
-    sex_ploidy_args.add_argument(
-        "--calling-interval-name",
-        help=(
-            "Name of calling intervals to use for interval coverage. One of: 'ukb', 'broad', or 'intersection'. Only "
-            "used if '--test' is set and final coverage MT and/or platform assignment HT are not already written."
-        ),
-        type=str,
-        choices=["ukb", "broad", "intersection"],
-        default="intersection",
-    )
-    sex_ploidy_args.add_argument(
-        "--calling-interval-padding",
-        help=(
-            "Number of base pair padding to use on the calling intervals. One of 0 or 50 bp. Only used if '--test' is "
-            "set and final coverage MT and/or platform assignment HT are not already written."
-        ),
-        type=int,
-        choices=[0, 50],
-        default=50,
     )
 
     args = parser.parse_args()

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -21,6 +21,8 @@ from gnomad_qc.v4.resources.sample_qc import (
     interval_coverage,
     platform,
     sex,
+    sex_imputation_coverage,
+    sex_imputation_platform_coverage,
 )
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -375,7 +375,7 @@ def compute_sex(
                 & agg_func(interval_qc_mt[f"{prefix}over_{y_cov}x"] > prop_samples_y)
             )
             | (
-                (interval_qc_mt.interval.start.contig == "chr20")
+                (interval_qc_mt.interval.start.contig == normalization_contig)
                 & agg_func(
                     interval_qc_mt[f"{prefix}over_{norm_cov}x"] > prop_samples_norm
                 )

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import hail as hl
 
@@ -254,7 +254,7 @@ def compute_sex(
     prop_samples_x: float = None,
     prop_samples_y: float = None,
     prop_samples_norm: float = None,
-    freq_ht=None,
+    freq_ht: Optional[hl.Table] = None,
     min_af: float = 0.001,
     f_stat_cutoff: float = 0.5,
 ) -> hl.Table:


### PR DESCRIPTION
Note: this PR is stacked on #266 and should be reviewed after #266

Moving this outside the `compute_sex` function allows us to reuse these computations rather than redo them each time we need to run the `compute_sex` function.

Also:
 - Cleans up main by moving the platform HT loading into a function.
 - Renames `high_cov_by_platform_all` -> `high_cov_all_platforms`