### PR TITLE
replace 'oth' with remaining in Global fields of v4 genomes HT

### DIFF
--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -49,6 +49,36 @@ def remove_missing_vep_fields(vep_ht: hl.Table) -> hl.Table:
     return vep_ht
 
 
+def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
+    """
+    Replace 'oth' with 'remaining' in Global fields of a Table.
+
+    .. note::
+        This function is used to rename ancestry group fields to match v4 exomes.
+        Which means that all "oth" will be changed to "remaining".
+        2 Global fields are renamed: freq_meta (in value of key "pop") and freq_index_dict (in the keys).
+
+    :param ht: release sites Table to be modified
+    :return: release sites Table with 'oth' replaced with 'remaining'
+    """
+    # in freq_meta, type: array<dict<str, str>>, the value of key "pop" is
+    # changed from 'oth' to 'remaining'.
+    ht = ht.annotate_globals(
+        freq_meta=ht.freq_meta.map(
+            lambda d: d.map_values(lambda x: x.replace("oth", "remaining"))
+        )
+    )
+
+    # in freq_index_dict, type: dict<str, int>, the keys containing 'oth'
+    # inside are changed to 'remaining'.
+    oldkeys = hl.eval(ht.freq_index_dict.keys())
+    newkeys = [s.replace("oth", "remaining") for s in oldkeys]
+    vals = hl.eval(ht.freq_index_dict.values())
+    freq_index_dict_new = {k: v for k, v in zip(newkeys, vals)}
+    ht = ht.annotate_globals(freq_index_dict=freq_index_dict_new)
+    return ht
+
+
 # TODO: drop old_locus, old_alleles, seems to be already dropped in v3.1.4 release table
 # TODO: rename ancestry group fields to match v4 exomes
 # TODO: drop missing fields from VEP 105 annotations
@@ -67,10 +97,10 @@ def main(args):
         "gs://gnomad/release/3.1.4/ht/genomes/gnomad.genomes.v3.1.4.sites.ht"
     )
 
-    logger.info("Dropping old_locus and old_alleles...")
-    ht = ht.drop("old_locus", "old_alleles")
+    logger.info("Replacing ancestry group 'oth' with 'remaining'...")
+    ht = replace_oth_with_remaining(ht)
 
-    logger.info("Loading annotation tables...")
+    logger.info("Loading VEP-annotated table...")
     vep_ht = get_vep(version=CURRENT_VERSION, data_type="genomes").ht()
 
     logger.info("Removing missing VEP fields...")

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -126,7 +126,7 @@ def main(args):
     vep_ht = get_vep(version=CURRENT_VERSION, data_type="genomes").ht()
 
     logger.info("Removing missing VEP fields...")
-    vep_ht = remove_missing_vep_fields(vep_ht)
+    vep_ht = ht.annotate(vep=remove_missing_vep_fields(vep_ht.vep))
 
     logger.info("Loading dbsnp table...")
     dbsnp_ht = dbsnp.ht().select("rsid")

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -56,7 +56,7 @@ def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
     .. note::
         This function is used to rename ancestry group fields to match v4 exomes.
         Which means that all "oth" will be changed to "remaining".
-        2 Global fields are renamed: freq_meta (in value of key "pop") and freq_index_dict (in the keys).
+        2 Global fields are renamed: freq_meta (in the value of the key "pop") and freq_index_dict (in the keys).
 
     :param ht: release sites Table to be modified
     :return: release sites Table with 'oth' replaced with 'remaining'

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -26,3 +26,33 @@ def remove_missing_vep_fields(vep_expr: hl.StructExpression) -> hl.StructExpress
             **{consequence: vep_expr[consequence].map(lambda x: x.drop("minimised"))}
         )
     return vep_expr
+
+
+def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
+    """
+    Replace 'oth' with 'remaining' in Global fields of a Table.
+
+    .. note::
+        This function is used to rename ancestry group fields to match v4 exomes.
+        Which means that all "oth" will be changed to "remaining".
+        2 Global fields are renamed: freq_meta (in the value of the key "pop") and freq_index_dict (in the keys).
+
+    :param ht: release sites Table to be modified
+    :return: release sites Table with 'oth' replaced with 'remaining'
+    """
+    # in freq_meta, type: array<dict<str, str>>, the value of key "pop" is
+    # changed from 'oth' to 'remaining'.
+    ht = ht.annotate_globals(
+        freq_meta=ht.freq_meta.map(
+            lambda d: d.map_values(lambda x: x.replace("oth", "remaining"))
+        )
+    )
+
+    # in freq_index_dict, type: dict<str, int>, the keys containing 'oth'
+    # inside are changed to 'remaining'.
+    oldkeys = hl.eval(ht.freq_index_dict.keys())
+    newkeys = [s.replace("oth", "remaining") for s in oldkeys]
+    vals = hl.eval(ht.freq_index_dict.values())
+    freq_index_dict_new = {k: v for k, v in zip(newkeys, vals)}
+    ht = ht.annotate_globals(freq_index_dict=freq_index_dict_new)
+    return ht

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -77,39 +77,3 @@ def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
     freq_index_dict_new = {k: v for k, v in zip(newkeys, vals)}
     ht = ht.annotate_globals(freq_index_dict=freq_index_dict_new)
     return ht
-
-
-# TODO: drop old_locus, old_alleles, seems to be already dropped in v3.1.4 release table
-# TODO: rename ancestry group fields to match v4 exomes
-# TODO: drop missing fields from VEP 105 annotations
-# TODO: merge vep_ht with v3.1.4 release table
-# TODO: rerun inbreeding coefficient with callstats instead of GT calls
-# TODO: annotate with newest dbsnp release
-# TODO: add Pangolin prediction
-# TODO: add zoonomia constraint scores
-
-
-def main(args):
-    """Script to generate release sites ht for v4 genomes."""
-    logger.info("Loading release table of v3.1.4...")
-    # ht = release_sites(public=True).versions["3.1.4"].ht()
-    ht = hl.read_table(
-        "gs://gnomad/release/3.1.4/ht/genomes/gnomad.genomes.v3.1.4.sites.ht"
-    )
-
-    logger.info("Replacing ancestry group 'oth' with 'remaining'...")
-    ht = replace_oth_with_remaining(ht)
-
-    logger.info("Loading VEP-annotated table...")
-    vep_ht = get_vep(version=CURRENT_VERSION, data_type="genomes").ht()
-
-    logger.info("Removing missing VEP fields...")
-    vep_ht = remove_missing_vep_fields(vep_ht)
-
-    logger.info("Loading dbsnp table...")
-    dbsnp_ht = dbsnp.ht().select("rsid")
-
-    logger.info("Loading pangolin table...")
-    pangolin_ht = hl.read_table(
-        "gs://gnomad/v4.0/annotations/genomes/gnomad.genomes.v4.0.pangolin.ht"
-    )  # TODO: make Pangolin a versioned resource

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -77,3 +77,61 @@ def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
     freq_index_dict_new = {k: v for k, v in zip(newkeys, vals)}
     ht = ht.annotate_globals(freq_index_dict=freq_index_dict_new)
     return ht
+
+
+def pangolin_vcf_to_ht(path: str) -> hl.Table:
+    """Convert pangolin VCF to Table."""
+    mt = hl.import_vcf(
+        "gs://gnomad-qin/v4_annotations/gnomad.v4.0.genomes.pangolin.vcf.bgz/*.bgz",
+        reference_genome="GRCh38",
+    )
+
+    ht = mt.rows()
+    pangolin_fields = ht.info.Pangolin[0].split(delim=":|\\|")
+    ht = ht.annotate(
+        pangolin=hl.struct(
+            gene=pangolin_fields[0].split(delim="\.")[0],
+            splice_gain_pos=hl.int(pangolin_fields[1]),
+            splice_gain_score=hl.float(pangolin_fields[2]),
+            splice_loss_pos=hl.int(pangolin_fields[3]),
+            splice_loss_score=hl.float(pangolin_fields[4]),
+        )
+    )
+    ht = ht.select("pangolin")
+    return ht
+
+
+# TODO: drop old_locus, old_alleles, seems to be already dropped in v3.1.4 release table
+# TODO: rename ancestry group fields to match v4 exomes
+# TODO: drop missing fields from VEP 105 annotations
+# TODO: merge vep_ht with v3.1.4 release table
+# TODO: rerun inbreeding coefficient with callstats instead of GT calls
+# TODO: annotate with newest dbsnp release
+# TODO: add Pangolin prediction
+# TODO: add zoonomia constraint scores
+
+
+def main(args):
+    """Script to generate release sites ht for v4 genomes."""
+    logger.info("Loading release table of v3.1.4...")
+    # ht = release_sites(public=True).versions["3.1.4"].ht()
+    ht = hl.read_table(
+        "gs://gnomad/release/3.1.4/ht/genomes/gnomad.genomes.v3.1.4.sites.ht"
+    )
+
+    logger.info("Replacing ancestry group 'oth' with 'remaining'...")
+    ht = replace_oth_with_remaining(ht)
+
+    logger.info("Loading VEP-annotated table...")
+    vep_ht = get_vep(version=CURRENT_VERSION, data_type="genomes").ht()
+
+    logger.info("Removing missing VEP fields...")
+    vep_ht = remove_missing_vep_fields(vep_ht)
+
+    logger.info("Loading dbsnp table...")
+    dbsnp_ht = dbsnp.ht().select("rsid")
+
+    logger.info("Loading pangolin table...")
+    pangolin_ht = hl.read_table(
+        "gs://gnomad/v4.0/annotations/genomes/gnomad.genomes.v4.0.pangolin.ht"
+    )  # TODO: make Pangolin a versioned resource

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -33,62 +33,20 @@ def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
     Replace 'oth' with 'remaining' in Global fields of a Table.
 
     .. note::
-        This function is used to rename ancestry group fields to match v4 exomes.
-        Which means that all "oth" will be changed to "remaining".
-        2 Global fields are renamed: freq_meta (in the value of the key "pop") and freq_index_dict (in the keys).
+        This function renames v3 ancestry groups to match v4 exomes' ancestry groups.
+        The value of the key "pop" within `freq_meta` and the keys of `freq_index_dict`
+        that contain "oth" are replaced with "remaining".
 
-    :param ht: release sites Table to be modified
-    :return: release sites Table with 'oth' replaced with 'remaining'
+    :param ht: release sites Table to be modified.
+    :return: release sites Table with 'oth' replaced with 'remaining'.
     """
-    # in freq_meta, type: array<dict<str, str>>, the value of key "pop" is
-    # changed from 'oth' to 'remaining'.
     ht = ht.annotate_globals(
         freq_meta=ht.freq_meta.map(
             lambda d: d.map_values(lambda x: x.replace("oth", "remaining"))
-        )
+        ),
+        freq_index_dict=hl.zip(
+            ht.freq_index_dict.keys().map(lambda k: k.replace("oth", "remaining")),
+            ht.freq_index_dict.values(),
+        ),
     )
-
-    # in freq_index_dict, type: dict<str, int>, the keys containing 'oth'
-    # inside are changed to 'remaining'.
-    oldkeys = hl.eval(ht.freq_index_dict.keys())
-    newkeys = [s.replace("oth", "remaining") for s in oldkeys]
-    vals = hl.eval(ht.freq_index_dict.values())
-    freq_index_dict_new = {k: v for k, v in zip(newkeys, vals)}
-    ht = ht.annotate_globals(freq_index_dict=freq_index_dict_new)
     return ht
-
-
-# TODO: drop old_locus, old_alleles, seems to be already dropped in v3.1.4 release table
-# TODO: rename ancestry group fields to match v4 exomes
-# TODO: drop missing fields from VEP 105 annotations
-# TODO: merge vep_ht with v3.1.4 release table
-# TODO: rerun inbreeding coefficient with callstats instead of GT calls
-# TODO: annotate with newest dbsnp release
-# TODO: add Pangolin prediction
-# TODO: add zoonomia constraint scores
-
-
-def main(args):
-    """Script to generate release sites ht for v4 genomes."""
-    logger.info("Loading release table of v3.1.4...")
-    # ht = release_sites(public=True).versions["3.1.4"].ht()
-    ht = hl.read_table(
-        "gs://gnomad/release/3.1.4/ht/genomes/gnomad.genomes.v3.1.4.sites.ht"
-    )
-
-    logger.info("Replacing ancestry group 'oth' with 'remaining'...")
-    ht = replace_oth_with_remaining(ht)
-
-    logger.info("Loading VEP-annotated table...")
-    vep_ht = get_vep(version=CURRENT_VERSION, data_type="genomes").ht()
-
-    logger.info("Removing missing VEP fields...")
-    vep_ht = ht.annotate(vep=remove_missing_vep_fields(vep_ht.vep))
-
-    logger.info("Loading dbsnp table...")
-    dbsnp_ht = dbsnp.ht().select("rsid")
-
-    logger.info("Loading pangolin table...")
-    pangolin_ht = hl.read_table(
-        "gs://gnomad/v4.0/annotations/genomes/gnomad.genomes.v4.0.pangolin.ht"
-    )  # TODO: make Pangolin a versioned resource

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -56,3 +56,39 @@ def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
     freq_index_dict_new = {k: v for k, v in zip(newkeys, vals)}
     ht = ht.annotate_globals(freq_index_dict=freq_index_dict_new)
     return ht
+
+
+# TODO: drop old_locus, old_alleles, seems to be already dropped in v3.1.4 release table
+# TODO: rename ancestry group fields to match v4 exomes
+# TODO: drop missing fields from VEP 105 annotations
+# TODO: merge vep_ht with v3.1.4 release table
+# TODO: rerun inbreeding coefficient with callstats instead of GT calls
+# TODO: annotate with newest dbsnp release
+# TODO: add Pangolin prediction
+# TODO: add zoonomia constraint scores
+
+
+def main(args):
+    """Script to generate release sites ht for v4 genomes."""
+    logger.info("Loading release table of v3.1.4...")
+    # ht = release_sites(public=True).versions["3.1.4"].ht()
+    ht = hl.read_table(
+        "gs://gnomad/release/3.1.4/ht/genomes/gnomad.genomes.v3.1.4.sites.ht"
+    )
+
+    logger.info("Replacing ancestry group 'oth' with 'remaining'...")
+    ht = replace_oth_with_remaining(ht)
+
+    logger.info("Loading VEP-annotated table...")
+    vep_ht = get_vep(version=CURRENT_VERSION, data_type="genomes").ht()
+
+    logger.info("Removing missing VEP fields...")
+    vep_ht = ht.annotate(vep=remove_missing_vep_fields(vep_ht.vep))
+
+    logger.info("Loading dbsnp table...")
+    dbsnp_ht = dbsnp.ht().select("rsid")
+
+    logger.info("Loading pangolin table...")
+    pangolin_ht = hl.read_table(
+        "gs://gnomad/v4.0/annotations/genomes/gnomad.genomes.v4.0.pangolin.ht"
+    )  # TODO: make Pangolin a versioned resource


### PR DESCRIPTION
This function is used to rename ancestry group fields to match v4 exomes.
Which means that all "oth" will be changed to "remaining".
2 Global fields are renamed: freq_meta (in the values of key "pop") and freq_index_dict (in the keys).