### PR TITLE
Remove elgh2 samples from release ranking/related samples to drop and trios

### DIFF
--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht.py
@@ -552,7 +552,9 @@ def get_sample_filter_ht(base_ht: hl.Table, relationship_ht: hl.Table) -> hl.Tab
     # variant QC and release.
     sample_filters_ht = sample_filters_ht.annotate(
         control=(control_samples.contains(sample_filters_ht.s)),
-        elgh2_project=(meta_ht[sample_filters_ht.key].project_meta.project == "elgh2"),
+        elgh2_project=hl.coalesce(
+            meta_ht[sample_filters_ht.key].project_meta.project == "elgh2", False
+        ),
     )
     sample_filters_ht = sample_filters_ht.checkpoint(
         new_temp_file("sample_filters", extension="ht"), overwrite=True


### PR DESCRIPTION
Both the ranking/related samples to drop and trio identification rely on the outlier detection filtered samples being the only other samples to exclude other than the hard-filtered samples that were removed prior to building the relatedness HT. So we now need to also exclude the ELGH2 project in those locations.