### PR TITLE
Add fix to allele specific annotations that are longer than LA

### DIFF
--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -172,7 +172,7 @@ def correct_as_annotations(
         a: hl.if_else(
             hl.len(expr) > hl.len(mt.LA),
             hl.or_missing(
-                set_to_missing, expr[:idx_remove].extend(expr[idx_remove + 1 :])
+                not set_to_missing, expr[:idx_remove].extend(expr[idx_remove + 1 :])
             ),
             expr,
         )


### PR DESCRIPTION
I ran the test dataset using:

```
hailctl dataproc submit jg2 gnomad_qc/v4/annotations/generate_variant_qc_annotations.py --test-dataset --compute-info --split-info
```

Output:
gs://gnomad-tmp/gnomad_v4.0_testing/annotations/exomes/gnomad.exomes.v4.0.info.ht
gs://gnomad-tmp/gnomad_v4.0_testing/annotations/exomes/gnomad.exomes.v4.0.info.split.ht


Test notebook: gs://gnomad-julia/gnomad_v4/test_allele_specific_annotation_correction.ipynb
Test HTML: gs://gnomad-julia/gnomad_v4/test_allele_specific_annotation_correction.html