### PR TITLE
Split `compute_sex` into two steps: ploidy imputation and then karyotype sex inference

### DIFF
--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -366,6 +366,17 @@ sex_imputation_platform_coverage = VersionedMatrixTableResource(
     },
 )
 
+# Ploidy imputation results
+ploidy = VersionedTableResource(
+    CURRENT_VERSION,
+    {
+        version: TableResource(
+            f"{get_sample_qc_root(version)}/gnomad.exomes.v{version}.ploidy.ht"
+        )
+        for version in VERSIONS
+    },
+)
+
 # Sex imputation results
 sex = VersionedTableResource(
     CURRENT_VERSION,

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -584,8 +584,8 @@ if __name__ == "__main__":
         "Impute sex ploidy", "Arguments used for imputing sex chromosome ploidy."
     )
     sex_ploidy_args.add_argument(
-        "--impute-sex",
-        help="Run sex ploidy and sex karyotyping imputation.",
+        "--impute-sex-ploidy",
+        help="Run sex chromosome ploidy imputation.",
         action="store_true",
     )
     sex_ploidy_args.add_argument(
@@ -612,28 +612,31 @@ if __name__ == "__main__":
         type=float,
         default=0.5,
     )
-    sex_ploidy_args.add_argument(
+    sex_ploidy_high_cov_method_parser = sex_ploidy_args.add_mutually_exclusive_group(
+        required=False
+    )
+    sex_ploidy_high_cov_method_parser.add_argument(
         "--high-cov-intervals",
-        help="Whether to filter to high coverage intervals for the sex ploidy and karyotype inference.",
+        help="Whether to filter to high coverage intervals for the sex ploidy imputation.",
         action="store_true",
     )
-    sex_ploidy_args.add_argument(
-        "--per-platform",
-        help="Whether to run the sex ploidy and karyotype inference per platform.",
+    sex_ploidy_high_cov_method_parser.add_argument(
+        "--high-cov-per-platform",
+        help="Whether filter to per platform high coverage intervals for the sex ploidy imputation.",
         action="store_true",
     )
-    sex_ploidy_args.add_argument(
-        "--high-cov-by-platform-all",
+    sex_ploidy_high_cov_method_parser.add_argument(
+        "--high-cov-all-platforms",
         help=(
-            "Whether to filter to high coverage intervals for the sex ploidy and karyotype inference. "
-            "Use only intervals that are considered high coverage across all platforms."
+            "Whether to filter to high coverage intervals for the sex ploidy imputation. Use only intervals that are "
+            "considered high coverage across all platforms."
         ),
         action="store_true",
     )
     sex_ploidy_args.add_argument(
         "--min-platform-size",
         help=(
-            "Required size of a platform to be considered in '--high-cov-by-platform-all'. Only platforms that "
+            "Required size of a platform to be considered in '--high-cov-all-platforms'. Only platforms that "
             "have # of samples > 'min_platform_size' are used to determine intervals that have a high coverage across "
             "all platforms."
         ),
@@ -729,6 +732,19 @@ if __name__ == "__main__":
         type=int,
         choices=[0, 50],
         default=50,
+    )
+    sex_karyotype_args = parser.add_argument_group(
+        "Annotate sex karyotype", "Arguments used for annotating sex karyotype."
+    )
+    sex_karyotype_args.add_argument(
+        "--annotate-sex-karyotype",
+        help="Run sex karyotype inference.",
+        action="store_true",
+    )
+    sex_karyotype_args.add_argument(
+        "--per-platform",
+        help="Whether to run the karyotype inference per platform.",
+        action="store_true",
     )
 
     args = parser.parse_args()

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -710,7 +710,7 @@ def main(args):
             )
             karyotype_ht = infer_sex_karyotype_from_ploidy(
                 ploidy_ht,
-                per_platform=args.per_platform,
+                per_platform=per_platform,
                 f_stat_cutoff=args.f_stat_cutoff,
             )
             sex_ht = ploidy_ht.annotate(**karyotype_ht[ploidy_ht.key])

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -312,7 +312,7 @@ def compute_sex_ploidy(
         `high_cov_per_platform` or `high_cov_all_platforms` are True.
     :param high_cov_intervals: Whether to filter to high coverage intervals for the sex ploidy imputation. Default
         is False.
-    :param high_cov_per_platform: Whether filter to per platform high coverage intervals for the sex ploidy imputation.
+    :param high_cov_per_platform: Whether to filter to per platform high coverage intervals for the sex ploidy imputation.
         Default is False.
     :param high_cov_all_platforms: Whether to filter to high coverage intervals for the sex ploidy imputation. Using
         only intervals that are considered high coverage across all platforms. Default is False.
@@ -408,7 +408,7 @@ def compute_sex_ploidy(
         Helper function to perform `annotate_sex` using unchanged parameters with changes to the VDS and calling
         intervals.
 
-        :param vds: Input VDS to use for sex annotation.
+        :param vds: Input VDS to use for sex ploidy annotation.
         :param calling_intervals_ht: Table including only intervals wanted for sex annotation.
         :return: Table containing sex ploidy estimates for samples in the input VDS.
         """
@@ -431,7 +431,7 @@ def compute_sex_ploidy(
 
     if high_cov_intervals or high_cov_all_platforms or high_cov_per_platform:
         logger.info(
-            "Running sex ploidy and sex karyotype estimation using only high coverage intervals: %d percent of samples "
+            "Running sex ploidy estimation using only high coverage intervals: %d percent of samples "
             "with greater than %dx coverage on chrX, %d percent of samples with greater than %dx coverage on chrY, and "
             "%d percent of samples with greater than %dx coverage on %s...",
             int(prop_samples_x * 100),
@@ -472,7 +472,7 @@ def compute_sex_ploidy(
             "with at least %s samples...",
             min_platform_size,
         )
-        # Excluding small platforms and platform_-1 (platfrom containing all samples with unassigned platform)
+        # Excluding small platforms and platform_-1 (platform containing all samples with unassigned platform)
         interval_qc_mt = interval_qc_mt.filter_cols(
             (interval_qc_mt.n_samples >= min_platform_size)
             & (interval_qc_mt.platform != "platform_-1")
@@ -665,7 +665,7 @@ def main(args):
                 get_checkpoint_path(f"ploidy_imputation") if test else ploidy.path
             )
             # Added because without this impute_sex_chromosome_ploidy will still run even with overwrite=False
-            if args.overwrite or not file_exists(ploidy_ht_path):
+            if overwrite or not file_exists(ploidy_ht_path):
                 interval_qc_mt = (
                     hl.read_matrix_table(
                         get_checkpoint_path(
@@ -722,7 +722,7 @@ def main(args):
             logger.info("Writing sex HT with karyotype annotation...")
             sex_ht.write(
                 get_checkpoint_path("sex") if test else sex.path,
-                overwrite=args.overwrite,
+                overwrite=overwrite,
             )
 
     finally:
@@ -886,7 +886,7 @@ if __name__ == "__main__":
     )
     sex_ploidy_high_cov_method_parser.add_argument(
         "--high-cov-per-platform",
-        help="Whether filter to per platform high coverage intervals for the sex ploidy imputation.",
+        help="Whether to filter to per platform high coverage intervals for the sex ploidy imputation.",
         action="store_true",
     )
     sex_ploidy_high_cov_method_parser.add_argument(

--- a/gnomad_qc/v4/sample_qc/sex_inference.py
+++ b/gnomad_qc/v4/sample_qc/sex_inference.py
@@ -881,19 +881,26 @@ if __name__ == "__main__":
     )
     sex_ploidy_high_cov_method_parser.add_argument(
         "--high-cov-intervals",
-        help="Whether to filter to high coverage intervals for the sex ploidy imputation.",
+        help=(
+            "Whether to filter to high coverage intervals for the sex ploidy imputation. Can't be used at the same "
+            "time as '--high-cov-per-platform' or '--high-cov-all-platforms'."
+        ),
         action="store_true",
     )
     sex_ploidy_high_cov_method_parser.add_argument(
         "--high-cov-per-platform",
-        help="Whether to filter to per platform high coverage intervals for the sex ploidy imputation.",
+        help=(
+            "Whether to filter to per platform high coverage intervals for the sex ploidy imputation. Can't be used "
+             "at the same time as '--high-cov-intervals' or '--high-cov-all-platforms'."
+        ),
         action="store_true",
     )
     sex_ploidy_high_cov_method_parser.add_argument(
         "--high-cov-all-platforms",
         help=(
             "Whether to filter to high coverage intervals for the sex ploidy imputation. Use only intervals that are "
-            "considered high coverage across all platforms."
+            "considered high coverage across all platforms.  Can't be used at the same time as '--high-cov-intervals' "
+            "or '--high-cov-per-platform'"
         ),
         action="store_true",
     )


### PR DESCRIPTION
Note: This PR is stacked on #267 so #267 should be reviewed first. This is also dependent on parameterizing karyotype assignment in the `gnomad_methods`: https://github.com/broadinstitute/gnomad_methods/pull/478

This cleans up the code and also makes it easy to later re-annotate karyotype using different cutoffs if we need to.