### PR TITLE
delete action method in vep_version argument & change input for VEP to raw VDS

### DIFF
--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -325,7 +325,11 @@ def run_vep(vep_version: str = "101") -> hl.Table:
 
 
 def main(args):  # noqa: D103
-    hl.init(default_reference="GRCh38", log="/qc_annotations.log")
+    hl.init(
+        default_reference="GRCh38",
+        log="/qc_annotations.log",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
 
     if args.compute_info:
         compute_info().write(get_info(split=False).path, overwrite=args.overwrite)

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -404,7 +404,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--vep_version",
         help="Version of VEPed context Table to use in vep_or_lookup_vep",
-        action="store_true",
         default="101",
     )
     parser.add_argument(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -34,7 +34,7 @@ from gnomad_qc.v3.resources.annotations import (
     qc_ac,
     vep,
 )
-from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds,get_gnomad_v3_mt
+from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds, get_gnomad_v3_mt
 from gnomad_qc.v3.resources.meta import trios
 
 logging.basicConfig(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -34,10 +34,7 @@ from gnomad_qc.v3.resources.annotations import (
     qc_ac,
     vep,
 )
-from gnomad_qc.v3.resources.basics import (
-    get_gnomad_v3_mt,
-    get_gnomad_v3_vds,
-)
+from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds,get_gnomad_v3_mt
 from gnomad_qc.v3.resources.meta import trios
 
 logging.basicConfig(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -312,18 +312,14 @@ def export_transmitted_singletons_vcf():
 
 def run_vep(vep_version: str = "101") -> hl.Table:
     """
-    Return a table with a VEP annotation for each variant in the raw MatrixTable.
+    Return a table with a VEP annotation for each variant in the raw VariantDataset.
 
     :param vep_version: Version of VEPed context Table to use in `vep_or_lookup_vep`
     :return: VEPed Table
     """
-    ht = get_gnomad_v3_mt(
-        key_by_locus_and_alleles=True, remove_hard_filtered_samples=False
-    ).rows()
-    ht = ht.filter(hl.len(ht.alleles) > 1)
-    ht = hl.split_multi_hts(ht)
+    ht = get_gnomad_v3_vds(remove_hard_filtered_samples=False).variant_data.rows()
+    ht = hl.split_multi(ht)
     ht = vep_or_lookup_vep(ht, vep_version=vep_version)
-    ht = ht.annotate_globals(version=f"v{vep_version}")
 
     return ht
 

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -34,7 +34,10 @@ from gnomad_qc.v3.resources.annotations import (
     qc_ac,
     vep,
 )
-from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds, get_gnomad_v3_mt
+from gnomad_qc.v3.resources.basics import (
+    get_gnomad_v3_vds,
+    get_gnomad_v3_mt,
+)
 from gnomad_qc.v3.resources.meta import trios
 
 logging.basicConfig(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -34,8 +34,7 @@ from gnomad_qc.v3.resources.annotations import (
     qc_ac,
     vep,
 )
-from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds
-from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt
+from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt, get_gnomad_v3_vds
 from gnomad_qc.v3.resources.meta import trios
 
 logging.basicConfig(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -34,10 +34,8 @@ from gnomad_qc.v3.resources.annotations import (
     qc_ac,
     vep,
 )
-from gnomad_qc.v3.resources.basics import (
-    get_gnomad_v3_vds,
-    get_gnomad_v3_mt,
-)
+from gnomad_qc.v3.resources.basics import get_gnomad_v3_vds
+from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt
 from gnomad_qc.v3.resources.meta import trios
 
 logging.basicConfig(

--- a/gnomad_qc/v3/annotations/generate_qc_annotations.py
+++ b/gnomad_qc/v3/annotations/generate_qc_annotations.py
@@ -34,7 +34,10 @@ from gnomad_qc.v3.resources.annotations import (
     qc_ac,
     vep,
 )
-from gnomad_qc.v3.resources.basics import get_gnomad_v3_mt
+from gnomad_qc.v3.resources.basics import (
+    get_gnomad_v3_mt,
+    get_gnomad_v3_vds,
+)
 from gnomad_qc.v3.resources.meta import trios
 
 logging.basicConfig(


### PR DESCRIPTION
1. remove` action="store_true"`, because it can't be used with `default="101"` together. It caused error:
`generate_qc_annotations.py: error: argument --vep_version: ignored explicit argument '105'`

2. since sparse MatrixTable was deleted (to save space), VEP will run on VariantDataset, it's better we change the code to get v3 vds directly. 

3. add a tmp_dir to hl.init for a faster I/O and potentially avoid disk space or Docker error. 


