### PR TITLE
Split `compute_sex` into two steps: ploidy imputation and then karyotype sex inference

### DIFF
--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -19,6 +19,7 @@ logger.setLevel(logging.INFO)
 def get_gnomad_v4_vds(
     split: bool = False,
     remove_hard_filtered_samples: bool = True,
+    remove_hard_filtered_samples_no_sex: bool = False,
     release_only: bool = False,
     test: bool = False,
     n_partitions: int = None,
@@ -27,12 +28,19 @@ def get_gnomad_v4_vds(
     Wrapper function to get gnomAD v4 data with desired filtering and metadata annotations.
 
     :param split: Perform split on VDS - Note: this will perform a split on the VDS rather than grab an already split VDS
-    :param remove_hard_filtered_samples: Whether to remove samples that failed hard filters (only relevant after sample QC)
+    :param remove_hard_filtered_samples: Whether to remove samples that failed hard filters (only relevant after hard filtering is complete)
+    :param remove_hard_filtered_samples_no_sex: Whether to remove samples that failed non sex inference hard filters (only relevant after pre-sex imputation hard filtering is complete)
     :param release_only: Whether to filter the VDS to only samples available for release (can only be used if metadata is present)
     :param test: Whether to use the test VDS instead of the full v4 VDS
     :param n_partitions: Optional argument to read the VDS with a specific number of partitions
     :return: gnomAD v4 dataset with chosen annotations and filters
     """
+
+    if remove_hard_filtered_samples and remove_hard_filtered_samples_no_sex:
+        raise ValueError(
+            "Only one of 'remove_hard_filtered_samples' or 'remove_hard_filtered_samples_no_sex' can be set to True."
+        )
+
     if test:
         gnomad_v4_resource = gnomad_v4_testset
     else:
@@ -43,19 +51,28 @@ def get_gnomad_v4_vds(
     else:
         vds = gnomad_v4_resource.vds()
 
-    if remove_hard_filtered_samples:
+    if remove_hard_filtered_samples or remove_hard_filtered_samples_no_sex:
         if test:
             meta_ht = gnomad_v4_testset_meta.ht()
-            meta_ht = meta_ht.filter(
-                hl.len(meta_ht.rand_sampling_meta.hard_filters_no_sex) == 0
-            )
+            if remove_hard_filtered_samples_no_sex:
+                hard_filter_expr = meta_ht.rand_sampling_meta.hard_filters_no_sex
+            else:
+                hard_filter_expr = meta_ht.rand_sampling_meta.hard_filters
+            meta_ht = meta_ht.filter(hl.len(hard_filter_expr) == 0)
             vds = hl.vds.filter_samples(vds, meta_ht)
         else:
-            from gnomad_qc.v4.resources.sample_qc import hard_filtered_samples
-
-            vds = hl.vds.filter_samples(
-                vds, hard_filtered_samples.versions[CURRENT_VERSION].ht(), keep=False
+            from gnomad_qc.v4.resources.sample_qc import (
+                hard_filtered_samples,
+                hard_filtered_samples_no_sex,
             )
+
+            if remove_hard_filtered_samples:
+                hard_filter_ht = hard_filtered_samples.versions[CURRENT_VERSION].ht()
+            else:
+                hard_filter_ht = hard_filtered_samples_no_sex.versions[
+                    CURRENT_VERSION
+                ].ht()
+            vds = hl.vds.filter_samples(vds, hard_filter_ht, keep=False)
 
     if release_only:
         if test:

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -311,23 +311,12 @@ platform = VersionedTableResource(
     },
 )
 
-# HT containing AC information for bi-allelic variants after hard filtering
-hard_filtered_ac = VersionedTableResource(
+# HT with bi-allelic SNPs on chromosome X used in sex imputation f-stat calculation
+f_stat_sites = VersionedTableResource(
     CURRENT_VERSION,
     {
         version: TableResource(
-            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.hard_filtered.ac.ht"
-        )
-        for version in VERSIONS
-    },
-)
-
-# HT containing AN, AF, and callrate information for bi-allelic variants after hard filtering
-hard_filtered_af_callrate = VersionedTableResource(
-    CURRENT_VERSION,
-    {
-        version: TableResource(
-            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.hard_filtered.af_callrate.ht"
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.f_stat_sites.ht"
         )
         for version in VERSIONS
     },

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -366,6 +366,17 @@ sex_imputation_platform_coverage = VersionedMatrixTableResource(
     },
 )
 
+# Ploidy imputation results
+ploidy = VersionedTableResource(
+    CURRENT_VERSION,
+    {
+        version: TableResource(
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.ploidy.ht"
+        )
+        for version in VERSIONS
+    },
+)
+
 # Sex imputation results
 sex = VersionedTableResource(
     CURRENT_VERSION,

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -344,6 +344,28 @@ relatedness = VersionedTableResource(
     },
 )
 
+# Sex imputation coverage aggregate stats MT
+sex_imputation_coverage = VersionedMatrixTableResource(
+    CURRENT_VERSION,
+    {
+        version: MatrixTableResource(
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.sex_imputation_coverage.mt"
+        )
+        for version in VERSIONS
+    },
+)
+
+# Sex imputation coverage aggregate stats per platform MT
+sex_imputation_platform_coverage = VersionedMatrixTableResource(
+    CURRENT_VERSION,
+    {
+        version: MatrixTableResource(
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.sex_imputation_coverage.per_platform.mt"
+        )
+        for version in VERSIONS
+    },
+)
+
 # Sex imputation results
 sex = VersionedTableResource(
     CURRENT_VERSION,

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import Callable
+from typing import Callable, List, Optional
 
 import hail as hl
 
@@ -10,6 +10,7 @@ from gnomad.utils.slack import slack_notifications
 
 from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v4.resources.basics import (
+    calling_intervals,
     get_checkpoint_path,
     get_gnomad_v4_vds,
     get_logging_path,
@@ -20,6 +21,8 @@ from gnomad_qc.v4.resources.sample_qc import (
     interval_coverage,
     platform,
     sex,
+    sex_imputation_coverage,
+    sex_imputation_platform_coverage,
 )
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
@@ -88,13 +91,159 @@ def determine_fstat_sites(
     return ht
 
 
+def load_platform_ht(
+    test: bool = False,
+    calling_interval_name: str = "intersection",
+    calling_interval_padding: int = 50,
+) -> hl.Table:
+    """
+    Load platform assignment Table or test Table and return an error if requested Table does not exist.
+
+    .. note::
+
+        If `test` is True and the test platform assignment Table does not exist, the function will load the final
+        platform assignment Table instead if it already exists.
+
+    :param test: Whether a test platform assignment Table should be loaded.
+    :param calling_interval_name: Name of calling intervals to use for interval coverage. One of: 'ukb', 'broad', or
+        'intersection'. Only used if `test` is True.
+    :param calling_interval_padding: Number of base pair padding to use on the calling intervals. One of 0 or 50 bp.
+        Only used if `test` is True.
+    :return: Platform assignment Table.
+    """
+    logger.info("Loading platform information...")
+    test_platform_path = get_checkpoint_path(
+        f"test_platform_assignment.{calling_interval_name}.pad{calling_interval_padding}"
+    )
+    if test and file_exists(test_platform_path):
+        ht = hl.read_table(test_platform_path)
+    elif file_exists(platform.path):
+        ht = platform.ht()
+        if test:
+            logger.warning(
+                "Test platform file does not exist for calling interval %s and interval padding %s, using final "
+                "platform assignment Table instead. To use a test platform assignment please run "
+                "platform_inference.py --assign-platforms with the --test argument and needed "
+                "--calling-interval-name/--calling-interval-padding arguments.",
+                calling_interval_name,
+                calling_interval_padding,
+            )
+    elif test:
+        raise FileNotFoundError(
+            f"There is no test platform assignment Table written for calling interval {calling_interval_name} and "
+            f"interval padding {calling_interval_padding} and a final platform assignment Table does not exist. "
+            f"Please run platform_inference.py --assign-platforms with the --test argument and needed "
+            f"--calling-interval-name/--calling-interval-padding arguments."
+        )
+    else:
+        raise FileNotFoundError(
+            f"There is no final platform assignment Table written. Please run: "
+            f"platform_inference.py --assign-platforms to compute the platform assignment Table."
+        )
+
+    return ht
+
+
+def generate_sex_imputation_interval_coverage_mt(
+    vds: hl.vds.VariantDataset,
+    calling_intervals_ht: hl.Table,
+    contigs: List[str] = ["chrX", "chrY", "chr20"],
+) -> hl.MatrixTable:
+    """
+    Create a MatrixTable of interval-by-sample coverage on a specified list of contigs with PAR regions excluded.
+
+    :param vds: Input VariantDataset.
+    :param calling_intervals_ht: Calling interval Table.
+    :param contigs: Which contigs to compute interval coverage on for sex imputation. Default: 'chrX', 'chrY', 'chr20'.
+    :return: MatrixTable with interval coverage per sample on specified contigs and PAR regions excluded.
+    """
+    calling_intervals_ht = calling_intervals_ht.filter(
+        hl.literal(contigs).contains(calling_intervals_ht.interval.start.contig)
+    )
+    logger.info(
+        "Filtering VariantDataset to the following contigs: %s...",
+        ", ".join(contigs),
+    )
+    vds = hl.vds.filter_chromosomes(vds, keep=contigs)
+    rg = vds.reference_data.locus.dtype.reference_genome
+
+    par_boundaries = []
+    for par_interval in rg.par:
+        par_boundaries.append(par_interval.start)
+        par_boundaries.append(par_interval.end)
+
+    # Segment on PAR interval boundaries
+    calling_intervals = hl.segment_intervals(calling_intervals_ht, par_boundaries)
+
+    # Remove intervals overlapping PAR
+    calling_intervals = calling_intervals.filter(
+        hl.all(lambda x: ~x.overlaps(calling_intervals.interval), hl.literal(rg.par))
+    )
+
+    kept_contig_filter = hl.array(contigs).map(
+        lambda x: hl.parse_locus_interval(x, reference_genome=rg)
+    )
+    vds = hl.vds.VariantDataset(
+        hl.filter_intervals(vds.reference_data, kept_contig_filter),
+        hl.filter_intervals(vds.variant_data, kept_contig_filter),
+    )
+    mt = hl.vds.interval_coverage(vds, calling_intervals, gq_thresholds=()).drop(
+        "gq_thresholds"
+    )
+
+    return mt
+
+
+def generate_sex_imputation_interval_qc_mt(
+    mt: hl.MatrixTable,
+    platform_ht: hl.Table,
+    mean_dp_thresholds: List[int] = [5, 10, 15, 20, 25],
+) -> hl.MatrixTable:
+    """
+    Create a Table of fraction of samples per interval and per platform with mean DP over specified thresholds.
+
+    :param mt: Input sex interval coverage MatrixTable.
+    :param platform_ht: Input platform assignment Table.
+    :param mean_dp_thresholds: List of mean DP thresholds to use for computing the fraction of samples with mean
+        interval DP >= the threshold.
+    :return: MatrixTable with annotations for the fraction of samples per interval and per platform over DP thresholds.
+    """
+    mt = mt.annotate_cols(platform=platform_ht[mt.col_key].qc_platform)
+    mt = mt.annotate_rows(
+        **{
+            f"over_{dp}x": hl.agg.fraction(mt.mean_dp >= dp)
+            for dp in mean_dp_thresholds
+        },
+        mean_fraction_over_dp_0=hl.agg.mean(mt.fraction_over_dp_threshold[1]),
+    )
+    mt = mt.select_globals(mean_dp_thresholds=mean_dp_thresholds)
+
+    logger.info("Adding per platform aggregation...")
+    platform_mt = mt.group_cols_by(mt.platform).aggregate(
+        **{
+            f"platform_over_{dp}x": hl.agg.fraction(mt.mean_dp >= dp)
+            for dp in mean_dp_thresholds
+        },
+        platform_mean_fraction_over_dp_0=hl.agg.mean(mt.fraction_over_dp_threshold[1]),
+    )
+
+    platform_ht = platform_ht.group_by(platform_ht.qc_platform).aggregate(
+        n_samples=hl.agg.count()
+    )
+    platform_mt = platform_mt.annotate_cols(
+        n_samples=platform_ht[platform_mt.col_key].n_samples
+    )
+
+    return platform_mt
+
+
 def compute_sex(
     vds: hl.vds.VariantDataset,
-    coverage_mt: hl.MatrixTable,
+    interval_qc_mt: Optional[hl.MatrixTable] = None,
     high_cov_intervals: bool = False,
     per_platform: bool = False,
-    high_cov_by_platform_all: bool = False,
-    platform_ht: hl.Table = None,
+    high_cov_all_platforms: bool = False,
+    platform_ht: Optional[hl.Table] = None,
     min_platform_size: bool = 100,
     normalization_contig: str = "chr20",
     variant_depth_only_x_ploidy: bool = False,
@@ -105,7 +254,7 @@ def compute_sex(
     prop_samples_x: float = None,
     prop_samples_y: float = None,
     prop_samples_norm: float = None,
-    freq_ht=None,
+    freq_ht: Optional[hl.Table] = None,
     min_af: float = 0.001,
     f_stat_cutoff: float = 0.5,
 ) -> hl.Table:
@@ -120,7 +269,7 @@ def compute_sex(
          using per platform high coverage intervals (`x_cov`, `y_cov`, `norm_cov`, `prop_samples_x`, `prop_samples_y`,
          `prop_samples_norm`, and `min_platform_size`).
         - Use per platform stats to determine which are high coverage across all platforms (depending on platform sample
-         size). Uses parameters `high_cov_by_platform_all`, `x_cov`, `y_cov`, `norm_cov`, `prop_samples_x`,
+         size). Uses parameters `high_cov_all_platforms`, `x_cov`, `y_cov`, `norm_cov`, `prop_samples_x`,
          `prop_samples_y`, `prop_samples_norm`.
         - We use `annotate_sex`, which uses Hail's VDS imputation of sex ploidy `hail.vds.impute_sex_chromosome_ploidy`,
           and uses `variant_depth_only_x_ploidy` and `variant_depth_only_y_ploidy`.
@@ -129,9 +278,9 @@ def compute_sex(
 
     The following are the available options for chrX and chrY relative sex ploidy estimation and sex karyotype
     cutoff determination:
-        - Ploidy estimation using all intervals found in `coverage_mt`.
-        - Per platform ploidy estimation using all intervals found in `coverage_mt`. Sex karyotype cutoffs are
-        determined by per platform ploidy distributions.
+        - Ploidy estimation using all intervals found in `interval_qc_mt`.
+        - Per platform ploidy estimation using all intervals found in `interval_qc_mt`. Sex karyotype cutoffs are
+         determined by per platform ploidy distributions.
         - Ploidy estimation using only high coverage intervals across the entire dataset, defined as: chrX intervals
          having a proportion of all samples (`prop_samples_x`) with over a specified mean DP (`x_cov`), chrY intervals
          having a proportion of all samples (`prop_samples_y`) with over a specified mean DP (`y_cov`), and
@@ -163,13 +312,14 @@ def compute_sex(
          determine the contig size and doesn't break up the reference blocks in the same way the Hail method does.
 
     :param vds: Input VDS for use in sex inference
-    :param coverage_mt: Input interval coverage MatrixTable
+    :param interval_qc_mt: Optional interval QC MatrixTable. This is only needed if `high_cov_intervals` or
+        `high_cov_all_platforms` are True
     :param high_cov_intervals: Whether to filter to high coverage intervals for the sex ploidy and karyotype inference
     :param per_platform: Whether to run the sex ploidy and karyotype inference per platform
-    :param high_cov_by_platform_all: Whether to filter to high coverage intervals for the sex ploidy and karyotype
+    :param high_cov_all_platforms: Whether to filter to high coverage intervals for the sex ploidy and karyotype
         inference. Using only intervals that are considered high coverage across all platforms
-    :param platform_ht: Input platform assignment Table. This is only needed if per_platform or high_cov_by_platform_all are True
-    :param min_platform_size: Required size of a platform to be considered when using `high_cov_by_platform_all`. Only
+    :param platform_ht: Input platform assignment Table. This is only needed if `per_platform` or `high_cov_all_platforms` are True
+    :param min_platform_size: Required size of a platform to be considered when using `high_cov_all_platforms`. Only
         platforms that have # of samples > 'min_platform_size' are used to determine intervals that have a
         high coverage across all platforms
     :param normalization_contig: Which autosomal chromosome to use for normalizing the coverage of chromosomes X and Y
@@ -195,36 +345,42 @@ def compute_sex(
     :return: Table with inferred sex annotation
     """
 
-    def _get_filtered_coverage_mt(
-        coverage_mt: hl.MatrixTable,
+    def _get_high_coverage_intervals_ht(
+        interval_qc_mt: hl.MatrixTable,
+        prefix: str = "",
         agg_func: Callable[
             [hl.expr.BooleanExpression], hl.BooleanExpression
         ] = hl.agg.all,
-    ) -> hl.MatrixTable:
+    ) -> hl.Table:
         """
-        Helper function to filter the interval coverage MatrixTable to high coverage intervals.
+        Helper function to create a Table filtered to high coverage intervals.
 
         High coverage intervals are determined using `agg_func`, `x_cov`, `y_cov`, `norm_cov`, `prop_samples_x`,
         `prop_samples_y`, and `prop_samples_norm`.
 
-        :param coverage_mt: Input interval coverage MatrixTable
-        :param agg_func: Hail aggregation function to determine if an interval coverage meets the `cov_*`> `prop_samples_*` criteria
-        :return: Filtered interval coverage MatrixTable
+        :param interval_qc_mt: Input interval QC MatrixTable.
+        :param prefix: Prefix of annotations in `interval_qc_mt` that contain the proportion of samples with
+            mean DP over coverage cutoffs.
+        :param agg_func: Hail aggregation function to determine if an interval coverage meets the
+            `cov_*` > `prop_samples_*` criteria.
+        :return: Table of high coverage intervals.
         """
-        return coverage_mt.filter_rows(
+        return interval_qc_mt.filter_rows(
             (
-                (coverage_mt.interval.start.contig == "chrX")
-                & agg_func(coverage_mt[f"over_{x_cov}x"] > prop_samples_x)
+                (interval_qc_mt.interval.start.contig == "chrX")
+                & agg_func(interval_qc_mt[f"{prefix}over_{x_cov}x"] > prop_samples_x)
             )
             | (
-                (coverage_mt.interval.start.contig == "chrY")
-                & agg_func(coverage_mt[f"over_{y_cov}x"] > prop_samples_y)
+                (interval_qc_mt.interval.start.contig == "chrY")
+                & agg_func(interval_qc_mt[f"{prefix}over_{y_cov}x"] > prop_samples_y)
             )
             | (
-                (coverage_mt.interval.start.contig == "chr20")
-                & agg_func(coverage_mt[f"over_{norm_cov}x"] > prop_samples_norm)
+                (interval_qc_mt.interval.start.contig == normalization_contig)
+                & agg_func(
+                    interval_qc_mt[f"{prefix}over_{norm_cov}x"] > prop_samples_norm
+                )
             )
-        )
+        ).rows()
 
     def _annotate_sex(vds, calling_intervals_ht):
         """
@@ -253,7 +409,7 @@ def compute_sex(
             hl.agg.collect_as_set(platform_ht.qc_platform)
         )
 
-    if high_cov_intervals or high_cov_by_platform_all:
+    if high_cov_intervals or high_cov_all_platforms:
         logger.info(
             "Running sex ploidy and sex karyotype estimation using only high coverage intervals: %d percent of samples "
             "with greater than %dx coverage on chrX, %d percent of samples with greater than %dx coverage on chrY, and "
@@ -267,21 +423,6 @@ def compute_sex(
             normalization_contig,
         )
 
-        if per_platform or high_cov_by_platform_all:
-            logger.info("Annotating coverage MatrixTable with platform information")
-            coverage_mt = coverage_mt.annotate_cols(
-                platform=platform_ht[coverage_mt.col_key].qc_platform
-            )
-            coverage_mt = coverage_mt.group_cols_by(coverage_mt.platform).aggregate(
-                **{
-                    f"over_{x_cov}x": hl.agg.fraction(coverage_mt.mean_dp > x_cov),
-                    f"over_{y_cov}x": hl.agg.fraction(coverage_mt.mean_dp > y_cov),
-                    f"over_{norm_cov}x": hl.agg.fraction(
-                        coverage_mt.mean_dp > norm_cov
-                    ),
-                }
-            )
-
         if per_platform:
             logger.info(
                 "Running sex ploidy and sex karyotype estimation per platform using per platform "
@@ -291,14 +432,18 @@ def compute_sex(
             x_ploidy_cutoffs = {}
             y_ploidy_cutoffs = {}
             for platform in platforms:
-                ht = platform_ht.filter(platform_ht.qc_platform == platform)
-                logger.info("Platform %s has %d samples...", platform, ht.count())
-                coverage_platform_mt = _get_filtered_coverage_mt(
-                    coverage_mt.filter_cols(coverage_mt.platform == platform)
+                logger.info(
+                    "Performing sex ploidy and sex karyotype estimation for platform %s...",
+                    platform,
                 )
-                calling_intervals_ht = coverage_platform_mt.rows()
                 sex_ht = _annotate_sex(
-                    hl.vds.filter_samples(vds, ht), calling_intervals_ht
+                    hl.vds.filter_samples(
+                        vds, platform_ht.filter(platform_ht.qc_platform == platform)
+                    ),
+                    _get_high_coverage_intervals_ht(
+                        interval_qc_mt.filter_cols(interval_qc_mt.platform == platform),
+                        prefix="platform_",
+                    ),
                 )
                 sex_ht = sex_ht.annotate(platform=platform)
                 per_platform_sex_hts.append(sex_ht)
@@ -309,42 +454,29 @@ def compute_sex(
                 x_ploidy_cutoffs=hl.struct(**x_ploidy_cutoffs),
                 y_ploidy_cutoffs=hl.struct(**y_ploidy_cutoffs),
             )
-        elif high_cov_by_platform_all:
+        elif high_cov_all_platforms:
             logger.info(
                 "Running sex ploidy and sex karyotype estimation using high coverage intervals across all platforms. "
                 "Limited to platforms with at least %s samples...",
                 min_platform_size,
             )
-            platform_n_ht = platform_ht.group_by(platform_ht.qc_platform).aggregate(
-                n_samples=hl.agg.count()
+            interval_qc_mt = interval_qc_mt.filter_cols(
+                (interval_qc_mt.n_samples >= min_platform_size)
+                & (interval_qc_mt.platform != "platform_-1")
             )
-            coverage_mt = coverage_mt.annotate_cols(
-                n_samples=platform_n_ht[coverage_mt.col_key].n_samples
+            sex_ht = _annotate_sex(
+                vds, _get_high_coverage_intervals_ht(interval_qc_mt, prefix="platform_")
             )
-            coverage_mt = coverage_mt.filter_cols(
-                coverage_mt.n_samples >= min_platform_size
-            )
-            coverage_mt = _get_filtered_coverage_mt(coverage_mt)
-            calling_intervals_ht = coverage_mt.rows()
-            sex_ht = _annotate_sex(vds, calling_intervals_ht)
         else:
             logger.info(
                 "Running sex ploidy and sex karyotype estimation using high coverage intervals across the full sample set..."
             )
-            coverage_mt = coverage_mt.annotate_rows(
-                **{
-                    f"over_{x_cov}x": hl.agg.fraction(coverage_mt.mean_dp > x_cov),
-                    f"over_{y_cov}x": hl.agg.fraction(coverage_mt.mean_dp > y_cov),
-                    f"over_{norm_cov}x": hl.agg.fraction(
-                        coverage_mt.mean_dp > norm_cov
-                    ),
-                }
+            sex_ht = _annotate_sex(
+                vds,
+                _get_high_coverage_intervals_ht(interval_qc_mt, agg_func=lambda x: x),
             )
-            coverage_mt = _get_filtered_coverage_mt(coverage_mt, lambda x: x)
-            calling_intervals_ht = coverage_mt.rows()
-            sex_ht = _annotate_sex(vds, calling_intervals_ht)
     else:
-        calling_intervals_ht = coverage_mt.rows()
+        calling_intervals_ht = interval_qc_mt.rows()
         if per_platform:
             logger.info(
                 "Running sex ploidy estimation and per platform sex karyotype estimation..."
@@ -353,10 +485,15 @@ def compute_sex(
             x_ploidy_cutoffs = {}
             y_ploidy_cutoffs = {}
             for platform in platforms:
-                ht = platform_ht.filter(platform_ht.qc_platform == platform)
-                logger.info("Platform %s has %d samples...", platform, ht.count())
+                logger.info(
+                    "Performing sex ploidy and sex karyotype estimation for platform %s...",
+                    platform,
+                )
                 sex_ht = _annotate_sex(
-                    hl.vds.filter_samples(vds, ht), calling_intervals_ht
+                    hl.vds.filter_samples(
+                        vds, platform_ht.filter(platform_ht.qc_platform == platform)
+                    ),
+                    calling_intervals_ht,
                 )
                 sex_ht = sex_ht.annotate(platform=platform)
                 per_platform_sex_hts.append(sex_ht)
@@ -374,7 +511,7 @@ def compute_sex(
     sex_ht = sex_ht.annotate_globals(
         high_cov_intervals=high_cov_intervals,
         per_platform=per_platform,
-        high_cov_by_platform_all=high_cov_by_platform_all,
+        high_cov_all_platforms=high_cov_all_platforms,
         min_platform_size=min_platform_size,
         normalization_contig=normalization_contig,
         variant_depth_only_x_ploidy=variant_depth_only_x_ploidy,
@@ -401,6 +538,11 @@ def main(args):
     # NOTE: remove this flag when the new shuffle method is the default
     hl._set_flags(use_new_shuffle="1")
 
+    test = args.test
+    calling_interval_name = args.calling_interval_name
+    calling_interval_padding = args.calling_interval_padding
+    normalization_contig = args.normalization_contig
+
     try:
         if args.determine_fstat_sites:
             vds = get_gnomad_v4_vds(
@@ -415,11 +557,69 @@ def main(args):
                 min_callrate=args.min_callrate,
             )
             ht.naive_coalesce(args.fstat_n_partitions).write(
-                get_checkpoint_path("test_f_stat_sites") if args.test else f_stat_sites.path,
+                get_checkpoint_path("test_f_stat_sites")
+                if args.test
+                else f_stat_sites.path,
                 overwrite=args.overwrite,
             )
+
+        if args.sex_imputation_interval_coverage:
+            vds = get_gnomad_v4_vds(
+                remove_hard_filtered_samples=False,
+                remove_hard_filtered_samples_no_sex=True,
+                test=test,
+            )
+            calling_intervals_ht = calling_intervals(
+                calling_interval_name, calling_interval_padding
+            ).ht()
+            coverage_mt = generate_sex_imputation_interval_coverage_mt(
+                vds,
+                calling_intervals_ht,
+                contigs=["chrX", "chrY", normalization_contig],
+            )
+            coverage_mt = coverage_mt.annotate_globals(
+                calling_interval_name=calling_interval_name,
+                calling_interval_padding=calling_interval_padding,
+                normalization_contig=normalization_contig,
+            )
+            coverage_mt.write(
+                get_checkpoint_path("test_sex_imputation_cov", mt=True)
+                if test
+                else sex_imputation_coverage.path,
+                overwrite=args.overwrite,
+            )
+
+        if args.sex_imputation_interval_qc:
+            if test:
+                coverage_mt = hl.read_matrix_table(
+                    get_checkpoint_path("test_sex_imputation_cov", mt=True)
+                )
+            else:
+                coverage_mt = sex_imputation_coverage.mt()
+
+            platform_ht = load_platform_ht(
+                test,
+                coverage_mt.calling_interval_name,
+                coverage_mt.calling_interval_padding,
+            )
+            platform_mt = generate_sex_imputation_interval_qc_mt(
+                coverage_mt,
+                platform_ht,
+                mean_dp_thresholds=args.mean_dp_thresholds,
+            )
+            platform_mt.naive_coalesce(args.interval_qc_n_partitions).write(
+                get_checkpoint_path("test_sex_imputation_cov.per_platform", mt=True)
+                if test
+                else sex_imputation_platform_coverage.path,
+                overwrite=args.overwrite,
+            )
+
         if args.impute_sex:
-            vds = get_gnomad_v4_vds(remove_hard_filtered_samples=True, test=args.test)
+            vds = get_gnomad_v4_vds(
+                remove_hard_filtered_samples=False,
+                remove_hard_filtered_samples_no_sex=True,
+                test=test,
+            )
             if args.f_stat_ukb_var:
                 # The UK Biobank f-stat table contains only variants that were high callrate (0.99) and common
                 # (AF >0.001) within the UK Biobank 200K Regeneron exome dataset and it includes the UK Biobank 200K
@@ -429,77 +629,37 @@ def main(args):
             else:
                 freq_ht = (
                     hl.read_table(get_checkpoint_path("test_f_stat_sites"))
-                    if args.test
+                    if test
                     else f_stat_sites.ht()
                 )
 
-            # Added because without this impute_sex_chromosome_ploidy will still run even with overwrite=False
-            if args.overwrite or not file_exists(
+            sex_ht_path = (
                 get_checkpoint_path("sex_imputation") if args.test else sex.path
-            ):
-                logger.info(
-                    "Loading interval coverage MatrixTable and filtering to chrX, chrY and %s...",
-                    args.normalization_contig,
+            )
+            # Added because without this impute_sex_chromosome_ploidy will still run even with overwrite=False
+            if args.overwrite or not file_exists(sex_ht_path):
+                interval_qc_mt = (
+                    hl.read_matrix_table(
+                        get_checkpoint_path(
+                            "test_sex_imputation_cov.per_platform", mt=True
+                        )
+                    )
+                    if test
+                    else sex_imputation_platform_coverage.mt()
                 )
-                if file_exists(interval_coverage.path):
-                    coverage_mt = interval_coverage.mt()
-                elif args.test:
-                    test_coverage_path = get_checkpoint_path(
-                        f"test_interval_coverage.{args.calling_interval_name}.pad{args.calling_interval_padding}",
-                        mt=True,
+                if args.per_platform or args.high_cov_all_platforms:
+                    platform_ht = load_platform_ht(
+                        test, calling_interval_name, calling_interval_padding
                     )
-                    if file_exists(test_coverage_path):
-                        coverage_mt = hl.read_matrix_table(test_coverage_path)
-                    else:
-                        raise FileNotFoundError(
-                            f"There is no final coverage MatrixTable written and a test interval coverage MatrixTable does "
-                            f"not exist for calling interval {args.calling_interval_name} and interval padding "
-                            f"{args.calling_interval_padding}. Please run platform_inference.py --compute_coverage with the "
-                            f"--test argument and needed --calling_interval_name/--calling_interval_padding arguments."
-                        )
-                else:
-                    raise FileNotFoundError(
-                        f"There is no final coverage MatrixTable written. Please run: "
-                        f"platform_inference.py --compute_coverage to compute the interval coverage MatrixTable."
-                    )
-
-                coverage_mt = coverage_mt.filter_rows(
-                    hl.literal({"chrY", "chrX", args.normalization_contig}).contains(
-                        coverage_mt.interval.start.contig
-                    )
-                )
-                if args.per_platform or args.high_cov_by_platform_all:
-                    logger.info("Loading platform information...")
-                    if file_exists(platform.path):
-                        platform_ht = platform.ht()
-                    elif args.test:
-                        test_platform_path = get_checkpoint_path(
-                            f"test_platform_assignment.{args.calling_interval_name}.pad{args.calling_interval_padding}"
-                        )
-                        if file_exists(test_platform_path):
-                            platform_ht = hl.read_table(test_platform_path)
-                        else:
-                            raise FileNotFoundError(
-                                f"There is no final platform assignment Table written and a test platform assignment Table "
-                                f"does not exist for calling interval {args.calling_interval_name} and interval padding "
-                                f"{args.calling_interval_padding}. Please run platform_inference.py --assign_platforms "
-                                f"with the --test argument and needed --calling_interval_name/--calling_interval_padding "
-                                f"arguments."
-                            )
-                    else:
-                        raise FileNotFoundError(
-                            f"There is no final platform assignment Table written. Please run: "
-                            f"platform_inference.py --assign_platforms to compute the platform assignment Table."
-                        )
                 else:
                     platform_ht = None
 
                 ht = compute_sex(
                     vds,
-                    coverage_mt,
+                    interval_qc_mt,
                     args.high_cov_intervals,
                     args.per_platform,
-                    args.high_cov_by_platform_all,
+                    args.high_cov_all_platforms,
                     platform_ht,
                     args.min_platform_size,
                     args.normalization_contig,
@@ -519,7 +679,7 @@ def main(args):
                 ht.write(
                     get_checkpoint_path(
                         f"sex_imputation{'.per_platform' if args.per_platform else ''}"
-                        f"{'.high_cov_by_platform_all' if args.high_cov_by_platform_all else ''}"
+                        f"{'.high_cov_all_platforms' if args.high_cov_all_platforms else ''}"
                         f"{'.high_cov' if args.high_cov_intervals else ''}"
                         f"{'.ukb_f_stat' if args.f_stat_ukb_var else ''}"
                     )
@@ -580,6 +740,75 @@ if __name__ == "__main__":
         default=1000,
         type=int,
     )
+
+    sex_coverage_args = parser.add_argument_group(
+        "Sex imputation interval coverage",
+        "Arguments used for computing interval coverage for sex imputation.",
+    )
+    sex_coverage_args.add_argument(
+        "--sex-imputation-interval-coverage",
+        help=(
+            "Create a MatrixTable of interval-by-sample coverage on a specified list of contigs with PAR regions "
+            "excluded."
+        ),
+        action="store_true",
+    )
+    sex_coverage_args.add_argument(
+        "--normalization-contig",
+        help="Which autosomal chromosome to use for normalizing the coverage of chromosomes X and Y.",
+        type=str,
+        default="chr20",
+    )
+    sex_coverage_args.add_argument(
+        "--calling-interval-name",
+        help=(
+            "Name of calling intervals to use for interval coverage. One of: 'ukb', 'broad', or 'intersection'. Only "
+            "used if '--test' is set."
+        ),
+        type=str,
+        choices=["ukb", "broad", "intersection"],
+        default="intersection",
+    )
+    sex_coverage_args.add_argument(
+        "--calling-interval-padding",
+        help=(
+            "Number of base pair padding to use on the calling intervals. One of 0 or 50 bp. Only used if '--test' is "
+            "set."
+        ),
+        type=int,
+        choices=[0, 50],
+        default=50,
+    )
+
+    sex_interval_qc_args = parser.add_argument_group(
+        "Sex chromosome interval QC",
+        "Arguments used for making an interval QC HT from the sex imputation interval coverage MT.",
+    )
+    sex_interval_qc_args.add_argument(
+        "--sex-imputation-interval-qc",
+        help=(
+            "Create a Table of the fraction of samples per interval and per platform with mean DP over thresholds "
+            "specified by '--mean-dp-thresholds'."
+        ),
+        action="store_true",
+    )
+    sex_interval_qc_args.add_argument(
+        "--mean-dp-thresholds",
+        help=(
+            "List of mean DP cutoffs to determining the fraction of samples with mean coverage >= the cutoff for each "
+            "interval."
+        ),
+        type=int,
+        nargs="+",
+        default=[5, 10, 15, 20, 25],
+    )
+    sex_interval_qc_args.add_argument(
+        "--interval-qc-n-partitions",
+        help="Number of desired partitions for the sex imputation interval QC output Table.",
+        default=500,
+        type=int,
+    )
+
     sex_ploidy_args = parser.add_argument_group(
         "Impute sex ploidy", "Arguments used for imputing sex chromosome ploidy."
     )
@@ -642,12 +871,6 @@ if __name__ == "__main__":
         ),
         type=int,
         default=100,
-    )
-    sex_ploidy_args.add_argument(
-        "--normalization-contig",
-        help="Which autosomal chromosome to use for normalizing the coverage of chromosomes X and Y.",
-        type=str,
-        default="chr20",
     )
     sex_ploidy_args.add_argument(
         "--variant-depth-only-x-ploidy",

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -580,12 +580,15 @@ if __name__ == "__main__":
         default=1000,
         type=int,
     )
-    parser.add_argument(
+    sex_ploidy_args = parser.add_argument_group(
+        "Impute sex ploidy", "Arguments used for imputing sex chromosome ploidy."
+    )
+    sex_ploidy_args.add_argument(
         "--impute-sex",
         help="Run sex ploidy and sex karyotyping imputation.",
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--f-stat-ukb-var",
         help=(
             "Whether to use UK Biobank high callrate (0.99) and common variants (UKB allele frequency > value specified "
@@ -594,13 +597,13 @@ if __name__ == "__main__":
         ),
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--min-af",
         help="Minimum variant allele frequency to retain variant in qc matrix table.",
         default=0.001,
         type=float,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--f-stat-cutoff",
         help=(
             "Cutoff for f-stat to roughly divide 'XX' from 'XY' samples. Assumes XX samples are below cutoff and XY "
@@ -609,17 +612,17 @@ if __name__ == "__main__":
         type=float,
         default=0.5,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--high-cov-intervals",
         help="Whether to filter to high coverage intervals for the sex ploidy and karyotype inference.",
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--per-platform",
         help="Whether to run the sex ploidy and karyotype inference per platform.",
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--high-cov-by-platform-all",
         help=(
             "Whether to filter to high coverage intervals for the sex ploidy and karyotype inference. "
@@ -627,7 +630,7 @@ if __name__ == "__main__":
         ),
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--min-platform-size",
         help=(
             "Required size of a platform to be considered in '--high-cov-by-platform-all'. Only platforms that "
@@ -637,13 +640,13 @@ if __name__ == "__main__":
         type=int,
         default=100,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--normalization-contig",
         help="Which autosomal chromosome to use for normalizing the coverage of chromosomes X and Y.",
         type=str,
         default="chr20",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--variant-depth-only-x-ploidy",
         help=(
             "Whether to use depth of variant data for the x ploidy estimation instead of the default behavior that "
@@ -651,7 +654,7 @@ if __name__ == "__main__":
         ),
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--variant-depth-only-y-ploidy",
         help=(
             "Whether to use depth of variant data for the y ploidy estimation instead of the default behavior that "
@@ -659,7 +662,7 @@ if __name__ == "__main__":
         ),
         action="store_true",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--x-cov",
         help=(
             "Mean coverage level used to define high coverage intervals on chromosome X. This field must be in the "
@@ -668,7 +671,7 @@ if __name__ == "__main__":
         type=int,
         default=10,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--y-cov",
         help=(
             "Mean coverage level used to define high coverage intervals on chromosome Y. This field must be in the "
@@ -677,7 +680,7 @@ if __name__ == "__main__":
         type=int,
         default=5,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--norm-cov",
         help=(
             "Mean coverage level used to define high coverage intervals on the normalization autosome. This field must "
@@ -686,19 +689,19 @@ if __name__ == "__main__":
         type=int,
         default=20,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--prop-samples-x",
         help="Proportion samples at specified coverage '--x-cov' to determine high coverage intervals on chromosome X.",
         type=float,
         default=0.80,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--prop-samples-y",
         help="Proportion samples at specified coverage '--y-cov' to determine high coverage intervals on chromosome Y.",
         type=float,
         default=0.35,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--prop-samples-norm",
         help=(
             "Proportion samples at specified coverage '--norm-cov' to determine high coverage intervals on the "
@@ -707,7 +710,7 @@ if __name__ == "__main__":
         type=float,
         default=0.85,
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--calling-interval-name",
         help=(
             "Name of calling intervals to use for interval coverage. One of: 'ukb', 'broad', or 'intersection'. Only "
@@ -717,7 +720,7 @@ if __name__ == "__main__":
         choices=["ukb", "broad", "intersection"],
         default="intersection",
     )
-    parser.add_argument(
+    sex_ploidy_args.add_argument(
         "--calling-interval-padding",
         help=(
             "Number of base pair padding to use on the calling intervals. One of 0 or 50 bp. Only used if '--test' is "

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -584,8 +584,8 @@ if __name__ == "__main__":
         "Impute sex ploidy", "Arguments used for imputing sex chromosome ploidy."
     )
     sex_ploidy_args.add_argument(
-        "--impute-sex",
-        help="Run sex ploidy and sex karyotyping imputation.",
+        "--impute-sex-ploidy",
+        help="Run sex chromosome ploidy imputation.",
         action="store_true",
     )
     sex_ploidy_args.add_argument(
@@ -612,28 +612,31 @@ if __name__ == "__main__":
         type=float,
         default=0.5,
     )
-    sex_ploidy_args.add_argument(
+    sex_ploidy_high_cov_method_parser = sex_ploidy_args.add_mutually_exclusive_group(
+        required=False
+    )
+    sex_ploidy_high_cov_method_parser.add_argument(
         "--high-cov-intervals",
-        help="Whether to filter to high coverage intervals for the sex ploidy and karyotype inference.",
+        help="Whether to filter to high coverage intervals for the sex ploidy imputation.",
         action="store_true",
     )
-    sex_ploidy_args.add_argument(
-        "--per-platform",
-        help="Whether to run the sex ploidy and karyotype inference per platform.",
+    sex_ploidy_high_cov_method_parser.add_argument(
+        "--high-cov-per-platform",
+        help="Whether filter to per platform high coverage intervals for the sex ploidy imputation.",
         action="store_true",
     )
-    sex_ploidy_args.add_argument(
-        "--high-cov-by-platform-all",
+    sex_ploidy_high_cov_method_parser.add_argument(
+        "--high-cov-all-platforms",
         help=(
-            "Whether to filter to high coverage intervals for the sex ploidy and karyotype inference. "
-            "Use only intervals that are considered high coverage across all platforms."
+            "Whether to filter to high coverage intervals for the sex ploidy imputation. Use only intervals that are "
+            "considered high coverage across all platforms."
         ),
         action="store_true",
     )
     sex_ploidy_args.add_argument(
         "--min-platform-size",
         help=(
-            "Required size of a platform to be considered in '--high-cov-by-platform-all'. Only platforms that "
+            "Required size of a platform to be considered in '--high-cov-all-platforms'. Only platforms that "
             "have # of samples > 'min_platform_size' are used to determine intervals that have a high coverage across "
             "all platforms."
         ),
@@ -729,6 +732,19 @@ if __name__ == "__main__":
         type=int,
         choices=[0, 50],
         default=50,
+    )
+    sex_karyotype_args = parser.add_argument_group(
+        "Annotate sex karyotype", "Arguments used for annotating sex karyotype."
+    )
+    sex_karyotype_args.add_argument(
+        "--annotate-sex-karyotype",
+        help="Run sex karyotype inference.",
+        action="store_true",
+    )
+    sex_karyotype_args.add_argument(
+        "--per-platform",
+        help="Whether to run the karyotype inference per platform.",
+        action="store_true",
     )
 
     args = parser.parse_args()

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -393,7 +393,13 @@ def compute_sex(
 
 
 def main(args):
-    hl.init(log="/sex_inference.log", default_reference="GRCh38")
+    hl.init(
+        log="/sex_inference.log",
+        default_reference="GRCh38",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
+    # NOTE: remove this flag when the new shuffle method is the default
+    hl._set_flags(use_new_shuffle="1")
 
     try:
         if args.determine_fstat_sites:

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -710,7 +710,7 @@ def main(args):
             )
             karyotype_ht = infer_sex_karyotype_from_ploidy(
                 ploidy_ht,
-                per_platform=args.per_platform,
+                per_platform=per_platform,
                 f_stat_cutoff=args.f_stat_cutoff,
             )
             sex_ht = ploidy_ht.annotate(**karyotype_ht[ploidy_ht.key])


### PR DESCRIPTION
Note: This PR is stacked on #267 so #267 should be reviewed first. This is also dependent on parameterizing karyotype assignment in the `gnomad_methods`: https://github.com/broadinstitute/gnomad_methods/pull/478

This cleans up the code and also makes it easy to later re-annotate karyotype using different cutoffs if we need to.