### PR TITLE
Fix get_gnomad_v4_vds to avoid writing sample ids

### DIFF
--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -104,15 +104,7 @@ def get_gnomad_v4_vds(
 
     logger.info("Total number of UKB samples to exclude: %d", len(withdrawn_ids))
 
-    with hl.hadoop_open(all_ukb_samples_to_remove, "w") as d:
-        for sample in withdrawn_ids:
-            d.write(sample + "\n")
-
-    withdrawn_ht = hl.import_table(all_ukb_samples_to_remove, no_header=True).key_by(
-        "f0"
-    )
-
-    vds = hl.vds.filter_samples(vds, withdrawn_ht, keep=False, remove_dead_alleles=True)
+    vds = hl.vds.filter_samples(vds, withdrawn_ids, keep=False, remove_dead_alleles=True)
 
     # Log number of UKB samples removed from the VDS.
     n_samples_after_exclusion = vds.variant_data.count_cols()


### PR DESCRIPTION
Also very much not concurrency-safe in its current form if multiple people are running this at the same time.