### PR TITLE
Variant QC allele counts 

### DIFF
--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -140,13 +140,14 @@ def main(args):
         # TODO: is there any reason to also compute info per platform?
         res = resources.compute_info
         res.check_resource_existence()
+        if test_dataset:
+            unrelated_expr = ~mt.meta.rand_sampling_meta.related
+        else:
+            unrelated_expr = ~mt.meta.sample_filters.relatedness_filters.related
         default_compute_info(
             mt,
             site_annotations=True,
-            ac_filter_groups={
-                "release": mt.meta.release,
-                "unrelated": ~mt.meta.sample_filters.relatedness_filters.related,
-            },
+            ac_filter_groups={"release": mt.meta.release, "unrelated": unrelated_expr},
         ).write(res.info_ht.path, overwrite=overwrite)
 
     if args.split_info:

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -111,7 +111,7 @@ def main(args):
         test=test_dataset,
         high_quality_only=True,
         # Keep control/truth samples because they are used in variant QC.
-        high_quality_only_keep_controls=True,
+        keep_controls=True,
         annotate_meta=True,
     ).variant_data
 

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -115,6 +115,24 @@ def main(args):
         annotate_meta=True,
     ).variant_data
 
+    mt.describe()
+    mt = mt._filter_partitions(range(20))
+    missing_stats = mt.annotate_cols(
+        defined_gvcf_info={
+            ann: hl.agg.count_where(hl.is_defined(mt.gvcf_info)) for ann in mt.gvcf_info
+        },
+        defined_gvcf_info_missing_stats={
+            ann: hl.agg.count_where(
+                hl.is_defined(mt.gvcf_info) & hl.is_missing(mt.gvcf_info[ann])
+            )
+            for ann in mt.gvcf_info
+        },
+    ).cols()
+    missing_stats = missing_stats.select(
+        "defined_gvcf_info", "defined_gvcf_info_missing_stats"
+    ).checkpoint("gs://gnomad-tmp-4day/julia/missing_stats_new2.ht", overwrite=True)
+    missing_stats.show()
+
     if test_n_partitions:
         mt = mt._filter_partitions(range(test_n_partitions))
 

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -115,24 +115,6 @@ def main(args):
         annotate_meta=True,
     ).variant_data
 
-    mt.describe()
-    mt = mt._filter_partitions(range(20))
-    missing_stats = mt.annotate_cols(
-        defined_gvcf_info={
-            ann: hl.agg.count_where(hl.is_defined(mt.gvcf_info)) for ann in mt.gvcf_info
-        },
-        defined_gvcf_info_missing_stats={
-            ann: hl.agg.count_where(
-                hl.is_defined(mt.gvcf_info) & hl.is_missing(mt.gvcf_info[ann])
-            )
-            for ann in mt.gvcf_info
-        },
-    ).cols()
-    missing_stats = missing_stats.select(
-        "defined_gvcf_info", "defined_gvcf_info_missing_stats"
-    ).checkpoint("gs://gnomad-tmp-4day/julia/missing_stats_new2.ht", overwrite=True)
-    missing_stats.show()
-
     if test_n_partitions:
         mt = mt._filter_partitions(range(test_n_partitions))
 

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -135,16 +135,6 @@ vep = VersionedTableResource(
     },
 )
 
-qc_ac = VersionedTableResource(
-    CURRENT_VERSION,
-    {
-        version: TableResource(
-            f"{_annotations_root(version)}/gnomad.exomes.v{version}.qc_ac.ht"
-        )
-        for version in VERSIONS
-    },
-)
-
 fam_stats = VersionedTableResource(
     CURRENT_VERSION,
     {

--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -11,9 +11,12 @@ from gnomad.resources.resource_utils import (
 
 from gnomad_qc.v4.resources.constants import CURRENT_VERSION
 from gnomad_qc.v4.resources.meta import meta
+from gnomad_qc.v4.resources.variant_qc import TRUTH_SAMPLES
 
 logger = logging.getLogger("basic_resources")
 logger.setLevel(logging.INFO)
+
+TRUTH_SAMPLES_S = [TRUTH_SAMPLES[s]["s"] for s in TRUTH_SAMPLES]
 
 
 # Note: Unlike previous versions, the v4 resource directory uses a general format of
@@ -23,10 +26,12 @@ def get_gnomad_v4_vds(
     remove_hard_filtered_samples: bool = True,
     remove_hard_filtered_samples_no_sex: bool = False,
     high_quality_only: bool = False,
+    high_quality_only_keep_controls: bool = False,
     release_only: bool = False,
     test: bool = False,
     n_partitions: int = None,
     remove_dead_alleles: bool = True,
+    annotate_meta: bool = False,
 ) -> hl.vds.VariantDataset:
     """
     Get gnomAD v4 data with desired filtering and metadata annotations.
@@ -40,6 +45,8 @@ def get_gnomad_v4_vds(
         filtering is complete).
     :param high_quality_only: Whether to filter the VDS to only high quality samples
         (only relevant after outlier filtering is complete).
+    :param high_quality_only_keep_controls: Whether to keep control samples when
+        filtering the VDS to only high quality samples.
     :param release_only: Whether to filter the VDS to only samples available for
         release (can only be used if metadata is present).
     :param test: Whether to use the test VDS instead of the full v4 VDS.
@@ -47,6 +54,8 @@ def get_gnomad_v4_vds(
         partitions.
     :param remove_dead_alleles: Whether to remove dead alleles from the VDS when
         removing withdrawn UKB samples. Default is True.
+    :param annotate_meta: Whether to annotate the VDS with the sample QC metadata.
+        Default is False.
     :return: gnomAD v4 dataset with chosen annotations and filters.
     """
     if remove_hard_filtered_samples and remove_hard_filtered_samples_no_sex:
@@ -164,15 +173,28 @@ def get_gnomad_v4_vds(
                 filter_ht = hard_filtered_samples.versions[CURRENT_VERSION].ht()
             else:
                 filter_ht = hard_filtered_samples_no_sex.versions[CURRENT_VERSION].ht()
-            vds = hl.vds.filter_samples(vds, filter_ht, keep=keep_samples)
 
-    if release_only:
+            filter_s = filter_ht.s.collect()
+            if high_quality_only_keep_controls:
+                if keep_samples:
+                    filter_s += TRUTH_SAMPLES_S
+                else:
+                    filter_s = [s for s in filter_s if s not in TRUTH_SAMPLES_S]
+
+            vds = hl.vds.filter_samples(vds, filter_s, keep=keep_samples)
+
+    if release_only or annotate_meta:
         if test:
             meta_ht = gnomad_v4_testset_meta.ht()
         else:
             meta_ht = meta.versions[CURRENT_VERSION].ht()
-        meta_ht = meta_ht.filter(meta_ht.release)
-        vds = hl.vds.filter_samples(vds, meta_ht)
+        if release_only:
+            vds = hl.vds.filter_samples(vds, meta_ht.filter(meta_ht.release))
+        if annotate_meta:
+            vds = hl.vds.VariantDataset(
+                vds.reference_data,
+                vds.variant_data.annotate_cols(meta=meta_ht[vds.variant_data.col_key]),
+            )
 
     if split:
         vmt = vds.variant_data


### PR DESCRIPTION
Add computation of allele counts to be done by the default_compute_info` in gnomad_methods instead of as an additional pipeline step.