### PR TITLE
v4 frequency script

### DIFF
--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -408,19 +408,19 @@ def correct_qual_hists(ht: hl.Table) -> hl.Table:  # add ab_threshold as arg
     return ht
 
 
-def generate_faf_popmax(ht: hl.Table) -> hl.Table:
+def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
     """
-    Compute filtering allele frequencies and popmax with the AB-adjusted frequencies.
+    Compute filtering allele frequencies and grpmax with the AB-adjusted frequencies.
 
     :param ht: Hail Table containing freq, ab_adjusted_freq, high_ab_het annotations.
-    :return: Hail Table with faf & popmax annotations.
+    :return: Hail Table with faf & grpmax annotations.
     """
     faf, faf_meta = faf_expr(
         ht.ab_adjusted_freq, ht.freq_meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX
     )
     ht = ht.annotate(
         faf=faf,
-        popmax=pop_max_expr(  # TODO: Update popmax to grpmax
+        grpmax=pop_max_expr(
             ht.ab_adjusted_freq, ht.freq_meta, POPS_TO_REMOVE_FOR_POPMAX
         ),
     )
@@ -429,9 +429,9 @@ def generate_faf_popmax(ht: hl.Table) -> hl.Table:
         faf_index_dict=make_faf_index_dict(faf_meta, label_delimiter="-"),
     )
     ht = ht.annotate(
-        popmax=ht.popmax.annotate(  # TODO: Update popmax to grpmax
+        grpmax=ht.grpmax.annotate(
             faf95=ht.faf[
-                ht.faf_meta.index(lambda x: x.values() == ["adj", ht.popmax.pop])
+                ht.faf_meta.index(lambda x: x.values() == ["adj", ht.grpmax.pop])
             ].faf95
         )
     )
@@ -712,8 +712,8 @@ def main(args):  # noqa: D103
         logger.info("Correcting age histograms...")
         ht = correct_age_hists(ht)
 
-        logger.info("computing FAF & popmax...")
-        ht = generate_faf_popmax(ht)
+        logger.info("computing FAF & grpmax...")
+        ht = generate_faf_grpmax(ht)
 
         logger.info("Calculating InbreedingCoeff...")
         ht = compute_inbreeding_coeff(ht)

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -1,0 +1,614 @@
+"""Script to generate the frequency data annotations across v4 exomes."""  # TODO: Expand on script description once nearing completion.
+import argparse
+import logging
+
+import hail as hl
+from gnomad.resources.grch38.gnomad import (
+    SUBSETS,  # TODO: subsets will be changed to UKB, non-UKB, non-TopMed
+)
+from gnomad.resources.grch38.gnomad import DOWNSAMPLINGS, POPS_TO_REMOVE_FOR_POPMAX
+from gnomad.sample_qc.sex import adjusted_sex_ploidy_expr
+from gnomad.utils.annotations import (
+    age_hists_expr,
+    annotate_freq_and_high_ab_hets,
+    bi_allelic_site_inbreeding_expr,
+    faf_expr,
+    get_adj_expr,
+    pop_max_expr,
+    qual_hist_expr,
+    set_female_y_metrics_to_na_expr,
+)
+from gnomad.utils.release import make_faf_index_dict, make_freq_index_dict
+from gnomad.utils.slack import slack_notifications
+
+from gnomad_qc.resource_utils import (
+    PipelineResourceCollection,
+    PipelineStepResourceCollection,
+)
+from gnomad_qc.slack_creds import slack_token
+from gnomad_qc.v4.resources.annotations import (  # TODO: Need to generate this resource for raw callstats
+    get_freq,
+)
+from gnomad_qc.v4.resources.basics import (
+    get_checkpoint_path,
+    get_gnomad_v4_vds,
+    qc_temp_prefix,
+)
+from gnomad_qc.v4.resources.meta import meta
+from gnomad_qc.v4.resources.release import release_sites
+from gnomad_qc.v4.resources.variant_qc import (  # TODO: Confirm we want this in frequency calculations
+    SYNDIP,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s: %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+logger = logging.getLogger("gnomAD_frequency")
+logger.setLevel(logging.INFO)
+
+
+def get_freq_resources(
+    overwrite: bool, test: bool, chr: str
+) -> PipelineResourceCollection:
+    """
+    Get frequency resources.
+
+    :param overwrite: Whether to overwrite existing files.
+    :param test: Whether to use test resources.
+    :return: Frequency resources.
+    """
+    freq_pipeline = PipelineResourceCollection(
+        pipeline_name="frequency",
+        overwrite=overwrite,
+    )
+    get_freq_and_high_ab = PipelineStepResourceCollection(
+        "--get-freq-and-high-ab",
+        output_resources={
+            "freq_high_ab_ht": get_freq(test=test, hom_alt_adjustment=False, chr=chr),
+        },
+    )
+    correct_for_high_ab_hets = PipelineStepResourceCollection(
+        "--correct-for-high-ab-hets",
+        pipeline_input_steps=[get_freq_and_high_ab],
+        output_resources={
+            "freq_ht": get_freq(test=test, hom_alt_adjustment=True, chr=chr),
+        },
+    )
+    freq_pipeline.add_steps(
+        {
+            "get_freq_and_high_ab": get_freq_and_high_ab,
+            "correct_for_high_ab_hets": correct_for_high_ab_hets,
+        }
+    )
+    return freq_pipeline
+
+
+def annotate_non_ref_het(vds: hl.vds.VariantDataset) -> hl.vds.VariantDataset:
+    """
+    Annotate non-ref heterozygous calls to prevent incorrect call adjustment post-split.
+
+    :param vds: Hail VDS to annotate non-ref het onto variant data.
+    :return: Hail VDS with _non_ref_het annotation.
+    """
+    vds.variant_data = vds.variant_data.annotate_entries(
+        _het_non_ref=vds.variant_data.LGT.is_het_non_ref()
+    )
+    return vds
+
+
+def needs_high_ab_het_fix_expr(
+    mt: hl.MatrixTable,
+    ab_cutoff: hl.float = 0.9,
+) -> hl.MatrixTable:
+    """
+    Annotate the MatrixTable rows with the count of high AB het genotypes per frequency sample grouping.
+
+    This arrary allows the AC to be corrected with the homalt depletion fix.
+
+    :param mt: Hail MatrixTable to annotate.
+    :param ab_cutoff: Alelle balance threshold at which the GT changes to homalt. Default is 0.9.
+    :return mt:
+    """
+    return (
+        (mt.AD[1] / mt.DP > ab_cutoff)
+        & mt.adj
+        & mt.GT.is_het_ref()
+        & ~mt.meta.project_meta.fixed_homalt_model
+        & ~mt._het_non_ref  # Skip adjusting genotypes if sample originally had a het nonref genotype
+    )
+
+
+def correct_call_stats(ht: hl.Table, af_threshold: float = 0.01) -> hl.Table:
+    """
+    Correct frequencies at sites with an AF greater than the af_threshold.
+
+    :param ht: Hail Table containing freq and high_ab_het annotations.
+    :param af_threshold: AF threshold at which to correct frequency. Default is 0.01.
+    :return: Hail Table with adjusted frequencies.
+    """
+    ht = ht.annotate(
+        ab_adjusted_freq=hl.if_else(
+            ht.freq[0].AF > af_threshold,
+            hl.map(
+                lambda f, g: hl.struct(
+                    AC=hl.int32(f.AC + g),
+                    AF=hl.if_else(f.AN > 0, (f.AC + g) / f.AN, hl.missing(hl.tfloat64)),
+                    AN=f.AN,
+                    homozygote_count=f.homozygote_count + g,
+                ),
+                ht.freq,
+                ht.high_ab_hets_by_group_membership,
+            ),
+            ht.freq,
+        )
+    )
+
+    return ht
+
+
+def compute_age_hist(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """
+    Compute age histograms for each variant.
+
+    :param mt: Input MT with age annotation.
+    :return: MatrixTable with age histogram annotations.
+    """
+    mt = mt.annotate_rows(**age_hists_expr(mt.adj, mt.GT, mt.meta.project_meta.age))
+
+    # Compute callset-wide age histogram global
+    mt = mt.annotate_globals(
+        age_distribution=mt.aggregate_cols(
+            hl.agg.hist(mt.meta.project_meta.age, 30, 80, 10)
+        )
+    )
+    return mt
+
+
+def annotate_quality_metrics_hist(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """
+    Annotate quality metrics histograms.
+
+    :param mt: Input MT.
+    :return: MatrixTable with qual histogram annotations.
+    """
+    mt = mt.annotate_rows(qual_hists=qual_hist_expr(mt.GT, mt.GQ, mt.DP, mt.AD, mt.adj))
+    mt = mt.annotate_rows(
+        qual_hists=hl.Struct(
+            **{
+                i.replace("_adj", ""): mt.qual_hists[i]
+                for i in mt.qual_hists
+                if "_adj" in i
+            }
+        ),
+        raw_qual_hists=hl.Struct(
+            **{i: mt.qual_hists[i] for i in mt.qual_hists if "_adj" not in i}
+        ),
+    )
+    return mt
+
+
+def generate_faf_popmax(ht: hl.Table) -> hl.Table:
+    """
+    Compute filtering allele frequencies and popmax with the AB-adjusted frequencies.
+
+    :param ht: Hail Table containing freq, ab_adjusted_freq, high_ab_het annotations.
+    :return: Hail Table with faf & popmax annotations.
+    """
+    faf, faf_meta = faf_expr(
+        ht.ab_adjusted_freq, ht.freq_meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX
+    )
+    ht = ht.annotate(
+        faf=faf,
+        popmax=pop_max_expr(
+            ht.ab_adjusted_freq, ht.freq_meta, POPS_TO_REMOVE_FOR_POPMAX
+        ),
+    )
+    ht = ht.annotate_globals(
+        faf_meta=faf_meta,
+        faf_index_dict=make_faf_index_dict(faf_meta, label_delimiter="-"),
+    )
+    ht = ht.annotate(
+        popmax=ht.popmax.annotate(  # TODO: Update popmax to grpmax
+            faf95=ht.faf[
+                ht.faf_meta.index(lambda x: x.values() == ["adj", ht.popmax.pop])
+            ].faf95
+        )
+    )
+    return ht
+
+
+def get_sample_age_bin(
+    sample_age: hl.expr.Int32Expression,
+    lower_bound: int = 30,
+    upper_bound: int = 80,
+    number_of_bins: int = 10,
+) -> hl.expr.StringExpression:
+    """
+    Get the age bin for a sample.
+
+    :param sample_age: Sample age.
+    :return: Sample age bin.
+    """
+    bin_size = (upper_bound - lower_bound) / number_of_bins
+    lower_bin = hl.int(
+        hl.floor((sample_age - lower_bound) / bin_size) * bin_size + lower_bound
+    )
+    upper_bin = hl.int(lower_bin + bin_size)
+
+    bin_label = hl.if_else(
+        sample_age < lower_bound,
+        "n_smaller",
+        hl.if_else(
+            sample_age >= upper_bound,
+            "n_larger",
+            hl.str(lower_bin) + "-" + hl.str(upper_bin),
+        ),
+    )
+
+    return hl.or_missing(hl.is_defined(sample_age), bin_label)
+
+
+def correct_qual_hists(ht: hl.Table) -> hl.Table:
+    """
+    Correct quality metrics histograms.
+
+    Correct by accessing the qual_hist and raw_qual_hist structs and removing
+    all counts from the ab_hist_alt array where bin_edges exceed 0.9 AB.
+
+    :param ht: Hail Table containing qual hists, AB annotation.
+    :return: Hail Table
+    """
+
+    def _correct_ab_hist_alt(ab_hist_alt):
+        return hl.struct(
+            bin_edges=ab_hist_alt.bin_edges,
+            bin_freq=hl.map(
+                lambda edge, freq: hl.if_else(edge >= 0.4, 0, freq),
+                ab_hist_alt.bin_edges[:-1],
+                ab_hist_alt.bin_freq,
+            ),
+            n_smaller=ab_hist_alt.n_smaller,
+            n_larger=0,
+        )
+
+    ht = ht.annotate(
+        qual_hist=ht.qual_hist.annotate(
+            ab_hist_alt=_correct_ab_hist_alt(ht.qual_hists.ab_hist_alt)
+        ),
+        raw_qual_hist=ht.raw_qual_hist.annotate(
+            ab_hist_alt=_correct_ab_hist_alt(ht.raw_qual_hists.ab_hist_alt)
+        ),
+    )
+    return ht
+
+
+def create_high_ab_age_hists(
+    ht: hl.Table, freq_meta_expr: hl.tstr = "freq_meta", age_group_key="sample_age_bin"
+) -> hl.Table:
+    """
+    Create age histograms of high ab counts to account for high AB hets becoming hom alts.
+
+    :param ht: Hail Table containing age hists, AB annotation.
+    :return: Hail Table
+    """
+    non_range_entries = hl.set(["n_larger", "n_smaller"])
+    age_bins_indices = hl.sorted(
+        hl.enumerate(ht["freq_meta"], index_first=False)
+        .filter(lambda x: x[0].contains(age_group_key))
+        .map(lambda x: (x[0][age_group_key], x[1]))
+    )
+
+    age_bins_indices_dict = hl.dict(age_bins_indices)
+    age_bin_indices_no_edges = age_bins_indices.filter(
+        lambda x: ~non_range_entries.contains(x[0])
+    )
+    ht = ht.annotate(
+        age_high_ab_hist=hl.struct(
+            bin_freq=hl.starmap(
+                lambda x, y: ht.high_ab_hets_by_group_membership[y],
+                age_bin_indices_no_edges,
+            ),
+            n_smaller=ht.high_ab_hets_by_group_membership[
+                age_bins_indices_dict["n_smaller"]
+            ],
+            n_larger=ht.high_ab_hets_by_group_membership[
+                age_bins_indices_dict["n_larger"]
+            ],
+        )
+    )
+
+
+def correct_age_hists(ht: hl.Table) -> hl.Table:
+    """
+    Correct age histograms.
+
+    Correct by subtracting age_high_ab_hists from age_hist_het and adding
+    age_high_ab_hists to age_hist_hom to account for high AB hets becoming hom alts.
+
+    :param ht: Hail Table containing age hists and hist of AB counts by age annotation.
+    :return: Hail Table
+    """
+    return ht.annotate(
+        age_hist_het=hl.struct(
+            bin_freq=hl.map(
+                lambda x, y: x.bin_freq - y.bin_freq,
+                ht.age_hist_het.bin_freq,
+                ht.age_high_ab_hist.bin_freq,
+            ),
+            n_smaller=ht.age_hist_het.n_smaller - ht.age_high_ab_hist.n_smaller,
+            n_larger=ht.age_hist_het.n_larger - ht.age_high_ab_hist.n_larger,
+        ),
+        age_hist_hom=hl.struct(
+            bin_freq=hl.map(
+                lambda x, y: x.bin_freq + y.bin_freq,
+                ht.age_hist_hom.bin_freq,
+                ht.age_high_ab_hist.bin_freq,
+            ),
+            n_smaller=ht.age_hist_hom.n_smaller + ht.age_high_ab_hist.n_smaller,
+            n_larger=ht.age_hist_hom.n_larger + ht.age_high_ab_hist.n_larger,
+        ),
+    )
+
+
+def main(args):  # noqa: D103
+    subsets = args.subsets
+    test_dataset = args.test_dataset
+    test_n_partitions = args.test_n_partitions
+    test = test_dataset or test_n_partitions
+    chrom = args.chrom
+
+    ab_cutoff = args.ab_cutoff
+    af_threshold = args.af_threshold
+    correct_for_high_ab_hets = args.correct_for_high_ab_hets
+
+    hl.init(
+        log=f"/generate_frequency_data{'.' + '_'.join(subsets) if subsets else ''}.log",
+        default_reference="GRCh38",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
+    # TODO: Determine if splitting subset freq from whole callset agg
+    resources = get_freq_resources(args.overwrite, test, chrom)
+
+    logger.info("Getting gnomAD v4 VDS...")
+    # TODO: Update this to get the raw vds or change get_gnomad_vds logic so
+    # if release only samples, skip all other sample removal steps,
+    # partitioning may need to go too.
+    vds = get_gnomad_v4_vds(
+        test=test_dataset,
+        release_only=True,
+        chrom=chrom,
+        n_partitions=10000,
+    )
+    meta = meta.ht()
+
+    if test or chrom:
+        if test_dataset:
+            logger.info("Filtering to DRD2 in test VDS for testing purposes...")
+            test_interval = [
+                hl.parse_locus_interval(
+                    "chr11:113409605-113475691", reference_genome="GRCh38"
+                )
+            ]  # NOTE: test on gene DRD2 for now, will update to chr22 when original PR goes in
+            vds = hl.vds.filter_intervals(
+                vds, test_interval, split_reference_blocks=True
+            )
+            variants, samples = vds.variant_data.count()
+            logger.info(
+                "Test VDS has %s variants in DRD2 in %s samples...", variants, samples
+            )
+        elif test_n_partitions:
+            test_vd = vds.variant_data._filter_partitions(range(test_n_partitions))
+            test_rd = vds.reference_data._filter_partitions(range(test_n_partitions))
+            vds = hl.vds.VariantDataset(test_rd, test_vd)
+        else:
+            logger.info("Filtering to chromosome %s...", chrom)
+            vds = hl.vds.filter_chromosomes(vds, keep=chrom)
+
+    logger.info("Annotating needed metadata...")
+    vds = hl.vds.VariantDataset(
+        vds.reference_data,
+        vds.variant_data.annotate_cols(
+            pop=meta[vds.variant_data.col_key].population_inference.pop,
+            sex_karyotype=meta[vds.variant_data.col_key].sex_imputation.sex_karyotype,
+            gatk_version=meta[vds.variant_data.col_key].project_meta.gatk_version,
+            age=meta[vds.variant_data.col_key].project_meta.age,
+            sample_age_bin=get_sample_age_bin(
+                meta[vds.variant_data.col_key].project_meta.age
+            ),
+            # subsets=meta[vds.variant_data.col_key].project_meta.subsets,
+        ),
+    )
+
+    logger.info("Annotating non_ref hets pre-split...")
+    vds = annotate_non_ref_het(vds)
+
+    if args.subsets:
+        vds = hl.vds.filter_samples(
+            vds,
+            vds.variant_data.subsets.contains(
+                hl.literal(subsets)
+            ),  # TODO: Fix this logic and all subset logic
+        )
+    logger.info("Splitting VDS....")
+    vds = hl.vds.split_multi(vds, filter_changed_loci=True)
+
+    vds = hl.vds.VariantDataset(
+        vds.reference_data,
+        vds.variant_data.select_entries("_het_non_ref", "AD", "DP", "GQ", "GT"),
+    )
+
+    logger.info("Densifying VDS...")
+    mt = hl.vds.to_dense_mt(vds)
+
+    logger.info("Computing adj and sex adjusted genotypes...")
+    mt = mt.select_entries(
+        "_het_non_ref",
+        "AD",
+        "DP",
+        "GQ",
+        GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, mt.sex_karyotype),
+        adj=get_adj_expr(mt.GT, mt.GQ, mt.DP, mt.AD),
+    )
+    # mt = mt.checkpoint(
+    #     "gs://gnomad-tmp/mwilson/dense_mt_chr20_10k_partitions.mt", overwrite=True
+    # )
+    if args.run_dense_dependent_steps:
+        logger.info("Annotating frequencies and counting high AB het calls...")
+        res = resources.get_freq_and_high_ab
+
+        freq_ht = annotate_freq_and_high_ab_hets(
+            mt,
+            sex_expr=mt.sex_karyotype,
+            pop_expr=mt.pop,
+            downsamplings=DOWNSAMPLINGS["v4"],
+            additional_strata_expr=[
+                {"gatk_version": mt.gatk_version},
+                {
+                    "gatk_version": mt.gatk_version,
+                    "pop": mt.pop,
+                },
+                {"sample_age_bin": mt.sample_age_bin},
+            ],
+            ab_cutoff=ab_cutoff,
+        )
+
+        logger.info("Making freq index dict...")
+        freq_ht = freq_ht.annotate_globals(
+            freq_index_dict=make_freq_index_dict(
+                freq_meta=hl.eval(freq_ht.freq_meta),
+                downsamplings=hl.eval(freq_ht.downsamplings),
+                label_delimiter="_",
+            )  # TODO: Update to use Julia's suggestion with edits in notebook -- make new make_freq_dict_from_meta function
+        )
+        logger.info("Setting XX y metrics to NA...")
+        freq_ht = freq_ht.annotate(freq=set_female_y_metrics_to_na_expr(freq_ht))
+
+        final_anns = {}
+        logger.info("Annotating quality metrics histograms...")
+        mt = annotate_quality_metrics_hist(mt)
+        final_anns.update(
+            {
+                "qual_hists": mt.rows()[freq_ht.key].qual_hists,
+                "raw_qual_hists": mt.rows()[freq_ht.key].raw_qual_hists,
+            }
+        )
+        logger.info("Computing age histograms for each variant...")
+        mt = compute_age_hist(mt)
+        final_anns.update(
+            {
+                "age_hist_het": mt.rows()[freq_ht.key].age_hist_het,
+                "age_hist_hom": mt.rows()[freq_ht.key].age_hist_hom,
+            }
+        )
+
+        freq_ht = freq_ht.annotate(**final_anns)
+        freq_ht.write(res.freq_high_ab_ht.path, overwrite=args.overwrite)
+
+    if correct_for_high_ab_hets:
+        logger.info(
+            "Adjusting annotations impacted by high AB het -> hom alt adjustment..."
+        )
+        res = resources.correct_call_stats
+        ht = res.freq_high_ab_ht.ht()
+
+        logger.info("Correcting call stats...")
+        ht = correct_call_stats(ht, af_threshold)
+
+        logger.info("Correcting qual AB histograms...")
+        ht = correct_qual_hists(ht)
+
+        logger.info("Correcting age histograms...")
+        ht = correct_age_hists(ht)
+
+        logger.info("computing FAF & popmax...")
+        ht = generate_faf_popmax(ht)
+
+        logger.info("Calculating InbreedingCoeff...")
+        # NOTE: This is not the ideal location to calculate this, but added here to avoid another densify # noqa
+        ht = ht.annotate(
+            InbreedingCoeff=bi_allelic_site_inbreeding_expr(use_callstats=True)
+        )
+
+        logger.info("Writing frequency table...")
+        ht.describe()
+        ht.write(res.freq_ht.path, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--test-dataset",
+        help="Runs a test on two partitions of the MT.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test-n-partitions",
+        help=(
+            "Use only N partitions of the VDS as input for testing purposes. Defaults"
+            "to 2 if passed without a value."
+        ),
+        nargs="?",
+        const=2,
+        type=int,
+    )
+    parser.add_argument(
+        "--chrom",
+        help="If passed, script will only run on passed chromosome.",
+        type=str,
+    )
+    parser.add_argument(
+        "--overwrite", help="Overwrites existing files.", action="store_true"
+    )
+    parser.add_argument(
+        "--slack-channel", help="Slack channel to post results and notifications to."
+    )
+    parser.add_argument(
+        "--subsets",
+        help="Subsets to run frequency calculation on.",
+        choices=SUBSETS["v4"],
+    )
+    parser.add_argument(
+        "--run-dense-dependent-steps",
+        help=(
+            "Calculate frequencies, histograms, and high AB sites per sample grouping."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--correct-for-high-ab-hets",
+        help=(
+            "Correct each frequency entry to account for homozygous alternate depletion"
+            " present in GATK versions released prior to 4.1.4.1 and run chosen"
+            " downstream annotations."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--ab-cutoff",
+        help=(
+            "Allele balance threshold to use when adjusting heterozygous calls to "
+            "homozygous alternate calls at sites for samples that used GATK versions"
+            " released prior to 4.1.4.1."
+        ),
+        type=float,
+        default=0.9,
+    )
+    parser.add_argument(
+        "--af-threshold",
+        help=(
+            "Threshold at which to adjust site group frequencies at sites for"
+            " homozygous alternate depletion present in GATK versions released prior to"
+            " 4.1.4.1."
+        ),
+        type=float,
+        default=0.01,
+    )
+    args = parser.parse_args()
+
+    if args.slack_channel:
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
+    else:
+        main(args)

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -36,9 +36,7 @@ from gnomad_qc.resource_utils import (
     PipelineStepResourceCollection,
 )
 from gnomad_qc.slack_creds import slack_token
-from gnomad_qc.v4.resources.annotations import (
-    get_freq,  # TODO: Need to generate this resource for raw callstats; TODO: add the args used in this script to the resource on this new branch, use old branch as reference
-)
+from gnomad_qc.v4.resources.annotations import get_freq
 from gnomad_qc.v4.resources.basics import get_gnomad_v4_vds
 from gnomad_qc.v4.resources.meta import meta
 
@@ -52,13 +50,14 @@ logger.setLevel(logging.INFO)
 
 
 def get_freq_resources(
-    overwrite: bool, test: bool, chrom: str
+    overwrite: bool = False, test: Optional[bool] = False, chrom: Optional[str] = None
 ) -> PipelineResourceCollection:
     """
     Get frequency resources.
 
     :param overwrite: Whether to overwrite existing files.
     :param test: Whether to use test resources.
+    :param chrom: Chromosome used in freq calculations.
     :return: Frequency resources.
     """
     freq_pipeline = PipelineResourceCollection(
@@ -69,7 +68,7 @@ def get_freq_resources(
         "--run-freq-and-dense-annotations",
         output_resources={
             "run_freq_and_dense_annotations": get_freq(
-                test=test, hom_alt_adjustment=False, chr=chrom
+                test=test, hom_alt_adjusted=False, chrom=chrom
             ),
         },
     )
@@ -77,7 +76,7 @@ def get_freq_resources(
         "--correct-for-high-ab-hets",
         pipeline_input_steps=[run_freq_and_dense_annotations],
         output_resources={
-            "freq_ht": get_freq(test=test, hom_alt_adjustment=True, chr=chrom),
+            "freq_ht": get_freq(test=test, hom_alt_adjustedt=True, chr=chrom),
         },
     )
     freq_pipeline.add_steps(

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -923,6 +923,19 @@ def generate_freq_and_hists_ht(
         .extend(freq_ht.high_ab_hets_by_group_membership[1:])
     )
 
+    logger.info("Making freq index dict...")
+    # Add our additional strata to the sort order, keeping group, i.e. adj, at the end
+    sort_order = deepcopy(SORT_ORDER)
+    sort_order[-1:-1] = ["gatk_version", "ukb_sample", "sample_age_bin"]
+
+    freq_ht = freq_ht.annotate_globals(
+        freq_index_dict=make_freq_index_dict_from_meta(
+            freq_meta=freq_ht.freq_meta,
+            label_delimiter="_",
+            sort_order=sort_order,
+            # TODO: Check if we actually want to see age_bin, I dont think we do
+        )
+    )
     logger.info("Setting Y metrics to NA for XX groups...")
     freq_ht = freq_ht.annotate(freq=set_female_y_metrics_to_na_expr(freq_ht))
 
@@ -947,8 +960,8 @@ def generate_freq_and_hists_ht(
     freq_ht = freq_ht.annotate_globals(**final_globals_anns)
     freq_ht.describe()
     freq_ht = freq_ht.checkpoint(
-        # new_temp_file(f"freq_ht_{idx}", extension="ht"),
-        f"gs://gnomad-mwilson/v4/frequencies/test/freq_ht_{idx}.ht",
+        new_temp_file(f"freq_ht_{idx}", extension="ht"),
+        # f"gs://gnomad-mwilson/v4/frequencies/test/freq_ht_{idx}.ht",
         overwrite=args.overwrite,
         _read_if_exists=True,
     )
@@ -1092,8 +1105,8 @@ def combine_freq_hts(
     # Add our additional strata to the sort order, keeping group, i.e. adj, at the end
     sort_order = deepcopy(SORT_ORDER)
     sort_order[-1:-1] = ["gatk_version", "ukb_sample", "sample_age_bin"]
+    freq_ht = freq_ht.annotate_globals(freq_meta=hl.eval(comb_freq_meta))
     freq_ht = freq_ht.annotate_globals(
-        freq_meta=hl.eval(comb_freq_meta),
         freq_index_dict=make_freq_index_dict_from_meta(
             freq_meta=freq_ht.freq_meta,
             label_delimiter="_",

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -1,7 +1,7 @@
 """Script to generate the frequency data annotations across v4 exomes."""  # TODO: Expand on script description once nearing completion.
 import argparse
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 import hail as hl
 from gnomad.resources.grch38.gnomad import DOWNSAMPLINGS, POPS_TO_REMOVE_FOR_POPMAX
@@ -12,6 +12,7 @@ from gnomad.utils.annotations import (
     bi_allelic_site_inbreeding_expr,
     faf_expr,
     get_adj_expr,
+    merge_freq_arrays,
     pop_max_expr,
     qual_hist_expr,
     set_female_y_metrics_to_na_expr,
@@ -19,6 +20,7 @@ from gnomad.utils.annotations import (
 from gnomad.utils.release import make_faf_index_dict, make_freq_index_dict_from_meta
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.vcf import SORT_ORDER
+from hail.utils.misc import new_temp_file
 
 from gnomad_qc.resource_utils import (
     PipelineResourceCollection,
@@ -40,7 +42,7 @@ logger.setLevel(logging.INFO)
 
 
 def get_freq_resources(
-    overwrite: bool, test: bool, chr: str
+    overwrite: bool, test: bool, chrom: str
 ) -> PipelineResourceCollection:
     """
     Get frequency resources.
@@ -57,7 +59,7 @@ def get_freq_resources(
         "--run-freq-and-dense-annotations",
         output_resources={
             "run_freq_and_dense_annotations": get_freq(
-                test=test, hom_alt_adjustment=False, chr=chr
+                test=test, hom_alt_adjustment=False, chr=chrom
             ),
         },
     )
@@ -65,7 +67,7 @@ def get_freq_resources(
         "--correct-for-high-ab-hets",
         pipeline_input_steps=[run_freq_and_dense_annotations],
         output_resources={
-            "freq_ht": get_freq(test=test, hom_alt_adjustment=True, chr=chr),
+            "freq_ht": get_freq(test=test, hom_alt_adjustment=True, chr=chrom),
         },
     )
     freq_pipeline.add_steps(
@@ -124,20 +126,36 @@ def get_vds_for_freq(
             sex_karyotype=meta_ht[
                 vds.variant_data.col_key
             ].sex_imputation.sex_karyotype,
+            fixed_homalt_model=meta_ht[
+                vds.variant_data.col_key
+            ].project_meta.fixed_homalt_model,
             gatk_version=meta_ht[vds.variant_data.col_key].project_meta.gatk_version,
             age=meta_ht[vds.variant_data.col_key].project_meta.age,
             sample_age_bin=get_sample_age_bin(
                 meta_ht[vds.variant_data.col_key].project_meta.age
             ),
-            ukb_sample=meta_ht[vds.variant_data.col_key].project_meta.ukb_sample,
+            ukb_sample=hl.if_else(
+                meta_ht[vds.variant_data.col_key].project_meta.ukb_sample,
+                "ukb",
+                "non_ukb",
+            ),
         ),
     )
+
+    # Downsamplings are down outside the above function as we need to store
+    # global and row annotations
+    logger.info("Annotating downsampling groups...")
+    vds = hl.vds.VariantDataset(
+        vds.reference_data,
+        annotate_downsamplings(vds.variant_data, pop_expr=vds.variant_data.pop),
+    )
+
     logger.info("Annotating non_ref hets pre-split...")
     vds = annotate_non_ref_het(vds)
 
     logger.info("Selecting only required fields to reduce memory usage...")
     vds = hl.vds.VariantDataset(
-        vds.reference_data_data,
+        vds.reference_data,
         vds.variant_data.select_entries("LA", "LAD", "DP", "GQ", "LGT", "_het_non_ref"),
     )
 
@@ -181,28 +199,6 @@ def annotate_adj_and_select_fields(vds: hl.vds.VariantDataset) -> hl.vds.Variant
     return hl.vds.VariantDataset(rmt, vmt)
 
 
-def needs_high_ab_het_fix_expr(
-    mt: hl.MatrixTable,
-    ab_cutoff: hl.float = 0.9,
-) -> hl.MatrixTable:
-    """
-    Annotate the MatrixTable rows with the count of high AB het genotypes per frequency sample grouping.
-
-    This arrary allows the AC to be corrected with the homalt depletion fix.
-
-    :param mt: Hail MatrixTable to annotate.
-    :param ab_cutoff: Alelle balance threshold at which the GT changes to homalt. Default is 0.9.
-    :return mt:
-    """
-    return (
-        (mt._het_AD / mt.DP > ab_cutoff)
-        & mt.adj
-        & mt.GT.is_het_ref()
-        & ~mt.meta.project_meta.fixed_homalt_model
-        & ~mt._het_non_ref  # Skip adjusting genotypes if sample originally had a het nonref genotype
-    )
-
-
 def correct_call_stats(ht: hl.Table, af_threshold: float = 0.01) -> hl.Table:
     """
     Correct frequencies at sites with an AF greater than the af_threshold.
@@ -231,13 +227,12 @@ def correct_call_stats(ht: hl.Table, af_threshold: float = 0.01) -> hl.Table:
     return ht
 
 
-def create_high_ab_age_hists(
-    ht: hl.Table, freq_meta_expr: hl.tstr = "freq_meta", age_group_key="sample_age_bin"
-) -> hl.Table:
+def create_high_ab_age_hists(ht: hl.Table, age_group_key="sample_age_bin") -> hl.Table:
     """
     Create age histograms of high ab counts to account for high AB hets becoming hom alts.
 
     :param ht: Hail Table containing age hists, AB annotation.
+    :param age_group_key: Age group key to use for age histogram.
     :return: Hail Table
     """
     non_range_entries = hl.set(["n_larger", "n_smaller"])
@@ -456,6 +451,199 @@ def compute_inbreeding_coeff(ht: hl.Table) -> hl.Table:
     return ht
 
 
+def annotate_downsamplings(
+    mt: hl.MatrixTable,
+    pop_expr: Optional[hl.expr.StringExpression] = None,
+    downsamplings=DOWNSAMPLINGS["v4"],
+) -> hl.MatrixTable:
+    """
+    Annotate downsampling groups.
+
+    :param mt: Input MT.
+    :param pop_expr: Optional expression for population group. When provided, population sample sizes are added as values to downsamplings.
+    :return: MatrixTable with downsampling annotations.
+    """
+    if pop_expr is not None:
+        mt = mt.annotate_cols(pop=pop_expr)
+        pop_sizes = list(mt.aggregate_cols(hl.agg.counter(mt.pop)).values())
+        downsamplings = [x for x in downsamplings if x <= sum(pop_sizes)]
+        downsamplings = sorted(set(downsamplings + pop_sizes))
+
+    logger.info("Found %i downsamplings: %s", len(downsamplings), downsamplings)
+    downsampling_ht = mt.cols()
+    downsampling_ht = downsampling_ht.annotate(r=hl.rand_unif(0, 1))
+    downsampling_ht = downsampling_ht.order_by(downsampling_ht.r)
+    scan_expr = {"global_idx": hl.scan.count()}
+
+    if pop_expr is not None:
+        scan_expr["pop_idx"] = hl.scan.counter(downsampling_ht.pop).get(
+            downsampling_ht.pop, 0
+        )
+
+    downsampling_ht = downsampling_ht.annotate(**scan_expr)
+    downsampling_ht = downsampling_ht.key_by("s").select(*scan_expr)
+    mt = mt.annotate_cols(downsampling=downsampling_ht[mt.s])
+    mt = mt.annotate_globals(downsamplings=downsamplings)
+
+    return mt
+
+
+def split_vds(
+    vds: hl.vds.VariantDataset, split_annotation: hl.expr.Expression
+) -> hl.ArrayExpression:
+    """
+    Split a VDS into a list of VDSs based on the split_annotation.
+
+    :param vds: Input VDS.
+    :param split_annotation: Annotation on VDS variant_data MT split on.
+    :return: List of VDSs.
+    """
+    vds_list = []
+    for split in vds.variant_data.aggregate_cols(
+        hl.agg.collect_as_set(split_annotation)
+    ):
+        vds_list.append(
+            hl.vds.VariantDataset(
+                vds.reference_data,
+                vds.variant_data.filter_cols(split_annotation == split),
+            )
+        )
+
+    return vds_list
+
+
+def generate_freq_and_hists_ht(
+    vds: hl.vds.VariantDataset,
+    ab_cutoff: float = 0.9,
+    idx: Optional[int] = None,
+) -> hl.Table:
+    """
+    Generate frequency and histogram annotations.
+
+    Assumes all necessary annotations are present:
+        - adj
+        - _het_ad
+        - _het_non_ref
+        - GT
+        - GQ
+        - s
+        - pop
+        - sex_karyotype
+        - fixed_homalt_model
+        - gatk_version
+        - age
+        - sample_age_bin
+        - ukb_sample
+        - downsampling
+        - downsamplings
+
+    :param mt: Input MT.
+    :param ab_cutoff: Allele balance cutoff to use for high AB het annotation.
+    :param idx: Optional index to append to temp file name.
+    :return: Hail Table with frequency and histogram annotations.
+    """
+    final_rows_anns = {}
+    final_globals_anns = {}
+
+    logger.info("Densifying VDS # %s...", idx)
+    mt = hl.vds.to_dense_mt(vds)
+
+    logger.info("Computing sex adjusted genotypes...")
+    mt = mt.transmute_entries(
+        GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, mt.sex_karyotype),
+    )
+
+    logger.info("Annotating frequencies and counting high AB het calls...")
+    additional_strata_expr = [
+        {"gatk_version": mt.gatk_version},
+        {
+            "gatk_version": mt.gatk_version,
+            "pop": mt.pop,
+        },
+        {"sample_age_bin": mt.sample_age_bin},
+        {"ukb_sample": mt.ukb_sample},  # confirm this is how we want to name this
+    ]
+
+    freq_ht = annotate_freq_and_high_ab_hets(  # TODO: Update this function to use _het_ad when passed or maybe create AB ann?
+        mt,
+        sex_expr=mt.sex_karyotype,
+        pop_expr=mt.pop,
+        downsamplings=mt.downsamplings,
+        downsampling_expr=mt.downsampling,
+        additional_strata_expr=additional_strata_expr,
+        ab_cutoff=ab_cutoff,
+    )
+
+    logger.info("Making freq index dict...")
+    freq_ht = freq_ht.annotate_globals(
+        freq_index_dict=make_freq_index_dict_from_meta(
+            freq_meta=hl.eval(freq_ht.freq_meta),
+            label_delimiter="_",
+            sort_order=SORT_ORDER.insert(
+                -1, "gatk_version"
+            ),  # TODO: Check if we actually want to see age_bin, I dont thin we do
+        )
+    )
+    logger.info("Setting Y metrics to NA for XX groups...")
+    freq_ht = freq_ht.annotate(freq=set_female_y_metrics_to_na_expr(freq_ht))
+
+    logger.info("Annotating quality metrics histograms...")
+    mt = compute_qual_hists(mt)
+    final_rows_anns.update(
+        {
+            "qual_hists": mt.rows()[freq_ht.key].qual_hists,
+            "raw_qual_hists": mt.rows()[freq_ht.key].raw_qual_hists,
+        }
+    )
+    logger.info("Computing age histograms for each variant...")
+    mt = compute_age_hist(mt)  # globla age distribution is a global
+    final_rows_anns.update(
+        {
+            "age_hist_het": mt.rows()[freq_ht.key].age_hist_het,
+            "age_hist_hom": mt.rows()[freq_ht.key].age_hist_hom,
+        }
+    )
+    final_globals_anns.update({"age_distribution": mt[freq_ht.key].age_distribution})
+    freq_ht = freq_ht.annotate(**final_rows_anns)
+    freq_ht = freq_ht.annotate_globals(**final_globals_anns)
+    freq_ht = freq_ht.checkpoint(
+        new_temp_file(f"freq_ht{idx}", extension="ht"),
+        overwrite=args.overwrite,
+    )
+    return freq_ht
+
+
+def combine_freq_hts(freq_hts: hl.DictExpression, hists=[]) -> hl.Table:
+    """
+    Combine frequency HTs into a single HT.
+
+    :param freq_hts: Dictionary of frequency HTs.
+    :param hists: List of histograms to combine.
+    :return: Combined frequency HT.
+    """
+    freq_ht = hl.fold(
+        lambda x, y: x.union(y),
+        freq_hts.values()[0],
+        freq_hts.values()[1:],
+    )
+    freq, freq_meta = merge_freq_arrays(freq_ht.freq, freq_hts[1].freq_meta)
+    freq_ht = freq_ht.annotate(
+        freq=freq,
+        high_ab_hets_by_group_membership=hl.agg.array_agg(  # TODO: This may need to be change
+            lambda x: hl.agg.sum(x), freq_hts.values().map(lambda x: x.high_ab_hets)
+        ),
+    )
+    freq_ht = freq_ht.annotate_globals(
+        freq_meta=freq_meta,
+        freq_index_dict=make_freq_index_dict_from_meta(
+            freq_meta=freq_meta, label_delimiter="_"
+        ),
+    )
+    # TODO Merge all histograms here
+
+    return freq_ht
+
+
 def main(args):  # noqa: D103
     """Script to generate frequency and dense dependent annotations on v4 exomes."""
     test_gene = args.test_gene
@@ -467,91 +655,45 @@ def main(args):  # noqa: D103
     correct_for_high_ab_hets = args.correct_for_high_ab_hets
 
     hl.init(
-        log=f"/generate_frequency_data.log",
+        log="/generate_frequency_data.log",
         default_reference="GRCh38",
         tmp_dir="gs://gnomad-tmp-4day",
     )
-    # TODO: Determine if splitting subset freq from whole callset agg -- no
-    # splitting callset between ukb and non-ukb but same groupings
-    resources = get_freq_resources(args.overwrite, test, chrom)
 
-    logger.info("Getting VDS with fields required for splitting VDS...")
-    vds = get_vds_for_freq(test_gene, test_n_partitions, chrom)
-
-    logger.info("Spltting VDS...")
-    vds = hl.vds.split_multi(vds, filter_changed_loci=True)
-
-    logger.info(
-        "Computing adj and _het_AD as part of reducing fields to reduce memory usage"
-        " during dense dependent steps..."
-    )
-    vds = annotate_adj_and_select_fields(vds)
-
-    logger.info("Densifying VDS...")
-    mt = hl.vds.to_dense_mt(vds)
-
-    logger.info("Computing sex adjusted genotypes...")
-    mt = mt.transmute_entries(
-        GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, mt.sex_karyotype),
-    )
-    # mt = mt.checkpoint(
-    #     "gs://gnomad-tmp/mwilson/dense_mt_chr20_10k_partitions.mt", overwrite=True
-    # )
     if args.run_dense_dependent_steps:
         logger.info("Running dense dependent steps...")
+        resources = get_freq_resources(args.overwrite, test, chrom)
         res = resources.run_freq_and_dense_annotations
 
-        logger.info("Annotating frequencies and counting high AB het calls...")
-        additional_strata_expr = [
-            {"gatk_version": mt.gatk_version},
-            {
-                "gatk_version": mt.gatk_version,
-                "pop": mt.pop,
-            },
-            {"sample_age_bin": mt.sample_age_bin},
-        ]
+        logger.info("Getting VDS with fields required for splitting VDS...")
+        vds = get_vds_for_freq(test_gene, test_n_partitions, chrom)
 
-        freq_ht = annotate_freq_and_high_ab_hets(  # TODO: Update this function to use _het_ad when passed or maybe create AB ann?
-            mt,
-            sex_expr=mt.sex_karyotype,
-            pop_expr=mt.pop,
-            downsamplings=DOWNSAMPLINGS["v4"],
-            additional_strata_expr=additional_strata_expr,
-            ab_cutoff=ab_cutoff,
+        logger.info("Spltting mutliallelics in VDS...")
+        vds = hl.vds.split_multi(vds, filter_changed_loci=True)
+
+        logger.info(
+            "Computing adj and _het_AD as part of reducing fields to reduce memory"
+            " usage during dense dependent steps..."
         )
+        vds = annotate_adj_and_select_fields(vds)
 
-        logger.info("Making freq index dict...")
-        freq_ht = freq_ht.annotate_globals(
-            freq_index_dict=make_freq_index_dict_from_meta(
-                freq_meta=hl.eval(freq_ht.freq_meta),
-                label_delimiter="_",
-                sort_order=SORT_ORDER.insert(
-                    -1, "gatk_version"
-                ),  # TODO: Check if we actually want to see age_bin, I dont thin we do
+        logger.info(
+            "Splitting VDS by sample annotation to reduce data size for"
+            " densification..."
+        )
+        if args.split_vds_by_annotation:
+            vds_list = split_vds(vds, split_annotation=vds.variant_data.ukb_sample)
+            freq_hts = {}
+            for idx, vds in enumerate(vds_list, start=1):
+                freq_ht = generate_freq_and_hists_ht(vds, ab_cutoff=ab_cutoff, idx=idx)
+                freq_hts[idx] = freq_ht
+            freq_ht = combine_freq_hts(
+                freq_hts,
+                ["qual_hists", "raw_qual_hists", "age_hist_het", "age_hist_hom"],
             )
-        )
-        logger.info("Setting Y metrics to NA for XX groups...")
-        freq_ht = freq_ht.annotate(freq=set_female_y_metrics_to_na_expr(freq_ht))
+        else:
+            freq_ht = generate_freq_and_hists_ht(vds, ab_cutoff=ab_cutoff)
 
-        final_anns = {}
-        logger.info("Annotating quality metrics histograms...")
-        mt = compute_qual_hists(mt)
-        final_anns.update(
-            {
-                "qual_hists": mt.rows()[freq_ht.key].qual_hists,
-                "raw_qual_hists": mt.rows()[freq_ht.key].raw_qual_hists,
-            }
-        )
-        logger.info("Computing age histograms for each variant...")
-        mt = compute_age_hist(mt)  # globla age distribution is a global
-        final_anns.update(
-            {
-                "age_hist_het": mt.rows()[freq_ht.key].age_hist_het,
-                "age_hist_hom": mt.rows()[freq_ht.key].age_hist_hom,
-            }
-        )
-
-        freq_ht = freq_ht.annotate(**final_anns)
         freq_ht.write(res.freq_high_ab_ht.path, overwrite=args.overwrite)
 
     if correct_for_high_ab_hets:
@@ -576,6 +718,7 @@ def main(args):  # noqa: D103
         logger.info("Calculating InbreedingCoeff...")
         ht = compute_inbreeding_coeff(ht)
 
+        # TODO: Drop Age bins from freq fields
         logger.info("Writing frequency table...")
         ht.describe()
         ht.write(res.freq_ht.path, overwrite=args.overwrite)
@@ -613,6 +756,14 @@ if __name__ == "__main__":
         "--run-freq-and-dense-annotations",
         help=(
             "Calculate frequencies, histograms, and high AB sites per sample grouping."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--split-vds-by-annotation",
+        help=(
+            "Split VDS by annotation to reduce data size for densification."
+            " Defaults to False."
         ),
         action="store_true",
     )

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -160,7 +160,7 @@ fam_stats = VersionedTableResource(
 def get_freq(
     version: str = CURRENT_VERSION,
     test: bool = False,
-    hom_alt_adjustment=False,
+    hom_alt_adjusted=False,
     chrom: Optional[str] = None,
 ) -> VersionedTableResource:
     """
@@ -168,12 +168,12 @@ def get_freq(
 
     :param version: Version of annotation path to return
     :param test: Whether to use a tmp path for tests.
-    :param hom_alt_adjustment: Whether to return the frequency table before the hom alt adjustment.
+    :param hom_alt_adjusted: Whether to return the hom alt adjusted frequency table.
     :param chrom: Chromosome to return frequency table for. Entire Table will be returned if not specified.
     :return: Hail Table containing subset or overall cohort frequency annotations
     """
     ht_name = (
-        f"gnomad.exomes.v{version}.{'' + chrom if chrom else ''}.frequencies{'.pre_ab_adjustment' if not hom_alt_adjustment else ''}.ht"
+        f"gnomad.exomes.v{version}.{'' + chrom if chrom else ''}.frequencies{'.pre_hom_alt_adjustment' if not hom_alt_adjusted else '.hom_alt_adjusted'}.ht"
     )
     return VersionedTableResource(
         version,

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -173,14 +173,12 @@ def get_freq(
     :return: Hail Table containing subset or overall cohort frequency annotations
     """
     ht_name = (
-        f"gnomad.exomes.v{version}.{'' + chrom if chrom else ''}.frequencies{'.pre_hom_alt_adjustment' if not hom_alt_adjusted else '.hom_alt_adjusted'}.ht"
+        f"gnomad.exomes.v{version}.{'' + chrom + '.' if chrom else ''}frequencies{'.pre_hom_alt_adjustment' if not hom_alt_adjusted else '.hom_alt_adjusted'}.ht"
     )
     return VersionedTableResource(
         version,
         {
-            version: TableResource(
-                f"gs://gnomad-mwilson/v4/frequences/{ht_name}"
-            )  # {_annotations_root(version, test)}/{ht_name}")
+            version: TableResource(f"{_annotations_root(version, test)}/{ht_name}")
             for version in VERSIONS
         },
     )

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -158,30 +158,27 @@ fam_stats = VersionedTableResource(
 
 
 def get_freq(
-    version: str = CURRENT_VERSION, subset: Optional[str] = None
+    version: str = CURRENT_VERSION,
+    test: bool = False,
+    hom_alt_adjustment=False,
+    chrom: Optional[str] = None,
 ) -> VersionedTableResource:
     """
     Get the frequency annotation table for a specified release.
 
     :param version: Version of annotation path to return
-    :param subset: One of the official subsets of the specified release (e.g., non_neuro, non_cancer,
-        controls_and_biobanks) or a combination of them split by '-'
+    :param test: Whether to use a tmp path for tests.
+    :param hom_alt_adjustment: Whether to return the frequency table before the hom alt adjustment.
+    :param chrom: Chromosome to return frequency table for. Entire Table will be returned if not specified.
     :return: Hail Table containing subset or overall cohort frequency annotations
     """
-    if subset is not None:
-        for s in subset.split("-"):
-            if s not in SUBSETS:
-                raise DataException(
-                    f"{subset} subset is not one of the following official subsets:"
-                    f" {SUBSETS}"
-                )
-
+    ht_name = (
+        f"gnomad.exomes.v{version}.{'' + chrom if chrom else ''}.frequencies{'.pre_ab_adjustment' if not hom_alt_adjustment else ''}.ht"
+    )
     return VersionedTableResource(
         version,
         {
-            version: TableResource(
-                f"{_annotations_root(version)}/gnomad.exomes.v{version}.frequencies{'.' + subset if subset else ''}.ht"
-            )
+            version: TableResource(f"{_annotations_root(version, test)}/{ht_name}")
             for version in VERSIONS
         },
     )

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -178,7 +178,9 @@ def get_freq(
     return VersionedTableResource(
         version,
         {
-            version: TableResource(f"{_annotations_root(version, test)}/{ht_name}")
+            version: TableResource(
+                f"gs://gnomad-mwilson/v4/frequences/{ht_name}"
+            )  # {_annotations_root(version, test)}/{ht_name}")
             for version in VERSIONS
         },
     )


### PR DESCRIPTION
Here is the full frequency script. I've run it on the test dataset using the `--use-test-dataset` arg. The script currently puts out all of the annotations from the split VDSs and any annotation used in correcting for the high AB hets. I plan on removing these once this is ready and have a note before the final write on which fields I plan on removing for now. I also realized this does not account for the downsamplings within the ukb subset which Konrad had asked for so I will work on adding that but figured this is huge so should not hold up review with it. As I mentioned in one of our chats, I copied Tim's freq updates and then updated them here to account for the upstream downsampling annotation. Post v4, I will rewrite the gnomad_methods annotate_freq method. 