### PR TITLE
add function to process REVEL score

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,4 +7,4 @@ disable=
   R,
   C
 
-ignore-paths=^gnomad_qc/v2/.*$
+ignore-paths=^gnomad_qc/v2/.*$,^gnomad_qc/v4/sample_qc/cuKING/.*$

--- a/gnomad_qc/v4/annotations/Dockerfile_vrs084_v4
+++ b/gnomad_qc/v4/annotations/Dockerfile_vrs084_v4
@@ -26,6 +26,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     software-properties-common \
     unzip \
     wget \
+    apt-transport-https \
     zlib1g-dev \
     libpq-dev \
     python-dev\
@@ -34,9 +35,8 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Install Java 8 for hail
-RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
-    && add-apt-repository -y https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
-    && apt-get update && apt-get install -y adoptopenjdk-8-hotspot
+RUN mkdir -p /etc/apt/keyrings
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt install -y --no-install-recommends temurin-8-jdk
 
 RUN mkdir tools
 WORKDIR /tools
@@ -79,9 +79,10 @@ RUN python3 -m pip install --upgrade pip
 # Including packages needed for VRS annotation functionality
 # Also include version for ga4gh.vrs-python to be most recent and supporting their new variant schema
 # Please update the constant VRS_VERSION in vrs_annotation_batch.py accordingly when GA4GH_VRS_VERSION is changed
-ENV HAIL_VERSION="0.2.113"
+ENV HAIL_VERSION="0.2.121"
 ENV GA4GH_VRS_VERSION="0.8.4"
 RUN python3 --version
+RUN python3 -m pip install --ignore-installed PyYAML
 RUN python3 -m pip install \
     wheel \
     pypandoc \

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -1,0 +1,1032 @@
+"""
+Script to generate the frequency data annotations across v4 exomes.
+
+This script first splits the v4 VDS into multiples VDSs based which are then densified
+and annotated with frequency data and histograms. The VDSs are then merged back together
+in a hail Table. Next the script corrects for the high AB heterozygous GATK artifact in
+existing annotations when given the AF threshold using a high AB het array. The script
+then computes the inbreeding coefficient using the raw call stats. Finally, it computes
+the filtering allele frequency and grpmax with the AB-adjusted frequencies.
+"""
+import argparse
+import logging
+from copy import deepcopy
+from typing import Dict, List, Optional, Tuple, Union
+
+import hail as hl
+from gnomad.resources.grch38.gnomad import DOWNSAMPLINGS, POPS_TO_REMOVE_FOR_POPMAX
+from gnomad.sample_qc.sex import adjusted_sex_ploidy_expr
+from gnomad.utils.annotations import (
+    age_hists_expr,
+    annotate_downsamplings,
+    annotate_freq,
+    bi_allelic_site_inbreeding_expr,
+    build_freq_stratification_list,
+    compute_freq_by_strata,
+    faf_expr,
+    generate_freq_group_membership_array,
+    get_adj_expr,
+    merge_freq_arrays,
+    merge_histograms,
+    pop_max_expr,
+    qual_hist_expr,
+    set_female_y_metrics_to_na_expr,
+)
+from gnomad.utils.filtering import filter_arrays_by_meta, split_vds_by_strata
+from gnomad.utils.release import make_faf_index_dict, make_freq_index_dict_from_meta
+from gnomad.utils.slack import slack_notifications
+from gnomad.utils.vcf import SORT_ORDER
+from hail.utils.misc import new_temp_file
+
+from gnomad_qc.resource_utils import (
+    PipelineResourceCollection,
+    PipelineStepResourceCollection,
+)
+from gnomad_qc.slack_creds import slack_token
+from gnomad_qc.v4.resources.annotations import get_freq
+from gnomad_qc.v4.resources.basics import get_gnomad_v4_vds, get_logging_path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s: %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+logger = logging.getLogger("gnomAD_frequency")
+logger.setLevel(logging.INFO)
+
+AGE_HISTS = [
+    "age_hist_het",
+    "age_hist_hom",
+]
+"""Age histograms to compute and keep on the frequency Table."""
+QUAL_HISTS = [
+    "gq_hist_all",
+    "dp_hist_all",
+    "gq_hist_alt",
+    "dp_hist_alt",
+    "ab_hist_alt",
+]
+"""Quality histograms to compute and keep on the frequency Table."""
+FREQ_HIGH_AB_HET_ROW_FIELDS = [
+    "high_ab_hets_by_group",
+    "high_ab_het_adjusted_ab_hists",
+    "high_ab_het_adjusted_age_hists",
+]
+"""
+List of top level row and global annotations relating to the high allele balance
+heterozygote correction that we want on the frequency HT before deciding on the AF
+cutoff.
+"""
+FREQ_ROW_FIELDS = [
+    "freq",
+    "qual_hists",
+    "raw_qual_hists",
+    "age_hists",
+]
+"""
+List of top level row and global annotations with no high allele balance heterozygote
+correction that we want on the frequency HT.
+"""
+ALL_FREQ_ROW_FIELDS = FREQ_ROW_FIELDS + FREQ_HIGH_AB_HET_ROW_FIELDS
+"""
+List of final top level row and global annotations created from dense data that we
+want on the frequency HT before deciding on the AF cutoff.
+"""
+FREQ_GLOBAL_FIELDS = [
+    "downsamplings",
+    "freq_meta",
+    "age_distribution",
+    "freq_index_dict",
+    "freq_meta_sample_count",
+]
+"""
+List of final global annotations created from dense data that we want on the frequency
+HT before deciding on the AF cutoff.
+"""
+SUBSET_DICT = {"gnomad": 0, "non_ukb": 1}
+"""
+Dictionary for accessing the annotations with subset specific annotations such as
+age_hists, popmax, and faf.
+"""
+
+
+def get_freq_resources(
+    overwrite: bool = False, test: Optional[bool] = False, chrom: Optional[str] = None
+) -> PipelineResourceCollection:
+    """
+    Get frequency resources.
+
+    :param overwrite: Whether to overwrite existing files.
+    :param test: Whether to use test resources.
+    :param chrom: Chromosome used in freq calculations.
+    :return: Frequency resources.
+    """
+    freq_pipeline = PipelineResourceCollection(
+        pipeline_name="frequency",
+        overwrite=overwrite,
+    )
+    run_freq_and_dense_annotations = PipelineStepResourceCollection(
+        "--run-freq-and-dense-annotations",
+        output_resources={
+            f"{s}_freq_ht": get_freq(
+                test=test,
+                hom_alt_adjusted=False,
+                chrom=chrom,
+                intermediate_subset=s,
+                finalized=False,
+            )
+            for s in ["ukb", "non_ukb"]
+        },
+    )
+    combine_freq = PipelineStepResourceCollection(
+        "--combine-freq-hts",
+        pipeline_input_steps=[run_freq_and_dense_annotations],
+        output_resources={
+            "freq_ht": get_freq(
+                test=test,
+                hom_alt_adjusted=False,
+                chrom=chrom,
+                finalized=False,
+            )
+        },
+    )
+    correct_for_high_ab_hets = PipelineStepResourceCollection(
+        "--correct-for-high-ab-hets",
+        pipeline_input_steps=[combine_freq],
+        output_resources={
+            "corrected_freq_ht": get_freq(
+                test=test, hom_alt_adjusted=True, chrom=chrom, finalized=False
+            )
+        },
+    )
+    finalize_freq_ht = PipelineStepResourceCollection(
+        "--finalize-freq-ht",
+        pipeline_input_steps=[correct_for_high_ab_hets],
+        output_resources={"final_freq_ht": get_freq(test=test, finalized=True)},
+    )
+    freq_pipeline.add_steps(
+        {
+            "run_freq_and_dense_annotations": run_freq_and_dense_annotations,
+            "combine_freq": combine_freq,
+            "correct_for_high_ab_hets": correct_for_high_ab_hets,
+            "finalize_freq_ht": finalize_freq_ht,
+        }
+    )
+    return freq_pipeline
+
+
+def get_vds_for_freq(
+    use_test_dataset: hl.bool = False,
+    test_gene: hl.bool = False,
+    test_n_partitions: Optional[hl.int] = None,
+    chrom: Optional[hl.int] = None,
+) -> hl.vds.VariantDataset:
+    """
+    Prepare VDS for frequency calculation by filtering to release samples and only adding necessary annotations.
+
+    :param use_test_dataset: Whether to use test dataset.
+    :param test_gene: Whether to filter to DRD2 for testing purposes.
+    :param test_n_partitions: Number of partitions to use for testing.
+    :param chrom: Chromosome to filter to.
+    :return: Hail VDS with only necessary annotations.
+    """
+    logger.info(
+        "Reading the %s gnomAD v4 VDS...", "test" if use_test_dataset else "full"
+    )
+    if test_n_partitions:
+        test_partitions = range(test_n_partitions)
+    else:
+        test_partitions = None
+
+    vds = get_gnomad_v4_vds(
+        test=use_test_dataset,
+        release_only=True,
+        filter_partitions=test_partitions,
+        chrom=chrom,
+        annotate_meta=True,
+    )
+
+    if test_gene:
+        logger.info("Filtering to DRD2 in VDS for testing purposes...")
+        test_interval = [
+            hl.parse_locus_interval(
+                "chr11:113409605-113475691", reference_genome="GRCh38"
+            )
+        ]
+        vds = hl.vds.filter_intervals(vds, test_interval, split_reference_blocks=True)
+
+    logger.info("Annotating VDS with only necessary sample metadata...")
+    rmt = vds.reference_data
+    vmt = vds.variant_data
+    project_meta_expr = vmt.meta.project_meta
+    vmt = vmt.select_cols(
+        pop=vmt.meta.population_inference.pop,
+        sex_karyotype=vmt.meta.sex_imputation.sex_karyotype,
+        fixed_homalt_model=project_meta_expr.fixed_homalt_model,
+        gatk_version=project_meta_expr.gatk_version,
+        age=project_meta_expr.age,
+        ukb_sample=hl.if_else(project_meta_expr.ukb_sample, "ukb", "non_ukb"),
+    )
+
+    logger.info("Dropping excessively multi-allelic site at chr19:5787204...")
+    vmt = vmt.filter_rows(
+        vmt.locus != hl.parse_locus("chr19:5787204", reference_genome="GRCh38")
+    )
+
+    logger.info("Getting age distribution of all samples in the callset...")
+    vmt = vmt.annotate_globals(
+        age_distribution=vmt.aggregate_cols(hl.agg.hist(vmt.age, 30, 80, 10))
+    )
+
+    logger.info("Annotating non_ref hets pre-split...")
+    vmt = vmt.annotate_entries(_het_non_ref=vmt.LGT.is_het_non_ref())
+
+    logger.info("Selecting only required fields to reduce memory usage...")
+    vmt = vmt.select_entries("LA", "LAD", "DP", "GQ", "LGT", "_het_non_ref")
+
+    logger.info("Spltting mutliallelics in VDS...")
+    vds = hl.vds.VariantDataset(rmt, vmt)
+    vds = hl.vds.split_multi(vds, filter_changed_loci=True)
+
+    return vds
+
+
+def annotate_freq_index_dict(ht: hl.Table) -> hl.Table:
+    """
+    Create frequency index dictionary.
+
+    The keys are the strata over which frequency aggregations where calculated and
+    the values are the strata's index in the frequency array.
+
+    :param ht: Input Table.
+    :return: Table with 'freq_index_dict' global field.
+    """
+    logger.info("Making freq index dict...")
+    # Add additional strata to the sort order, keeping group, i.e. adj, at the end.
+    sort_order = deepcopy(SORT_ORDER)
+    sort_order[-1:-1] = ["gatk_version"]
+    ht = ht.annotate_globals(
+        freq_index_dict=make_freq_index_dict_from_meta(
+            freq_meta=ht.freq_meta,
+            label_delimiter="_",
+            sort_order=sort_order,
+        )
+    )
+    return ht
+
+
+def filter_freq_arrays_for_non_ukb_subset(
+    ht: hl.Table,
+    items_to_filter: Union[List[str], Dict[str, List[str]]],
+    keep: bool = True,
+    combine_operator: str = "and",
+    annotations: Union[List[str], Tuple[str]] = ("freq", "high_ab_hets_by_group"),
+    remove_subset_from_meta: bool = False,
+) -> hl.Table:
+    """
+    Filter frequency arrays by metadata.
+
+    Filter 'annotations' and `freq_meta` array fields to only `items_to_filter` by
+    using the 'freq_meta' array field values.
+
+    If `remove_subset_from_meta` is True, update 'freq_meta' dicts by removing items
+    with the key "subset" removed. If False, update 'freq_meta' dicts to include a
+    "subset" key with "non_ukb" value.
+
+    Also rename the 'downsamplings' global field to "non_ukb_downsamplings" so we can
+    merge them later without losing the non-UKB downsampling information.
+
+    :param ht: Input Table.
+    :param items_to_filter: Items to filter by.
+    :param keep: Whether to keep or remove items. Default is True.
+    :param combine_operator: Operator ("and" or "or") to use when combining items in
+        'items_to_filter'. Default is "and".
+    :param annotations: Annotations in 'ht' to filter by `items_to_filter`.
+    :param remove_subset_from_meta: Whether to remove the "subset" key from 'freq_meta'
+        or add "subset" key with "non_ukb" value. Default is False.
+    :return: Table with filtered 'annotations' and 'freq_meta' array fields.
+    """
+    freq_meta, array_exprs = filter_arrays_by_meta(
+        ht.freq_meta,
+        {
+            **{a: ht[a] for a in annotations},
+            "freq_meta_sample_count": ht.index_globals().freq_meta_sample_count,
+        },
+        items_to_filter=items_to_filter,
+        keep=keep,
+        combine_operator=combine_operator,
+    )
+    if remove_subset_from_meta:
+        logger.info("Dropping non_ukb subset key from freq_meta...")
+        freq_meta = freq_meta.map(
+            lambda d: hl.dict(d.items().filter(lambda x: x[0] != "subset"))
+        )
+    else:
+        logger.info("Adding non_ukb subset key from freq_meta...")
+        freq_meta = freq_meta.map(
+            lambda d: hl.dict(d.items().append(("subset", "non_ukb")))
+        )
+
+    ht = ht.annotate(**{a: array_exprs[a] for a in annotations})
+    ht = ht.annotate_globals(
+        freq_meta=freq_meta,
+        freq_meta_sample_count=array_exprs["freq_meta_sample_count"],
+        non_ukb_downsamplings=ht.downsamplings,
+    )
+
+    return ht
+
+
+def high_ab_het(
+    entry: hl.StructExpression, col: hl.StructExpression
+) -> hl.Int32Expression:
+    """
+    Determine if a call is considered a high allele balance heterozygous call.
+
+    High allele balance heterozygous calls were introduced in certain GATK versions.
+    Track how many calls appear at each site to correct them to homozygous
+    alternate calls downstream in frequency calculations and histograms.
+
+    Assumes the following annotations are present in `entry` struct:
+        - GT
+        - adj
+        - _high_ab_het_ref
+
+    Assumes the following annotations are present in `col` struct:
+        - fixed_homalt_model
+
+    :param entry: Entry struct.
+    :param col: Column struct.
+    :return: 1 if high allele balance heterozygous call, else 0.
+    """
+    return hl.int(
+        entry.GT.is_het_ref()
+        & entry.adj
+        & ~col.fixed_homalt_model
+        & entry._high_ab_het_ref
+    )
+
+
+def generate_freq_ht(
+    mt: hl.MatrixTable,
+    ds_ht: hl.Table,
+    meta_ht: hl.Table,
+) -> hl.Table:
+    """
+    Generate frequency Table.
+
+    Assumes all necessary annotations are present:
+        `mt` annotations:
+            - GT
+            - adj
+            - _high_ab_het_ref
+            - fixed_homalt_model
+            - fixed_homalt_model
+
+        `ds_ht` annotations:
+            - downsampling
+            - downsamplings
+            - ds_pop_counts
+
+        `meta_ht` annotations:
+            - pop
+            - sex_karyotype
+            - gatk_version
+            - age
+            - ukb_sample
+
+    :param mt: Input MatrixTable.
+    :param ds_ht: Table with downsampling annotations.
+    :param meta_ht: Table with sample metadata annotations.
+    :return: Hail Table with frequency annotations.
+    """
+    meta_ht = meta_ht.semi_join(mt.cols())
+    additional_strata_expr = [
+        {"gatk_version": meta_ht.gatk_version},
+        {"gatk_version": meta_ht.gatk_version, "pop": meta_ht.pop},
+    ]
+    logger.info("Building frequency stratification list...")
+    strata_expr = build_freq_stratification_list(
+        sex_expr=meta_ht.sex_karyotype,
+        pop_expr=meta_ht.pop,
+        additional_strata_expr=additional_strata_expr,
+        downsampling_expr=ds_ht[meta_ht.key].downsampling,
+    )
+    logger.info("Generating group_membership array....")
+    meta_ht = generate_freq_group_membership_array(
+        meta_ht,
+        strata_expr,
+        downsamplings=hl.eval(ds_ht.downsamplings),
+        ds_pop_counts=hl.eval(ds_ht.ds_pop_counts),
+    )
+    logger.info("Annotating frequencies and counting high AB het calls...")
+    freq_ht = compute_freq_by_strata(
+        mt.annotate_cols(group_membership=meta_ht[mt.col_key].group_membership),
+        entry_agg_funcs={"high_ab_hets_by_group": (high_ab_het, hl.agg.sum)},
+    )
+    # Note: To use "multi_way_zip_join" need globals to be the same but an if_else based
+    #  on strata doesn't work because hail looks for the annotation
+    #  "non_ukb_downsamplings" regardless of the conditional value and throws an error
+    #  if it doesn't exist.
+    freq_ht = freq_ht.annotate_globals(
+        **meta_ht.index_globals(), non_ukb_downsamplings=hl.missing(hl.tarray(hl.tint))
+    )
+
+    return freq_ht
+
+
+def densify_and_prep_vds_for_freq(
+    vds: hl.vds.VariantDataset,
+    ab_cutoff: float = 0.9,
+) -> hl.MatrixTable:
+    """
+    Densify VDS and select necessary annotations for frequency and histogram calculations.
+
+    Select entry annotations required for downstream work. 'DP', 'GQ', and '_het_ab' are
+    required for histograms. 'GT' and 'adj' are required for frequency calculations.
+    '_high_ab_het_ref' is required for high AB call corrections in frequency and
+    histogram annotations.
+
+    Assumes all necessary annotations are present:
+        - adj
+        - _het_non_ref
+        - GT
+        - GQ
+        - AD
+        - DP
+        - sex_karyotype
+
+    :param vds: Input VDS.
+    :param ab_cutoff: Allele balance cutoff to use for high AB het annotation.
+    :return: Dense MatrixTable with only necessary entry annotations.
+    """
+    logger.info("Densifying VDS...")
+    mt = hl.vds.to_dense_mt(vds)
+
+    logger.info("Computing sex adjusted genotypes...")
+    ab_expr = mt.AD[1] / mt.DP
+    gt_expr = adjusted_sex_ploidy_expr(mt.locus, mt.GT, mt.sex_karyotype)
+
+    mt = mt.select_entries(
+        "DP",
+        "GQ",
+        GT=gt_expr,
+        adj=get_adj_expr(gt_expr, mt.GQ, mt.DP, mt.AD),
+        _het_ab=ab_expr,
+        _high_ab_het_ref=(ab_expr > ab_cutoff) & ~mt._het_non_ref,
+    )
+    return mt
+
+
+def non_ukb_freq_downsampling(mt: hl.MatrixTable, freq_ht: hl.Table) -> hl.Table:
+    """
+    Add non-ukb specific downsamplings and frequency calculations to frequency Table.
+
+    :param mt: Input MatrixTable.
+    :param freq_ht: Frequency Table.
+    :return: Frequency Table with non-UKB specific downsamplings and frequency
+        calculations.
+    """
+    annotations = ["freq", "high_ab_hets_by_group"]
+    global_annotations = ["freq_meta", "freq_meta_sample_count"]
+
+    logger.info("Downsampling the non_ukb VDS for separate freq calculation...")
+    non_ukb_ds_ht = annotate_freq(
+        mt,
+        pop_expr=mt.pop,
+        downsamplings=DOWNSAMPLINGS["v4"][:-1],
+        annotate_mt=False,
+        entry_agg_funcs={"high_ab_hets_by_group": (high_ab_het, hl.agg.sum)},
+    )
+
+    # Filter 'freq' array field to only downsampling indices.
+    logger.info("Filtering the 'freq array to only downsampling indices...")
+    non_ukb_ds_ht = filter_freq_arrays_for_non_ukb_subset(
+        non_ukb_ds_ht, items_to_filter=["downsampling"]
+    )
+    # Filter to only non_ukb group, pop, and sex strata so can add subset-specific freqs to main array.
+    # This is duplicated data here but it's necessary so we can merge split vds strata properly and still
+    # retain the subset freq data.
+    logger.info("Filtering to non_ukb subset strata...")
+    non_ukb_ht = filter_freq_arrays_for_non_ukb_subset(
+        freq_ht,
+        items_to_filter=["downsampling", "gatk_version"],
+        keep=False,
+        combine_operator="or",
+    )
+
+    # There are no overlap of strata groups here so can do basic flatmap on the
+    # arrays.
+    freqs = hl.array(
+        [freq_ht.row_value, non_ukb_ht[freq_ht.key], non_ukb_ds_ht[freq_ht.key]]
+    )
+    freq_ht = freq_ht.annotate(
+        **{a: hl.flatmap(lambda x: x[a], freqs) for a in annotations}
+    )
+    freq_globals = hl.array(
+        [
+            x.select_globals(*global_annotations).index_globals()
+            for x in [freq_ht, non_ukb_ht, non_ukb_ds_ht]
+        ]
+    )
+    freq_ht = freq_ht.annotate_globals(
+        **{a: hl.flatmap(lambda x: x[a], freq_globals) for a in global_annotations},
+        non_ukb_downsamplings=non_ukb_ds_ht.index_globals().non_ukb_downsamplings,
+    )
+
+    return freq_ht
+
+
+def annotate_hists_on_freq_ht(mt: hl.MatrixTable, freq_ht: hl.Table) -> hl.Table:
+    """
+    Annotate quality metrics histograms and age histograms onto frequency Table.
+
+    :param mt: Input MatrixTable.
+    :param freq_ht: Frequency Table.
+    :return: Frequency Table with quality metrics histograms and age histograms.
+    """
+    logger.info(
+        "Computing quality metrics histograms and age histograms for each variant..."
+    )
+    high_ab_gt_expr = hl.if_else(high_ab_het(mt, mt) == 1, hl.call(1, 1), mt.GT)
+    mt = mt.select_rows(
+        **qual_hist_expr(
+            gt_expr=mt.GT,
+            gq_expr=mt.GQ,
+            dp_expr=mt.DP,
+            adj_expr=mt.adj,
+            ab_expr=mt._het_ab,
+            split_adj_and_raw=True,
+        ),
+        high_ab_het_adjusted_ab_hists=qual_hist_expr(
+            gt_expr=high_ab_gt_expr,
+            adj_expr=mt.adj,
+            ab_expr=mt._het_ab,
+        ),
+        age_hists=age_hists_expr(mt.adj, mt.GT, mt.age),
+        high_ab_het_adjusted_age_hists=age_hists_expr(mt.adj, high_ab_gt_expr, mt.age),
+    )
+
+    hists = mt.rows()[freq_ht.key]
+    freq_ht = freq_ht.annotate(**{r: hists[r] for r in mt.row_value})
+
+    return freq_ht
+
+
+def combine_freq_hts(
+    freq_hts: Dict[str, hl.Table],
+    row_annotations: List[str],
+    global_annotations: List[str],
+    age_hists: List[str] = AGE_HISTS,
+    qual_hists: List[str] = QUAL_HISTS,
+) -> hl.Table:
+    """
+    Combine frequency HTs into a single HT.
+
+    :param freq_hts: Dictionary of frequency HTs.
+    :param row_annotations: List of annotations to put onto one hail Table.
+    :param global_annotations: List of global annotations to put onto one hail Table.
+    :param age_hists: List of age histogram annotations to merge.
+    :param qual_hists: List of quality histogram annotations to merge.
+    :return: HT with all freq_hts annotations.
+    """
+    ht_i = range(len(freq_hts))
+    freq_ht = hl.Table.multi_way_zip_join(
+        list(freq_hts.values()), "ann_array", "global_array"
+    )
+
+    # Combine freq arrays and high ab het counts by group arrays into single
+    # annotations.
+    logger.info(
+        "Merging frequency arrays, metadata, and high ab het counts by group array..."
+    )
+    a_array = freq_ht.ann_array
+    g_array = freq_ht.global_array
+    comb_freq, comb_freq_meta, count_arrays_dict = merge_freq_arrays(
+        farrays=[a_array[i].freq for i in ht_i],
+        fmeta=[g_array[i].freq_meta for i in ht_i],
+        count_arrays={
+            "high_ab_hets": [a_array[i].high_ab_hets_by_group for i in ht_i],
+            "freq_meta_sample_count": [g_array[i].freq_meta_sample_count for i in ht_i],
+        },
+    )
+
+    logger.info("Annotating merged freq array and high ab hets...")
+    freq_ht = freq_ht.annotate(
+        freq=comb_freq,
+        high_ab_hets_by_group=count_arrays_dict["high_ab_hets"],
+    )
+
+    # Merge all histograms into single annotations.
+    logger.info("Merging all histograms...")
+    hist_structs = {
+        "qual_hists": qual_hists,
+        "raw_qual_hists": qual_hists,
+        "high_ab_het_adjusted_ab_hists": ["ab_hist_alt", "ab_hist_alt_adj"],
+        "age_hists": age_hists,
+        "high_ab_het_adjusted_age_hists": age_hists,
+    }
+    hists_expr = {
+        hist_struct: hl.struct(
+            **{
+                h: merge_histograms(
+                    [freq_ht.ann_array[i][hist_struct][h] for i in ht_i]
+                )
+                for h in hists
+            }
+        )
+        for hist_struct, hists in hist_structs.items()
+    }
+    freq_ht = freq_ht.annotate(**hists_expr)
+
+    freq_ht = freq_ht.annotate_globals(
+        downsamplings={
+            "gnomad": freq_ht.global_array[0].downsamplings,
+            "non_ukb": freq_hts["non_ukb"].index_globals().non_ukb_downsamplings,
+        },
+        age_distribution=freq_ht.global_array[0].age_distribution,
+        freq_meta=comb_freq_meta,
+        freq_meta_sample_count=hl.eval(count_arrays_dict["freq_meta_sample_count"]),
+    )
+    freq_ht = annotate_freq_index_dict(freq_ht)
+    logger.info("Setting Y metrics to NA for XX groups...")
+    freq_ht = freq_ht.annotate(freq=set_female_y_metrics_to_na_expr(freq_ht))
+    freq_ht = freq_ht.select(*row_annotations)
+    freq_ht = freq_ht.select_globals(*global_annotations)
+
+    logger.info("Final frequency HT schema...")
+    freq_ht.describe()
+
+    return freq_ht
+
+
+def correct_for_high_ab_hets(ht: hl.Table, af_threshold: float = 0.01) -> hl.Table:
+    """
+    Correct for high allele balance heterozygous calls in call statistics and histograms.
+
+    High allele balance GTs were being called heterozygous instead of homozygous
+    alternate in GATK until version 4.1.4.1. This corrects for those calls by adjusting
+    them to homozygote alternate within our call statistics and histograms when a
+    site's allele frequency is greater than the passed `af_threshold`. Raw data is not
+    adjusted.
+
+    :param ht: Table with frequency and histogram annotations for correction as well as
+        high AB het annotations.
+    :param af_threshold: Allele frequency threshold for high AB adjustment. Default is
+        0.01.
+    :return: Table with corrected call statistics and histograms.
+    """
+    # Correct call statistics by passing through 'freq' and 'high_ab_hets_by_group'
+    # arrays to adjust each annotation accordingly.
+    call_stats_expr = hl.map(
+        lambda f, g: hl.struct(
+            AC=hl.int32(f.AC + g),
+            AF=hl.if_else(f.AN > 0, (f.AC + g) / f.AN, hl.missing(hl.tfloat64)),
+            AN=f.AN,
+            homozygote_count=f.homozygote_count + g,
+        ),
+        ht.freq,
+        ht.high_ab_hets_by_group,
+    )
+
+    # Add already computed 'ab_adjusted' histograms to the 'qual_hist_expr'.
+    qual_hist_expr = {
+        f"ab_adjusted_{x}": ht[x].annotate(
+            ab_hist_alt=ht.high_ab_het_adjusted_ab_hists[
+                f"ab_hist_alt{'' if x.startswith('raw') else '_adj'}"
+            ]
+        )
+        for x in FREQ_ROW_FIELDS
+        if "qual_hist" in x
+    }
+
+    # If a sites AF is greater than the 'af_threshold', add high AB het adjusted
+    # annotations, otherwise use original annotations.
+    no_ab_adjusted_expr = {f"ab_adjusted_{x}": ht[x] for x in FREQ_ROW_FIELDS}
+    ht = ht.select(
+        "high_ab_hets_by_group",
+        *FREQ_ROW_FIELDS,
+        **hl.if_else(
+            ht.freq[0].AF > af_threshold,
+            hl.struct(
+                ab_adjusted_freq=call_stats_expr,
+                **qual_hist_expr,
+                ab_adjusted_age_hists=ht.high_ab_het_adjusted_age_hists,
+            ),
+            hl.struct(**no_ab_adjusted_expr),
+        ),
+    )
+
+    return ht
+
+
+def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
+    """
+    Compute filtering allele frequencies ('faf') and 'grpmax' with the AB-adjusted frequencies.
+
+    :param ht: Hail Table containing 'freq', 'ab_adjusted_freq', 'high_ab_het'
+        annotations.
+    :return: Hail Table with 'faf' and 'grpmax' annotations.
+    """
+    logger.info(
+        "Filtering frequencies to just 'non_ukb' subset entries for 'faf' "
+        "calculations..."
+    )
+    # Remove the key "subset" from each dict in 'non_ukb_freq_meta' list so 'faf' will
+    # pull the correct indices, i.e. `faf_expr` requires specific lengths to consider
+    # each element in the freq list.
+    non_ukb_ht = filter_freq_arrays_for_non_ukb_subset(
+        ht,
+        items_to_filter={"subset": ["non_ukb"]},
+        combine_operator="or",
+        annotations=("ab_adjusted_freq",),
+        remove_subset_from_meta=True,
+    )
+    freq_metas = [
+        (ht.ab_adjusted_freq, ht.index_globals().freq_meta),
+        (non_ukb_ht[ht.key].ab_adjusted_freq, non_ukb_ht.index_globals().freq_meta),
+    ]
+    faf_grpmax_expr = [
+        hl.struct(
+            **hl.bind(
+                lambda f, g: hl.struct(
+                    faf=f[0],
+                    faf_meta=f[1],
+                    grpmax=g.annotate(
+                        faf95=f[0][
+                            f[1].index(lambda y: y.values() == ["adj", g.pop])
+                        ].faf95
+                    ),
+                ),
+                faf_expr(freq, meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX),
+                pop_max_expr(freq, meta, POPS_TO_REMOVE_FOR_POPMAX),
+            )
+        )
+        for freq, meta in freq_metas
+    ]
+
+    logger.info("Annotating 'faf' and 'grpmax'...")
+    ht = ht.annotate(
+        faf=[group for dataset in faf_grpmax_expr for group in dataset],
+        grpmax=hl.struct(
+            **{
+                "gnomad": faf_grpmax_expr[0].grpmax,
+                "non_ukb": faf_grpmax_expr[1].grpmax,
+            }
+        ),
+    )
+    faf_meta_expr = [x.faf_meta.collect(_localize=False)[0] for x in faf_grpmax_expr]
+    # Add subset back to non_ukb faf meta and flatten it
+    faf_meta_expr[1] = faf_meta_expr[1].map(
+        lambda d: hl.dict(d.items().append(("subset", "non_ukb")))
+    )
+    ht = ht.annotate_globals(
+        faf_meta=hl.flatten(faf_meta_expr),
+        faf_index_dict=[
+            make_faf_index_dict(hl.eval(x), label_delimiter="-") for x in faf_meta_expr
+        ],
+    )
+
+    return ht
+
+
+def compute_inbreeding_coeff(ht: hl.Table) -> hl.Table:
+    """
+    Compute inbreeding coefficient using raw call stats.
+
+    :param ht: Hail Table containing 'freq' array with struct entries of 'AC', 'AN', and
+        'homozygote_count'.
+    :return: Hail Table with inbreeding coefficient annotation.
+    """
+    ht = ht.annotate(
+        InbreedingCoeff=bi_allelic_site_inbreeding_expr(callstats_expr=ht.freq[1])
+    )
+    return ht
+
+
+def create_final_freq_ht(ht: hl.Table) -> hl.Table:
+    """
+    Create final freq Table with only desired annotations.
+
+    Drop the following annotations:
+        - 'age_high_ab_hist', all annotations from the split VDSs....
+
+    Rename the following annotations:
+        - 'ab_adjusted_freq' -> 'freq'
+        - decide if we want to store uncorrected? Probably,just rename it.
+
+    Filter the following from the 'freq' field:
+        - gatk versions
+
+    :param ht: Hail Table containing all annotations.
+    :return: Hail Table with only desired annotations.
+    """
+    raise NotImplementedError("Creation of final freq Table is not implemented yet.")
+
+
+def main(args):
+    """Script to generate frequency and dense dependent annotations on v4 exomes."""
+    overwrite = args.overwrite
+    use_test_dataset = args.use_test_dataset
+    test_n_partitions = args.test_n_partitions
+    test_gene = args.test_gene
+    test = use_test_dataset or test_n_partitions or test_gene
+    chrom = args.chrom
+    ab_cutoff = args.ab_cutoff
+    af_threshold = args.af_threshold
+
+    hl.init(
+        log="/generate_frequency_data.log",
+        default_reference="GRCh38",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
+    resources = get_freq_resources(overwrite, test, chrom)
+
+    try:
+        if args.run_freq_and_dense_annotations:
+            logger.info("Running dense dependent steps...")
+            res = resources.run_freq_and_dense_annotations
+            res.check_resource_existence()
+
+            logger.info(
+                "Getting multi-allelic split VDS with adj and _het_AD entry"
+                " annotations..."
+            )
+            vds = get_vds_for_freq(
+                use_test_dataset, test_gene, test_n_partitions, chrom
+            )
+            meta_ht = vds.variant_data.cols()
+
+            logger.info("Determining downsampling groups...")
+            ds_ht = annotate_downsamplings(
+                meta_ht, DOWNSAMPLINGS["v4"], pop_expr=meta_ht.pop
+            )
+            ds_ht = ds_ht.checkpoint(new_temp_file("downsamplings", extension="ht"))
+
+            logger.info(
+                "Splitting VDS by ukb_sample annotation to reduce data size for"
+                " densification..."
+            )
+            vds_dict = split_vds_by_strata(vds, strata_expr=vds.variant_data.ukb_sample)
+            for strata, vds in vds_dict.items():
+                if (
+                    args.ukb_only
+                    and strata == "non_ukb"
+                    or args.non_ukb_only
+                    and strata == "ukb"
+                ):
+                    continue
+
+                logger.info("Generating frequency and histograms for %s VDS...", strata)
+                mt = densify_and_prep_vds_for_freq(vds, ab_cutoff=ab_cutoff)
+                freq_ht = generate_freq_ht(mt, ds_ht, meta_ht)
+                if strata == "non_ukb":
+                    freq_ht = non_ukb_freq_downsampling(mt, freq_ht)
+                freq_ht = annotate_hists_on_freq_ht(mt, freq_ht)
+                freq_ht.write(
+                    getattr(res, f"{strata}_freq_ht").path, overwrite=overwrite
+                )
+
+        if args.combine_freq_hts:
+            logger.info("Combining frequency HTs...")
+            res = resources.combine_freq
+            res.check_resource_existence()
+            freq_ht = combine_freq_hts(
+                {"ukb": res.ukb_freq_ht.ht(), "non_ukb": res.non_ukb_freq_ht.ht()},
+                ALL_FREQ_ROW_FIELDS,
+                FREQ_GLOBAL_FIELDS,
+            )
+            freq_ht.write(res.freq_ht.path, overwrite=args.overwrite)
+
+        if args.correct_for_high_ab_hets:
+            logger.info(
+                "Adjusting annotations impacted by high AB het -> hom alt adjustment..."
+            )
+            res = resources.correct_for_high_ab_hets
+            res.check_resource_existence()
+            ht = res.freq_ht.ht()
+
+            logger.info("Correcting call stats, qual AB hists, and age hists...")
+            ht = correct_for_high_ab_hets(ht, af_threshold=af_threshold)
+
+            ht.describe()
+            logger.info("Computing FAF & grpmax...")
+            ht = generate_faf_grpmax(ht)
+
+            logger.info("Calculating InbreedingCoeff...")
+            ht = compute_inbreeding_coeff(ht)
+
+            logger.info("Writing corrected frequency Table...")
+            ht.write(res.corrected_freq_ht.path, overwrite=args.overwrite)
+
+        if args.finalize_freq_ht:
+            logger.info("Writing final frequency Table...")
+            ht = create_final_freq_ht(ht)
+            ht.write(res.final_freq_ht.path, overwrite=args.overwrite)
+    finally:
+        logger.info("Copying log to logging bucket...")
+        hl.copy_log(get_logging_path("frequency_data"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--use-test-dataset",
+        help="Runs a test on the gnomad test dataset.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test-gene",
+        help="Runs a test on the DRD2 gene in the gnomad test dataset.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test-n-partitions",
+        help=(
+            "Use only N partitions of the VDS as input for testing purposes. Defaults"
+            "to 2 if passed without a value."
+        ),
+        nargs="?",
+        const=2,
+        type=int,
+    )
+    parser.add_argument(
+        "--chrom",
+        help="If passed, script will only run on passed chromosome.",
+        type=str,
+    )
+    parser.add_argument(
+        "--overwrite", help="Overwrites existing files.", action="store_true"
+    )
+    parser.add_argument(
+        "--slack-channel", help="Slack channel to post results and notifications to."
+    )
+    parser.add_argument(
+        "--run-freq-and-dense-annotations",
+        help=(
+            "Calculate frequencies, histograms, and high AB sites per sample grouping."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--ukb-only",
+        help="Only run frequency and histogram calculations for UKB samples.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--non-ukb-only",
+        help="Only run frequency and histogram calculations for non-UKB samples.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--combine-freq-hts",
+        help=(
+            "Combine frequency and histogram Tables for UKB and non-UKB samples into a"
+            " single Table."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--correct-for-high-ab-hets",
+        help=(
+            "Correct each frequency entry to account for homozygous alternate depletion"
+            " present in GATK versions released prior to 4.1.4.1 and run chosen"
+            " downstream annotations."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--ab-cutoff",
+        help=(
+            "Allele balance threshold to use when adjusting heterozygous calls to "
+            "homozygous alternate calls at sites for samples that used GATK versions"
+            " released prior to 4.1.4.1."
+        ),
+        type=float,
+        default=0.9,
+    )
+    parser.add_argument(
+        "--af-threshold",
+        help=(
+            "Threshold at which to adjust site group frequencies at sites for"
+            " homozygous alternate depletion present in GATK versions released prior to"
+            " 4.1.4.1."
+        ),
+        type=float,
+        default=0.01,
+    )
+    parser.add_argument(
+        "--finalize-freq-ht",
+        help=(
+            "Finalize frequency Table by dropping unnecessary fields and renaming"
+            " remaining fields."
+        ),
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    if args.slack_channel:
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
+    else:
+        main(args)

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -1,16 +1,16 @@
 """Script to generate annotations for variant QC on gnomAD v4."""
-
 import argparse
 import logging
+from typing import Optional
 
 import hail as hl
 from gnomad.assessment.validity_checks import count_vep_annotated_variants_per_interval
 from gnomad.resources.grch38.reference_data import ensembl_interval
+from gnomad.resources.resource_utils import TableResource
 from gnomad.sample_qc.relatedness import filter_mt_to_trios
 from gnomad.utils.annotations import annotate_allele_info
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.sparse_mt import (
-    AS_INFO_AGG_FIELDS,
     default_compute_info,
     get_as_info_expr,
     split_info_annotation,
@@ -33,7 +33,11 @@ from gnomad_qc.v4.resources.annotations import (
     info_vcf_path,
     validate_vep_path,
 )
-from gnomad_qc.v4.resources.basics import get_gnomad_v4_vds, get_logging_path
+from gnomad_qc.v4.resources.basics import (
+    get_checkpoint_path,
+    get_gnomad_v4_vds,
+    get_logging_path,
+)
 from gnomad_qc.v4.resources.sample_qc import pedigree, relatedness
 
 logging.basicConfig(
@@ -182,7 +186,11 @@ def correct_as_annotations(
     return hl.struct(**corrected_annotations)
 
 
-def run_compute_info(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
+def run_compute_info(
+    mt: hl.MatrixTable,
+    max_n_alleles: Optional[int] = None,
+    min_n_alleles: Optional[int] = None,
+) -> hl.Table:
     """
     Run compute info on a MatrixTable.
 
@@ -192,9 +200,17 @@ def run_compute_info(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
         have different lengths than LA.
 
     :param mt: Input MatrixTable.
-    :param n_partitions: Number of partitions to use for the output Table.
+    :param max_n_alleles: Maximum number of alleles for the site to be included in
+        computations.
+    :param min_n_alleles: Minimum number of alleles for the site to be included in
+        computations.
     :return: Table with info annotations.
     """
+    if max_n_alleles:
+        mt = mt.filter_rows(hl.len(mt.alleles) <= max_n_alleles)
+    if min_n_alleles:
+        mt = mt.filter_rows(hl.len(mt.alleles) >= min_n_alleles)
+
     mt = mt.annotate_entries(
         gvcf_info=mt.gvcf_info.annotate(
             AS_QUALapprox=recompute_as_qualapprox_from_lpl(mt),
@@ -212,9 +228,6 @@ def run_compute_info(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
         },
         n_partitions=None,
     )
-    info_ht = info_ht.checkpoint(
-        hl.utils.new_temp_file("compute_info", extension="ht"), overwrite=True
-    )
 
     mt = mt.annotate_entries(gvcf_info=correct_as_annotations(mt, set_to_missing=True))
     mt = mt.annotate_rows(alt_alleles_range_array=hl.range(1, hl.len(mt.alleles)))
@@ -230,12 +243,8 @@ def run_compute_info(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
     ).rows()
 
     info_ht = info_ht.annotate(set_long_AS_missing_info=ht[info_ht.key])
-    info_ht = info_ht.checkpoint(
-        hl.utils.new_temp_file("compute_info_AS_missing", extension="ht"),
-        overwrite=True,
-    )
 
-    return info_ht.naive_coalesce(n_partitions)
+    return info_ht
 
 
 def split_info(info_ht: hl.Table) -> hl.Table:
@@ -317,16 +326,49 @@ def run_generate_sib_stats(
 
 
 def get_variant_qc_annotation_resources(
-    test: bool, overwrite: bool
+    test: bool,
+    overwrite: bool,
+    over_n_alleles: Optional[bool] = None,
+    combine_compute_info: bool = False,
 ) -> PipelineResourceCollection:
     """
     Get PipelineResourceCollection for all resources needed in the variant QC annotation pipeline.
 
     :param test: Whether to gather all resources for testing.
     :param overwrite: Whether to overwrite resources if they exist.
+    :param over_n_alleles: Whether to use a temporary info TableResource for results.
+        When True, use temporary info TableResource for only sites that have more
+        than the passed arg --compute-info-split-n-alleles alleles. When False, use
+        temporary info TableResource for only sites with fewer alleles. When None,
+        the finalize info ht is used instead of a temporary location. Default is None.
+    :param combine_compute_info: Whether the input for --compute-info should be the two
+        temporary files (with and without the --compute-info-over-split-n-alleles flag)
+        produced by running --compute-info with --compute-info-split-n-alleles.
     :return: PipelineResourceCollection containing resources for all steps of the
         variant QC annotation pipeline.
     """
+    if over_n_alleles is None or combine_compute_info:
+        info_ht = get_info(split=False, test=test)
+    else:
+        info_ht = TableResource(
+            get_checkpoint_path(
+                f"compute_info{'.test' if test else ''}.{'over_n_alleles' if over_n_alleles else 'under_n_alleles'}"
+            )
+        )
+    compute_info_input_resources = {}
+    if combine_compute_info:
+        res_key = "--compute-info --compute-info-split-n-alleles"
+        for n_alleles in ["under", "over"]:
+            if n_alleles == "over":
+                res_key += " --compute-info-over-split-n-alleles"
+            compute_info_input_resources[res_key] = {
+                f"{n_alleles}_info_ht": TableResource(
+                    get_checkpoint_path(
+                        f"compute_info{'.test' if test else ''}.{n_alleles}_n_alleles"
+                    )
+                )
+            }
+
     # Initialize variant QC annotation pipeline resource collection.
     ann_pipeline = PipelineResourceCollection(
         pipeline_name="variant_qc_annotation",
@@ -336,7 +378,8 @@ def get_variant_qc_annotation_resources(
     # Create resource collection for each step of the variant QC annotation pipeline.
     compute_info = PipelineStepResourceCollection(
         "--compute-info",
-        output_resources={"info_ht": get_info(split=False, test=test)},
+        input_resources=compute_info_input_resources,
+        output_resources={"info_ht": info_ht},
     )
     split_info_ann = PipelineStepResourceCollection(
         "--split-info",
@@ -396,9 +439,27 @@ def main(args):
     test_dataset = args.test_dataset
     test_n_partitions = args.test_n_partitions
     test = test_dataset or test_n_partitions
+    over_split_n_alleles = args.compute_info_over_split_n_alleles
+    split_n_alleles = args.compute_info_split_n_alleles
+    combine_compute_info = args.combine_compute_info
     run_vep = args.run_vep
     overwrite = args.overwrite
-    vqc_resources = get_variant_qc_annotation_resources(test=test, overwrite=overwrite)
+
+    max_n_alleles = min_n_alleles = over_n_alleles = None
+    if split_n_alleles is not None:
+        if over_split_n_alleles:
+            min_n_alleles = split_n_alleles
+            over_n_alleles = True
+        else:
+            max_n_alleles = split_n_alleles - 1
+            over_n_alleles = False
+
+    vqc_resources = get_variant_qc_annotation_resources(
+        test=test,
+        overwrite=overwrite,
+        over_n_alleles=over_n_alleles,
+        combine_compute_info=combine_compute_info,
+    )
     vds = get_gnomad_v4_vds(
         test=test_dataset,
         high_quality_only=True,
@@ -416,7 +477,17 @@ def main(args):
             # TODO: is there any reason to also compute info per platform?
             res = vqc_resources.compute_info
             res.check_resource_existence()
-            ht = run_compute_info(mt, args.compute_info_n_partitions)
+            if combine_compute_info:
+                ht = mt.select_rows().rows()
+                lt_ht = res.under_info_ht.ht()
+                gt_eq_ht = res.over_info_ht.ht()
+                ht = ht.annotate(**hl.coalesce(lt_ht[ht.key], gt_eq_ht[ht.key]))
+            else:
+                ht = run_compute_info(mt, max_n_alleles, min_n_alleles)
+
+            if split_n_alleles is None or combine_compute_info:
+                ht = ht.naive_coalesce(args.compute_info_n_partitions)
+
             ht.write(res.info_ht.path, overwrite=overwrite)
 
         if args.split_info:
@@ -483,13 +554,51 @@ if __name__ == "__main__":
         const=2,
         type=int,
     )
-    parser.add_argument("--compute-info", help="Compute info HT.", action="store_true")
-    parser.add_argument(
+    compute_info_args = parser.add_argument_group(
+        "Compute info HT.",
+        "Arguments relevant to computing the info HT..",
+    )
+    compute_info_args.add_argument(
+        "--compute-info", help="Compute info HT.", action="store_true"
+    )
+    compute_info_args.add_argument(
+        "--compute-info-split-n-alleles",
+        help=(
+            "Number of alleles at a site to filter results on. If "
+            "--compute-info-over-split-n-alleles is used, the results are filtered to "
+            "sites with greater than or equal to the value supplied, otherwise the "
+            "results are filtered to sites with less than the value supplied. By "
+            "default no sites are filtered."
+        ),
+        default=None,
+        type=int,
+    )
+    compute_info_args.add_argument(
+        "--compute-info-over-split-n-alleles",
+        help=(
+            "Whether to filter to sites greater than or equal to the value supplied to"
+            "--compute-info-split-n-alleles. By default, sites are filtered to sites "
+            "less than that value, or None if --compute-info-split-n-alleles is not "
+            "supplied."
+        ),
+        action="store_true",
+    )
+    compute_info_args.add_argument(
+        "--combine-compute-info",
+        help=(
+            "Whether to combine the output from running --compute-info "
+            "--compute-info-split-n-alleles with and without the "
+            "--compute-info-over-split-n-alleles flag."
+        ),
+        action="store_true",
+    )
+    compute_info_args.add_argument(
         "--compute-info-n-partitions",
         help="Number of desired partitions for the info HT.",
         default=5000,
         type=int,
     )
+
     parser.add_argument("--split-info", help="Split info HT.", action="store_true")
     parser.add_argument(
         "--export-info-vcf", help="Export info as VCF.", action="store_true"

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -33,7 +33,7 @@ from gnomad_qc.v4.resources.annotations import (
     info_vcf_path,
     validate_vep_path,
 )
-from gnomad_qc.v4.resources.basics import get_gnomad_v4_vds
+from gnomad_qc.v4.resources.basics import get_gnomad_v4_vds, get_logging_path
 from gnomad_qc.v4.resources.sample_qc import pedigree, relatedness
 
 logging.basicConfig(
@@ -182,7 +182,7 @@ def correct_as_annotations(
     return hl.struct(**corrected_annotations)
 
 
-def run_compute_info(mt: hl.MatrixTable) -> hl.Table:
+def run_compute_info(mt: hl.MatrixTable, n_partitions: int) -> hl.Table:
     """
     Run compute info on a MatrixTable.
 
@@ -192,16 +192,15 @@ def run_compute_info(mt: hl.MatrixTable) -> hl.Table:
         have different lengths than LA.
 
     :param mt: Input MatrixTable.
+    :param n_partitions: Number of partitions to use for the output Table.
     :return: Table with info annotations.
     """
     mt = mt.annotate_entries(
         gvcf_info=mt.gvcf_info.annotate(
             AS_QUALapprox=recompute_as_qualapprox_from_lpl(mt),
             **correct_as_annotations(mt),
-        ),
-        set_long_AS_missing=correct_as_annotations(mt, set_to_missing=True),
+        )
     )
-
     info_ht = default_compute_info(
         mt,
         site_annotations=True,
@@ -211,9 +210,13 @@ def run_compute_info(mt: hl.MatrixTable) -> hl.Table:
             "release": mt.meta.release,
             "unrelated": ~mt.meta.sample_filters.relatedness_filters.related,
         },
+        n_partitions=None,
+    )
+    info_ht = info_ht.checkpoint(
+        hl.utils.new_temp_file("compute_info", extension="ht"), overwrite=True
     )
 
-    mt = mt.annotate_entries(gvcf_info=mt.set_long_AS_missing)
+    mt = mt.annotate_entries(gvcf_info=correct_as_annotations(mt, set_to_missing=True))
     mt = mt.annotate_rows(alt_alleles_range_array=hl.range(1, hl.len(mt.alleles)))
     ht = mt.select_rows(
         **get_as_info_expr(
@@ -227,8 +230,12 @@ def run_compute_info(mt: hl.MatrixTable) -> hl.Table:
     ).rows()
 
     info_ht = info_ht.annotate(set_long_AS_missing_info=ht[info_ht.key])
+    info_ht = info_ht.checkpoint(
+        hl.utils.new_temp_file("compute_info_AS_missing", extension="ht"),
+        overwrite=True,
+    )
 
-    return info_ht
+    return info_ht.naive_coalesce(n_partitions)
 
 
 def split_info(info_ht: hl.Table) -> hl.Table:
@@ -404,49 +411,60 @@ def main(args):
     if test_n_partitions:
         mt = mt._filter_partitions(range(test_n_partitions))
 
-    if args.compute_info:
-        # TODO: is there any reason to also compute info per platform?
-        res = vqc_resources.compute_info
-        res.check_resource_existence()
-        ht = run_compute_info(mt)
-        ht.write(res.info_ht.path, overwrite=overwrite)
+    try:
+        if args.compute_info:
+            # TODO: is there any reason to also compute info per platform?
+            res = vqc_resources.compute_info
+            res.check_resource_existence()
+            ht = run_compute_info(mt, args.compute_info_n_partitions)
+            ht.write(res.info_ht.path, overwrite=overwrite)
 
-    if args.split_info:
-        res = vqc_resources.split_info
-        res.check_resource_existence()
-        split_info(res.info_ht.ht()).write(res.split_info_ht.path, overwrite=overwrite)
+        if args.split_info:
+            res = vqc_resources.split_info
+            res.check_resource_existence()
+            split_info(res.info_ht.ht()).write(
+                res.split_info_ht.path, overwrite=overwrite
+            )
 
-    if args.export_info_vcf:
-        res = vqc_resources.export_info_vcf
-        res.check_resource_existence()
-        hl.export_vcf(adjust_vcf_incompatible_types(res.info_ht.ht()), res.info_vcf)
+        if args.export_info_vcf:
+            res = vqc_resources.export_info_vcf
+            res.check_resource_existence()
+            hl.export_vcf(adjust_vcf_incompatible_types(res.info_ht.ht()), res.info_vcf)
 
-    if run_vep:
-        res = vqc_resources.run_vep
-        res.check_resource_existence()
-        ht = hl.split_multi(get_gnomad_v4_vds(test=test_dataset).variant_dataset.rows())
-        ht = vep_or_lookup_vep(ht, vep_version=args.vep_version)
-        ht.write(res.vep_ht.path, overwrite=overwrite)
+        if run_vep:
+            res = vqc_resources.run_vep
+            res.check_resource_existence()
+            ht = hl.split_multi(
+                get_gnomad_v4_vds(test=test_dataset).variant_dataset.rows()
+            )
+            ht = vep_or_lookup_vep(ht, vep_version=args.vep_version)
+            ht.write(res.vep_ht.path, overwrite=overwrite)
 
-    if args.validate_vep:
-        res = vqc_resources.validate_vep
-        res.check_resource_existence()
-        count_ht = count_vep_annotated_variants_per_interval(
-            res.vep_ht.ht(), ensembl_interval.ht()
-        )
-        count_ht.write(res.vep_count_ht.path, overwrite=args.overwrite)
+        if args.validate_vep:
+            res = vqc_resources.validate_vep
+            res.check_resource_existence()
+            count_ht = count_vep_annotated_variants_per_interval(
+                res.vep_ht.ht(), ensembl_interval.ht()
+            )
+            count_ht.write(res.vep_count_ht.path, overwrite=args.overwrite)
 
-    if args.generate_trio_stats:
-        res = vqc_resources.generate_trio_stats
-        res.check_resource_existence()
-        ht = run_generate_trio_stats(vds, res.final_ped.pedigree(), res.final_ped.ht())
-        ht.write(res.trio_stats_ht.path, overwrite=overwrite)
+        if args.generate_trio_stats:
+            res = vqc_resources.generate_trio_stats
+            res.check_resource_existence()
+            ht = run_generate_trio_stats(
+                vds, res.final_ped.pedigree(), res.final_ped.ht()
+            )
+            ht.write(res.trio_stats_ht.path, overwrite=overwrite)
 
-    if args.generate_sibling_stats:
-        res = vqc_resources.generate_sib_stats
-        res.check_resource_existence()
-        ht = run_generate_sib_stats(mt, res.rel_ht.ht())
-        ht.write(res.sib_stats_ht.path, overwrite=overwrite)
+        if args.generate_sibling_stats:
+            res = vqc_resources.generate_sib_stats
+            res.check_resource_existence()
+            ht = run_generate_sib_stats(mt, res.rel_ht.ht())
+            ht.write(res.sib_stats_ht.path, overwrite=overwrite)
+
+    finally:
+        logger.info("Copying log to logging bucket...")
+        hl.copy_log(get_logging_path("variant_qc_annotations.log"))
 
 
 if __name__ == "__main__":
@@ -466,6 +484,12 @@ if __name__ == "__main__":
         type=int,
     )
     parser.add_argument("--compute-info", help="Compute info HT.", action="store_true")
+    parser.add_argument(
+        "--compute-info-n-partitions",
+        help="Number of desired partitions for the info HT.",
+        default=5000,
+        type=int,
+    )
     parser.add_argument("--split-info", help="Split info HT.", action="store_true")
     parser.add_argument(
         "--export-info-vcf", help="Export info as VCF.", action="store_true"

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -7,7 +7,7 @@ import hail as hl
 from gnomad.utils.slack import slack_notifications
 
 from gnomad_qc.slack_creds import slack_token
-from gnomad_qc.v4.resources.annotations import get_insilico_predictors
+from gnomad_qc.v4.resources.annotations import get_insilico_predictors, get_insilico_raw
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -112,12 +112,12 @@ def create_revel_grch38_ht(revel_csv: str, ensembl_ids: str) -> hl.Table:
     that are in Ensembl 105.
     This deprecates the `has_duplicate` field present in gnomAD v3.
 
-    :param revel_csv: Temporary path to REVEL CSV file, downloaded from
-    https://www.google.com/url?q=https%3A%2F%2Frothsj06.dmz.hpc.mssm.edu%2Frevel-v1.3_all_chromosomes.zip&sa=D&sntz=1&usg=AOvVaw2DS2TWUYl__0vqijzzxp5M
-    size ~526M, ~82,100,677 variants
-    :param ensembl_ids: temporary path to Ensembl 105 ID file,
-    downloaded from Ensembl 105 archive. It must contain the following columns:
-    Transcript stable ID, Ensembl Canonical, MANE Select
+    :param revel_csv: Path to REVEL CSV file, downloaded from
+       https://www.google.com/url?q=https%3A%2F%2Frothsj06.dmz.hpc.mssm.edu%2Frevel-v1.3_all_chromosomes.zip&sa=D&sntz=1&usg=AOvVaw2DS2TWUYl__0vqijzzxp5M
+       size ~648M, ~82,100,677 variants
+    :param ensembl_ids: Path to Ensembl 105 ID file,
+       downloaded from Ensembl 105 archive. It contains the following columns:
+       Transcript stable ID, Ensembl Canonical, MANE Select
     :return: Hail Table with REVEL scores for GRCh38.
     """
     ht = hl.import_table(
@@ -206,11 +206,8 @@ def main(args):
 
     if args.revel:
         logger.info("Creating REVEL Hail Table for GRCh38...")
-        # TODO: update path, do we keep both the raw and processed files?
-        revel_csv = "gs://gnomad-qin/v4_annotations/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz"
-        ensembl_ids = (
-            "gs://gnomad-qin/ensembl/ensembl105_chr1-22XY_MANE_canonical_ucscid.tsv.bgz"
-        )
+        revel_csv = get_insilico_raw(predictor="revel-v1.3", postfix="csv.bgz")
+        ensembl_ids = get_insilico_raw(predictor="ensembl105id", postfix="tsv.bgz")
 
         ht = create_revel_grch38_ht(revel_csv, ensembl_ids)
         ht.write(

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -22,14 +22,26 @@ def create_cadd_grch38_ht() -> hl.Table:
     Create a Hail Table with CADD scores for GRCh38.
 
     The combined CADD scores in the returned table are from the following sources:
-        - all SNVs: `cadd.v1.6.whole_genome_SNVs.tsv.bgz` (81G) downloaded from `https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh38/whole_genome_SNVs.tsv.gz`. It contains 8,812,917,339 SNVs.
-        - gnomad 3.0 indels: `cadd.v1.6.indels.tsv.bgz` (1.1G) downloaded from `https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh38/gnomad.genomes.r3.0.indel.tsv.gz`. It contains 100,546,109 indels from gnomaD v3.0.
-        - gnomad 3.1 indels: `CADD-indels-gnomad.3.1.ht` was run on gnomAD v3.1 with CADD v1.6 in 2020. It contains 166,122,720 indels from gnomAD v3.1.
-        - gnomad 3.1 complex indels: `CADD-1.6-gnomad-complex-variants.ht` was run on gnomAD v3.1 with CADD v1.6 in 2020. It contains 2,307 complex variants that do not fit Hail's criteria for an indel and thus exist in a separate table than the gnomad 3.1 indels.
-        - gnomAD v4 indels: `cadd.v1.6.gnomAD_v4_new_indels.tsv.bgz` (368M) was run on gnomAD v4 with CADD v1.6 in 2023. It contains 32,561,253 indels that are new in gnomAD v4.
+        - all SNVs: `cadd.v1.6.whole_genome_SNVs.tsv.bgz` (81G) downloaded from
+        `https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh38/whole_genome_SNVs.tsv.gz`.
+        It contains 8,812,917,339 SNVs.
+        - gnomad 3.0 indels: `cadd.v1.6.indels.tsv.bgz` (1.1G) downloaded from `
+        https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh38/gnomad.genomes.r3.0.indel.tsv.gz`.
+        It contains 100,546,109 indels from gnomaD v3.0.
+        - gnomad 3.1 indels: `CADD-indels-gnomad.3.1.ht` was run on gnomAD v3.1
+        with CADD v1.6 in 2020. It contains 166,122,720 indels from gnomAD v3.1.
+        - gnomad 3.1 complex indels: `CADD-1.6-gnomad-complex-variants.ht` was
+        run on gnomAD v3.1 with CADD v1.6 in 2020. It contains 2,307 complex
+        variants that do not fit Hail's criteria for an indel and thus exist in
+        a separate table than the gnomad 3.1 indels.
+        - gnomAD v4 indels: `cadd.v1.6.gnomAD_v4_new_indels.tsv.bgz` (368M) was
+        run on gnomAD v4 with CADD v1.6 in 2023. It contains 32,561,253 indels
+        that are new in gnomAD v4.
 
          .. note::
-         1,972,208 indels were duplicated in gnomAD v3.0 and v4.0 or in gnomAD v3.1 and v4.0. However, CADD only generates a score per loci. We keep only the latest prediction, v4.0, for these loci.
+         1,972,208 indels were duplicated in gnomAD v3.0 and v4.0 or in gnomAD
+         v3.1 and v4.0. However, CADD only generates a score per loci.
+         We keep only the latest prediction, v4.0, for these loci.
     :return: Hail Table with CADD scores for GRCh38.
     """
 
@@ -88,18 +100,24 @@ def create_cadd_grch38_ht() -> hl.Table:
     return ht
 
 
-def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
+def create_revel_grch38_ht(revel_csv: str, ensembl_ids: str) -> hl.Table:
     """
     Create a Hail Table with REVEL scores for GRCh38.
 
-    .. Note::
-    Starting from gnomAD v4, we will use REVEL scores for MANE Select transcripts and canonical transcripts only.
-    We take a max of the REVEL scores if a variant falls on multiple transcripts.
-    Since the Ensembl ID used by REVEL was not from Ensembl 105, we also only filtered transcripts that are in Ensembl 105.
-    This will also deprecate `has_duplicate` field as in gnomAD v3.
+    .. note::
+    Starting with gnomAD v4, we use REVEL scores for only MANE Select and
+    canonical transcripts. Even when a variant falls on multiple MANE/canonical
+    transcripts of different genes, the scores are equal.
+    REVEL's Ensembl ID is not from Ensembl 105, so we filter to transcripts
+    that are in Ensembl 105.
+    This deprecates the `has_duplicate` field present in gnomAD v3.
 
-    :param revel_csv: Path to REVEL CSV file.
-    :param ensembl_ids: Path to Ensembl 105 ID file, downloaded from Ensembl 105 archive.
+    :param revel_csv: Temporary path to REVEL CSV file, downloaded from
+    https://www.google.com/url?q=https%3A%2F%2Frothsj06.dmz.hpc.mssm.edu%2Frevel-v1.3_all_chromosomes.zip&sa=D&sntz=1&usg=AOvVaw2DS2TWUYl__0vqijzzxp5M
+    size ~526M, ~82,100,677 variants
+    :param ensembl_ids: temporary path to Ensembl 105 ID file,
+    downloaded from Ensembl 105 archive. It must contain the following columns:
+    Transcript stable ID, Ensembl Canonical, MANE Select
     :return: Hail Table with REVEL scores for GRCh38.
     """
     ht = hl.import_table(
@@ -108,13 +126,10 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
         min_partitions=1000,
         types={"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
     )
-    ht = ht.checkpoint(
-        "gs://gnomad-tmp-4day/revel-v1.3_all_chromosomes_with_transcript_ids.ht",
-        _read_if_exists=True,
-    )
 
     logger.info("Annotating REVEL table...")
     ht = ht.drop("hg19_pos", "aaref", "aaalt")
+    # drop variants that have no position in GRCh38 when lifted over from GRCh37
     ht = ht.filter(ht.grch38_pos.contains("."), keep=False)
     ht = ht.transmute(chr="chr" + ht.chr)
     ht = ht.annotate(
@@ -127,20 +142,17 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
     ht = ht.key_by("Transcript_stable_ID")
 
     logger.info("Import and process the ensembl ID file...")
-    ensembl_ids = hl.import_table(ensembl_ids, min_partitions=200, impute=True)
+    ensembl_ids = hl.import_table(
+        ensembl_ids, min_partitions=200, impute=True, key="Transcript_stable_ID"
+    )
     ensembl_ids = ensembl_ids.select(
         "Transcript_stable_ID", "Ensembl_Canonical", "MANE_Select"
     )
-    ensembl_ids = ensembl_ids.key_by("Transcript_stable_ID")
-
-    ht = ht.annotate(
-        in_Ensembl105=hl.is_defined(ensembl_ids[ht.Transcript_stable_ID]),
-        MANE_Select=ensembl_ids[ht.Transcript_stable_ID].MANE_Select,
-        Ensembl_Canonical=ensembl_ids[ht.Transcript_stable_ID].Ensembl_Canonical,
-    )
+    logger.info("Annotating revel HT with canonical and MANE Select transcripts...")
+    ht = ht.annotate(**ensembl_ids[ht.Transcript_stable_ID])
 
     logger.info("Filtering transcripts that are in Ensembl 105...")
-    ht = ht.filter(hl.is_defined(ht.in_Ensembl105), keep=True)
+    ht = ht.filter(ht.in_Ensembl105, keep=True)
 
     logger.info(
         "Annotating REVEL scores for MANE Select transcripts and canonical"
@@ -148,13 +160,9 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
     )
     ht = ht.key_by("locus", "alleles")
     ht = ht.annotate(
-        revel_mane=hl.if_else(ht.MANE_Select != "", ht.REVEL, hl.missing(hl.tfloat)),
-        revel_canonical=hl.if_else(
-            ht.Ensembl_Canonical == "1", ht.REVEL, hl.missing(hl.tfloat)
-        ),
-        revel_noncanonical=hl.if_else(
-            ht.Ensembl_Canonical != "1", ht.REVEL, hl.missing(hl.tfloat)
-        ),
+        revel_mane=hl.or_missing(ht.MANE_Select != "", ht.REVEL),
+        revel_canonical=hl.or_missing(ht.Ensembl_Canonical == "1", ht.REVEL),
+        revel_noncanonical=hl.or_missing(ht.Ensembl_Canonical != "1", ht.REVEL),
     )
 
     logger.info("Taking max REVEL scores for MANE Select transcripts...")
@@ -163,13 +171,8 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
     )
     mane_ht = ht.filter(hl.is_defined(ht.revel_mane), keep=True)
     max_revel_mane = mane_ht.group_by(*mane_ht.key).aggregate(
-        max_revel=hl.agg.max(mane_ht.revel_mane)
-    )
-    transcripts_mane = mane_ht.group_by(*mane_ht.key).aggregate(
-        transcripts=hl.agg.collect_as_set(mane_ht.Transcript_stable_ID)
-    )
-    max_revel_mane = max_revel_mane.annotate(
-        transcripts=transcripts_mane[max_revel_mane.key].transcripts
+        max_revel=hl.agg.max(mane_ht.revel_mane),
+        transcripts=hl.agg.collect_as_set(mane_ht.Transcript_stable_ID),
     )
 
     logger.info("Taking max REVEL scores for canonical transcripts...")
@@ -177,15 +180,9 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
         (~hl.is_defined(ht.revel_mane)) & (hl.is_defined(ht.revel_canonical)), keep=True
     )
     max_revel_canonical = canonical_ht.group_by(*canonical_ht.key).aggregate(
-        max_revel=hl.agg.max(canonical_ht.revel_canonical)
+        max_revel=hl.agg.max(canonical_ht.revel_canonical),
+        transcripts=hl.agg.collect_as_set(canonical_ht.Transcript_stable_ID),
     )
-    transcripts_canonical = canonical_ht.group_by(*canonical_ht.key).aggregate(
-        transcripts=hl.agg.collect_as_set(canonical_ht.Transcript_stable_ID)
-    )
-    max_revel_canonical = max_revel_canonical.annotate(
-        transcripts=transcripts_canonical[max_revel_canonical.key].transcripts
-    )
-
     logger.info(
         "Merge max REVEL scores for MANE Select transcripts and canonical transcripts"
         " to one HT..."
@@ -220,7 +217,6 @@ def main(args):
             "gs://gnomad-qin/ensembl/ensembl105_chr1-22XY_MANE_canonical_ucscid.tsv.bgz"
         )
 
-        create_revel_grch38_ht(revel_csv, ensembl_ids)
         ht = create_revel_grch38_ht(revel_csv, ensembl_ids)
         ht.write(
             get_insilico_predictors(predictor="revel").path,

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -92,7 +92,7 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
     """
     Create a Hail Table with REVEL scores for GRCh38.
 
-    .. note::
+    .. Note::
     Starting from gnomAD v4, we will use REVEL scores for MANE Select transcripts and canonical transcripts only.
     We take a max of the REVEL scores if a variant falls on multiple transcripts.
     Since the Ensembl ID used by REVEL was not from Ensembl 105, we also only filtered transcripts that are in Ensembl 105.

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -96,6 +96,7 @@ def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
     Starting from gnomAD v4, we will use REVEL scores for MANE Select transcripts and canonical transcripts only.
     We take a max of the REVEL scores if a variant falls on multiple transcripts.
     Since the Ensembl ID used by REVEL was not from Ensembl 105, we also only filtered transcripts that are in Ensembl 105.
+    This will also deprecate `has_duplicate` field as in gnomAD v3.
 
     :param revel_csv: Path to REVEL CSV file.
     :param ensembl_ids: Path to Ensembl 105 ID file, downloaded from Ensembl 105 archive.

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -6,7 +6,6 @@ import logging
 import hail as hl
 from gnomad.utils.slack import slack_notifications
 
-from gnomad_qc.resource_utils import check_resource_existence
 from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v4.resources.annotations import get_insilico_predictors
 
@@ -89,6 +88,111 @@ def create_cadd_grch38_ht() -> hl.Table:
     return ht
 
 
+def create_revel_grch38_ht(revel_csv, ensembl_ids) -> hl.Table:
+    """
+    Create a Hail Table with REVEL scores for GRCh38.
+
+    .. note::
+    Starting from gnomAD v4, we will use REVEL scores for MANE Select transcripts and canonical transcripts only.
+    We take a max of the REVEL scores if a variant falls on multiple transcripts.
+    Since the Ensembl ID used by REVEL was not from Ensembl 105, we also only filtered transcripts that are in Ensembl 105.
+
+    :param revel_csv: Path to REVEL CSV file.
+    :param ensembl_ids: Path to Ensembl 105 ID file, downloaded from Ensembl 105 archive.
+    :return: Hail Table with REVEL scores for GRCh38.
+    """
+    ht = hl.import_table(
+        revel_csv,
+        delimiter=",",
+        min_partitions=1000,
+        types={"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
+    )
+    ht = ht.checkpoint(
+        "gs://gnomad-tmp-4day/revel-v1.3_all_chromosomes_with_transcript_ids.ht",
+        _read_if_exists=True,
+    )
+
+    logger.info("Annotating REVEL table...")
+    ht = ht.drop("hg19_pos", "aaref", "aaalt")
+    ht = ht.filter(ht.grch38_pos.contains("."), keep=False)
+    ht = ht.transmute(chr="chr" + ht.chr)
+    ht = ht.annotate(
+        locus=hl.locus(ht.chr, hl.int(ht.grch38_pos), reference_genome="GRCh38"),
+        alleles=hl.array([ht.ref, ht.alt]),
+        Transcript_stable_ID=ht.Ensembl_transcriptid.strip().split(";"),
+    )
+    ht = ht.select("locus", "alleles", "REVEL", "Transcript_stable_ID")
+    ht = ht.explode("Transcript_stable_ID")
+    ht = ht.key_by("Transcript_stable_ID")
+
+    logger.info("Import and process the ensembl ID file...")
+    ensembl_ids = hl.import_table(ensembl_ids, min_partitions=200, impute=True)
+    ensembl_ids = ensembl_ids.select(
+        "Transcript_stable_ID", "Ensembl_Canonical", "MANE_Select"
+    )
+    ensembl_ids = ensembl_ids.key_by("Transcript_stable_ID")
+
+    ht = ht.annotate(
+        in_Ensembl105=hl.is_defined(ensembl_ids[ht.Transcript_stable_ID]),
+        MANE_Select=ensembl_ids[ht.Transcript_stable_ID].MANE_Select,
+        Ensembl_Canonical=ensembl_ids[ht.Transcript_stable_ID].Ensembl_Canonical,
+    )
+
+    logger.info("Filtering transcripts that are in Ensembl 105...")
+    ht = ht.filter(hl.is_defined(ht.in_Ensembl105), keep=True)
+
+    logger.info(
+        "Annotating REVEL scores for MANE Select transcripts and canonical"
+        " transcripts..."
+    )
+    ht = ht.key_by("locus", "alleles")
+    ht = ht.annotate(
+        revel_mane=hl.if_else(ht.MANE_Select != "", ht.REVEL, hl.missing(hl.tfloat)),
+        revel_canonical=hl.if_else(
+            ht.Ensembl_Canonical == "1", ht.REVEL, hl.missing(hl.tfloat)
+        ),
+        revel_noncanonical=hl.if_else(
+            ht.Ensembl_Canonical != "1", ht.REVEL, hl.missing(hl.tfloat)
+        ),
+    )
+
+    logger.info("Taking max REVEL scores for MANE Select transcripts...")
+    ht = ht.checkpoint(
+        "gs://gnomad-tmp-4day/revel-v1.3_in_Ensembl105.ht", _read_if_exists=True
+    )
+    mane_ht = ht.filter(hl.is_defined(ht.revel_mane), keep=True)
+    max_revel_mane = mane_ht.group_by(*mane_ht.key).aggregate(
+        max_revel=hl.agg.max(mane_ht.revel_mane)
+    )
+    transcripts_mane = mane_ht.group_by(*mane_ht.key).aggregate(
+        transcripts=hl.agg.collect_as_set(mane_ht.Transcript_stable_ID)
+    )
+    max_revel_mane = max_revel_mane.annotate(
+        transcripts=transcripts_mane[max_revel_mane.key].transcripts
+    )
+
+    logger.info("Taking max REVEL scores for canonical transcripts...")
+    canonical_ht = ht.filter(
+        (~hl.is_defined(ht.revel_mane)) & (hl.is_defined(ht.revel_canonical)), keep=True
+    )
+    max_revel_canonical = canonical_ht.group_by(*canonical_ht.key).aggregate(
+        max_revel=hl.agg.max(canonical_ht.revel_canonical)
+    )
+    transcripts_canonical = canonical_ht.group_by(*canonical_ht.key).aggregate(
+        transcripts=hl.agg.collect_as_set(canonical_ht.Transcript_stable_ID)
+    )
+    max_revel_canonical = max_revel_canonical.annotate(
+        transcripts=transcripts_canonical[max_revel_canonical.key].transcripts
+    )
+
+    logger.info(
+        "Merge max REVEL scores for MANE Select transcripts and canonical transcripts"
+        " to one HT..."
+    )
+    final_ht = max_revel_mane.union(max_revel_canonical)
+    return final_ht
+
+
 def main(args):
     """Generate Hail Tables with in silico predictors."""
     hl.init(
@@ -107,6 +211,21 @@ def main(args):
         )
         logger.info("CADD Hail Table for GRCh38 created.")
 
+    if args.revel:
+        logger.info("Creating REVEL Hail Table for GRCh38...")
+        # TODO: update path, do we keep both the raw and processed files?
+        revel_csv = "gs://gnomad-qin/v4_annotations/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz"
+        ensembl_ids = (
+            "gs://gnomad-qin/ensembl/ensembl105_chr1-22XY_MANE_canonical_ucscid.tsv.bgz"
+        )
+
+        create_revel_grch38_ht(revel_csv, ensembl_ids)
+        ht = create_revel_grch38_ht(revel_csv, ensembl_ids)
+        ht.write(
+            get_insilico_predictors(predictor="revel").path,
+            overwrite=args.overwrite,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -115,6 +234,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--overwrite", help="Overwrite data", action="store_true")
     parser.add_argument("--cadd", help="Create CADD HT", action="store_true")
+    parser.add_argument("--revel", help="Create REVEL HT", action="store_true")
     args = parser.parse_args()
     if args.slack_channel:
         with slack_notifications(slack_token, args.slack_channel):

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -356,7 +356,7 @@ def main(args):
         )
 
     if args.annotate_original:
-        output_path = v4_vrs_annotations(test=args.test, original_annotations=True)
+        output_path = v4_vrs_annotations(test=args.test, original_annotations=True).path
         check_resource_existence(
             input_step_resources={
                 "--run-vrs": [v4_vrs_annotations(test=args.test).path],

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -313,23 +313,10 @@ def main(args):
         batch_vrs.run()
 
         logger.info(
-            "Batch jobs executed, preparing to read in sharded VCF from prior step."
-            " Preparing list of files first using Hail's hadoop_ls method."
+            "Batch jobs executed, importing annotated shards into Hail Table..."
         )
-
-        annotated_file_dict = hl.utils.hadoop_ls(
-            f"gs://{working_bucket}/vrs-temp/annotated-shards/annotated.vcf/*"
-        )
-
-        annotated_file_list = [
-            annotated_file_item["path"] for annotated_file_item in annotated_file_dict
-        ]
-
-        logger.info("File list created. Now reading in annotated shards.")
-
-        # Import all annotated shards
         ht_annotated = hl.import_vcf(
-            annotated_file_list,
+            f"gs://{working_bucket}/vrs-temp/annotated-shards/annotated.vcf/*",
             force_bgz=True,
             reference_genome=assembly,
         ).rows()

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -57,13 +57,10 @@ def get_info(split: bool = True, test: bool = False) -> VersionedTableResource:
     )
 
 
-def get_vep(
-    version: str = CURRENT_VERSION, test: bool = False, data_type: str = "exomes"
-) -> VersionedTableResource:
+def get_vep(test: bool = False, data_type: str = "exomes") -> VersionedTableResource:
     """
     Get the gnomAD v4 VEP annotation VersionedTableResource.
 
-    :param version: Version of annotation path to return.
     :param test: Whether to use a tmp path for analysis of the test Table instead of the full v4 Table.
     :param data_type: Data type of annotation resource. e.g. "exomes" or "genomes". Default is "exomes".
     :return: gnomAD v4 VEP VersionedTableResource.
@@ -82,12 +79,11 @@ def get_vep(
 
 
 def validate_vep_path(
-    version: str = CURRENT_VERSION, test: bool = False, data_type: str = "exomes"
+    test: bool = False, data_type: str = "exomes"
 ) -> VersionedTableResource:
     """
     Get the gnomAD v4 VEP annotation VersionedTableResource for validation counts.
 
-    :param version: Version of annotation path to return.
     :param test: Whether to use a tmp path for analysis of the test VDS instead of the full v4 VDS.
     :param data_type: Data type of annotation resource. e.g. "exomes" or "genomes". Default is "exomes".
     :return: gnomAD v4 VEP VersionedTableResource containing validity check.
@@ -105,7 +101,7 @@ def validate_vep_path(
     )
 
 
-def get_trio_stats(test: bool = False) -> str:
+def get_trio_stats(test: bool = False) -> VersionedTableResource:
     """
     Get the gnomAD v4 trio stats VersionedTableResource.
 
@@ -123,7 +119,7 @@ def get_trio_stats(test: bool = False) -> str:
     )
 
 
-def get_sib_stats(test: bool = False) -> str:
+def get_sib_stats(test: bool = False) -> VersionedTableResource:
     """
     Get the gnomAD v4 sibling stats VersionedTableResource.
 
@@ -135,6 +131,42 @@ def get_sib_stats(test: bool = False) -> str:
         {
             version: TableResource(
                 f"{_annotations_root(version, test=test)}/gnomad.exomes.v{version}.sib_stats.ht"
+            )
+            for version in VERSIONS
+        },
+    )
+
+
+def get_variant_qc_annotations(test: bool = False) -> VersionedTableResource:
+    """
+    Return the VersionedTableResource to the RF-ready annotated Table.
+
+    Annotations that are included in the Table:
+
+        Features for RF:
+            - variant_type
+            - allele_type
+            - n_alt_alleles
+            - has_star
+            - AS_QD
+            - AS_pab_max
+            - AS_MQRankSum
+            - AS_SOR
+            - AS_ReadPosRankSum
+
+        Training sites (bool):
+            - transmitted_singleton
+            - sibling_singleton
+            - fail_hard_filters - (ht.QD < 2) | (ht.FS > 60) | (ht.MQ < 30)
+
+    :param test: Whether to use a tmp path for testing.
+    :return: Table with variant QC annotations.
+    """
+    return VersionedTableResource(
+        CURRENT_VERSION,
+        {
+            version: TableResource(
+                f"{_annotations_root(version, test=test)}/gnomad.exomes.v{version}.variant_qc_annotations.ht"
             )
             for version in VERSIONS
         },
@@ -179,18 +211,32 @@ def info_vcf_path(version: str = CURRENT_VERSION, test: bool = False) -> str:
     )
 
 
-def get_transmitted_singleton_vcf_path(
-    adj: bool = False, version: str = CURRENT_VERSION
+def get_true_positive_vcf_path(
+    version: str = CURRENT_VERSION,
+    test: bool = False,
+    adj: bool = False,
+    true_positive_type: str = "transmitted_singleton",
 ) -> str:
     """
     Provide the path to the transmitted singleton VCF used as input to VQSR.
 
-    :param bool adj: Whether to use adj genotypes
-    :param version: Version of transmitted singleton VCF path to return
-    :return: String for the path to the transmitted singleton VCF
+    :param version: Version of true positive VCF path to return.
+    :param test: Whether to use a tmp path for testing.
+    :param adj: Whether to use adj genotypes.
+    :param true_positive_type: Type of true positive VCF path to return. Should be one
+        of "transmitted_singleton", "sibling_singleton", or
+        "transmitted_singleton.sibling_singleton". Default is "transmitted_singleton".
+    :return: String for the path to the true positive VCF.
     """
+    tp_types = [
+        "transmitted_singleton",
+        "sibling_singleton",
+        "transmitted_singleton.sibling_singleton",
+    ]
+    if true_positive_type not in tp_types:
+        raise ValueError(f"true_positive_type must be one of {tp_types}")
     return (
-        f'{_annotations_root(version)}/gnomad.exomes.v{version}.transmitted_singletons.{"adj" if adj else "raw"}.vcf.bgz'
+        f'{_annotations_root(version, test=test)}/gnomad.exomes.v{version}.{true_positive_type}.{"adj" if adj else "raw"}.vcf.bgz'
     )
 
 

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -364,6 +364,21 @@ def get_insilico_predictors(
     )
 
 
+def get_insilico_raw(
+    version: str = CURRENT_VERSION,
+    predictor: str = "revel-v1.3",
+    postfix: str = "csv.bgz",
+) -> str:
+    """
+    Get the path to the in silico predictors TableResource for a specified release.
+
+    :param version: Version of annotation path to return.
+    :param predictor: raw data of in silico predictors or other annotations.
+    :return: in silico predictor VersionedTableResource under v4 path.
+    """
+    return f"gs://gnomad/v{version}/annotations/in_silico_predictors/{predictor}.grch38.{postfix}"
+
+
 def get_vrs(
     version: str = CURRENT_VERSION,
     original_annotations: bool = False,

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -9,6 +9,7 @@ from gnomad.resources.resource_utils import (
     VersionedTableResource,
 )
 
+from gnomad_qc.v3.resources.basics import get_checkpoint_path
 from gnomad_qc.v4.resources.constants import CURRENT_VERSION, VERSIONS
 
 SUBSETS = SUBSETS["v4"]
@@ -262,32 +263,46 @@ qual_hist = VersionedTableResource(
 
 
 def get_freq(
-    version: str = CURRENT_VERSION, subset: Optional[str] = None
+    version: str = CURRENT_VERSION,
+    test: bool = False,
+    hom_alt_adjusted=False,
+    chrom: Optional[str] = None,
+    intermediate_subset: Optional[str] = None,
+    finalized: bool = True,
 ) -> VersionedTableResource:
     """
     Get the frequency annotation table for a specified release.
 
-    :param version: Version of annotation path to return
-    :param subset: One of the official subsets of the specified release (e.g., non_neuro, non_cancer,
-        controls_and_biobanks) or a combination of them split by '-'
-    :return: Hail Table containing subset or overall cohort frequency annotations
+    :param version: Version of annotation path to return.
+    :param test: Whether to use a tmp path for tests.
+    :param hom_alt_adjusted: Whether to return the hom alt adjusted frequency table.
+    :param chrom: Chromosome to return frequency table for. Entire Table will be
+        returned if not specified.
+    :param intermediate_subset: Optional intermediate subset to return temp frequency
+        Table for. Entire Table will be returned if not specified.
+    :param finalized: Whether to return the finalized frequency table. Default is True.
+    :return: Hail Table containing subset or overall cohort frequency annotations.
     """
-    if subset is not None:
-        for s in subset.split("-"):
-            if s not in SUBSETS:
-                raise DataException(
-                    f"{subset} subset is not one of the following official subsets:"
-                    f" {SUBSETS}"
-                )
+    ht_name = f"gnomad.exomes.v{version}"
+    if not finalized:
+        if chrom:
+            ht_name += f".{chrom}"
+        if not hom_alt_adjusted:
+            ht_name += ".pre_hom_alt_adjustment"
+    if intermediate_subset:
+        ht_name += f".{intermediate_subset}"
+        if test:
+            ht_name += ".test"
+        ht_path = get_checkpoint_path(ht_name, version=CURRENT_VERSION)
+    else:
+        if finalized:
+            ht_name += ".final"
+        if test:
+            ht_name += ".test"
+        ht_path = f"{_annotations_root(version, test)}/{ht_name}.ht"
 
     return VersionedTableResource(
-        version,
-        {
-            version: TableResource(
-                f"{_annotations_root(version)}/gnomad.exomes.v{version}.frequencies{'.' + subset if subset else ''}.ht"
-            )
-            for version in VERSIONS
-        },
+        version, {version: TableResource(ht_path) for version in VERSIONS}
     )
 
 

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -283,7 +283,7 @@ def get_freq(
     :param finalized: Whether to return the finalized frequency table. Default is True.
     :return: Hail Table containing subset or overall cohort frequency annotations.
     """
-    ht_name = f"gnomad.exomes.v{version}"
+    ht_name = f"gnomad.exomes.v{version}.frequencies"
     if not finalized:
         if chrom:
             ht_name += f".{chrom}"

--- a/gnomad_qc/v4/resources/variant_qc.py
+++ b/gnomad_qc/v4/resources/variant_qc.py
@@ -141,42 +141,6 @@ def get_binned_concordance(model_id: str, truth_sample: str) -> VersionedTableRe
     )
 
 
-def get_rf_annotations(adj: bool = False) -> VersionedTableResource:
-    """
-    Return the VersionedTableResource to the RF-ready annotated Table.
-
-    Annotations that are included in the Table:
-
-        Features for RF:
-            - InbreedingCoeff
-            - variant_type
-            - allele_type
-            - n_alt_alleles
-            - has_star
-            - AS_QD
-            - AS_pab_max
-            - AS_MQRankSum
-            - AS_SOR
-            - AS_ReadPosRankSum
-
-        Training sites (bool):
-            - transmitted_singleton
-            - fail_hard_filters - (ht.QD < 2) | (ht.FS > 60) | (ht.MQ < 30)
-
-    :param bool adj: Whether to load 'adj' or 'raw'
-    :return: Table with RF annotations
-    """
-    return VersionedTableResource(
-        CURRENT_VERSION,
-        {
-            version: TableResource(
-                f"{get_variant_qc_root(version)}/rf/gnomad.exomes.v{version}.rf_annotations.{'adj' if adj else 'raw'}.ht"
-            )
-            for version in VERSIONS
-        },
-    )
-
-
 def rf_run_path(version: str = CURRENT_VERSION) -> str:
     """
     Return the path to the json file containing the RF runs list.


### PR DESCRIPTION
Starting from gnomAD v4, we will use REVEL scores for MANE Select transcripts and canonical transcripts only.
We take a max of the REVEL scores if a variant falls on multiple transcripts.
Since the Ensembl ID used by REVEL was not from Ensembl 105, we also only filtered transcripts that are in Ensembl 105.
This will also avoid `has_duplicate`. 