### PR TITLE
update HGDP+TGP AF in v4 release HT with updated sample QC and pop names

### DIFF
--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -1101,10 +1101,14 @@ def main(args):
         res.check_resource_existence()
         logger.info("Determine variants in the release HT that need a recomputed AN...")
         ht = res.freq_join_ht.ht()
-        ht = ht.filter(hl.is_missing(ht.ann_array[0]))
+        # TODO: double check the filter at L660, maybe merge it to one filter here
+        ht = ht.filter(
+            hl.any(ht.ann_array[2].freq.map(lambda x: x.AC > 0))
+            & hl.is_missing(ht.ann_array[0])
+        )
         ht = ht.checkpoint(new_temp_file("variants_for_an", extension="ht"))
         logger.info(
-            "There are %i variants with an AC > 0 in the subset callstats HTs, but "
+            "There are %i variants with an AC > 0 in the added callstats HTs, but "
             "missing in the release HT...",
             ht.count(),
         )

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -342,7 +342,7 @@ def add_updated_sample_qc_annotations(ht: hl.Table) -> hl.Table:
         %d samples have different population labels compared to v3.1.2 subset release;
         %d samples related within the subset (%d samples different compared to v3.1.2 subset release);
         %d samples further filtered out due to their relatedness to samples outside the subset;
-        %d samples further filtered out because they are duplicated in the v4 exomes release;
+        %d samples filtered out because they are duplicated in the v4 exomes release;
         %d samples will be in the v4 release, compared to 3280 in the v3.1.2 release.""",
         updated_counts["n_hard_filtered"],
         updated_counts["n_diff"]["gnomad_sample_filters.hard_filtered"],

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1044,3 +1044,8 @@ hgdp_tgp_meta_updated = TableResource(
 hgdp_tgp_related_to_nonsubset = TableResource(
     path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_related_to_nonsubset.ht",
 )
+
+# List of HGDP+ 1KG/TGP samples that are duplicated in the v4.0 exome release.
+hgdp_tgp_duplicated_to_exomes = TableResource(
+    path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_duplicated_in_exomes.ht",
+)


### PR DESCRIPTION
This script includes the following functions:
1. add updated sample QC annotations; 
2. update the HGDP pop labels;
3. filter `samples_to_add` and `samples_to_subtract`; 
4. calculate AF with the old & new pop labels, for the whole set or subsets; 
5. concatenate subset frequencies; 
Along with the changes in some resources path. 