### PR TITLE
non_ukb downsamplings for v4 freq

### DIFF
--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -260,7 +260,7 @@ def annotate_freq_index_dict(ht: hl.Table) -> hl.Table:
     logger.info("Making freq index dict...")
     # Add additional strata to the sort order, keeping group, i.e. adj, at the end.
     sort_order = deepcopy(SORT_ORDER)
-    sort_order[-1:-1] = ["gatk_version", "ukb_sample"]
+    sort_order[-1:-1] = ["gatk_version"]
     ht = ht.annotate_globals(
         freq_index_dict=make_freq_index_dict_from_meta(
             freq_meta=ht.freq_meta,
@@ -399,7 +399,6 @@ def generate_freq_ht(
     additional_strata_expr = [
         {"gatk_version": meta_ht.gatk_version},
         {"gatk_version": meta_ht.gatk_version, "pop": meta_ht.pop},
-        {"ukb_sample": meta_ht.ukb_sample},
     ]
     logger.info("Building frequency stratification list...")
     strata_expr = build_freq_stratification_list(
@@ -504,7 +503,7 @@ def non_ukb_freq_downsampling(mt: hl.MatrixTable, freq_ht: hl.Table) -> hl.Table
     # retain the subset freq data.
     non_ukb_ht = filter_freq_arrays_for_non_ukb_subset(
         freq_ht,
-        items_to_filter=["downsampling", "gatk_version", "ukb_sample"],
+        items_to_filter=["downsampling", "gatk_version"],
         keep=False,
         combine_operator="or",
     )
@@ -859,7 +858,7 @@ def main(args):
                 "Splitting VDS by ukb_sample annotation to reduce data size for"
                 " densification..."
             )
-            vds_dict = split_vds_by_strata(vds, strata_expr=vds.variant_data.ukb_sample)
+            vds_dict = split_vds_by_strata(vds, strata_expr=meta_ht.ukb_sample)
             for strata, vds in vds_dict.items():
                 if (
                     args.ukb_only
@@ -876,7 +875,6 @@ def main(args):
                     freq_ht = non_ukb_freq_downsampling(mt, freq_ht)
 
                 logger.info("Setting Y metrics to NA for XX groups...")
-                freq_ht = annotate_freq_index_dict(freq_ht)
                 freq_ht = freq_ht.annotate(
                     freq=set_female_y_metrics_to_na_expr(freq_ht)
                 )

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -499,7 +499,7 @@ def non_ukb_freq_downsampling(mt: hl.MatrixTable, freq_ht: hl.Table) -> hl.Table
     non_ukb_ds_ht = filter_freq_arrays_for_non_ukb_subset(
         non_ukb_ds_ht, items_to_filter=["downsampling"]
     )
-    # Filter to only non_ukb group, pop, and sex strata so can add subset-specific freqs to main array. 
+    # Filter to only non_ukb group, pop, and sex strata so can add subset-specific freqs to main array.
     # This is duplicated data here but it's necessary so we can merge split vds strata properly and still
     # retain the subset freq data.
     non_ukb_ht = filter_freq_arrays_for_non_ukb_subset(

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -299,7 +299,6 @@ def annotate_freq_index_dict(ht: hl.Table) -> hl.Table:
             sort_order=sort_order,
         )
     )
-
     return ht
 
 
@@ -430,22 +429,16 @@ def generate_freq_and_hists_ht(
             ),
         )
         # Filter freq_meta array field to dict entries with a "downsampling" key and
-        # rename the key to "non_ukb_downsampling". We don't want any other strata that
-        # are returned from annotate_freq, e.g. 'pop'. Also rename the downsamplings
-        # global field to "non_ukb_downsamplings" so we can merge the two freq arrays
+        # update it to have "subset" key with "non_ukb" value. We don't want any other
+        # strata that are returned from annotate_freq, e.g. 'pop'. Also rename the
+        # downsamplings global field to "non_ukb_downsamplings" so we can merge two
         # later and not lose the non_ukb downsampling information.
         non_ukb_ds_freq_ht = non_ukb_ds_freq_ht.annotate_globals(
             freq_meta=non_ukb_ds_freq_ht.freq_meta.filter(
                 lambda i: i.keys().contains("downsampling")
             ).map(
-                lambda d: hl.dict(  # TODO: changes this to just add "subset": "non_ukb" to the dict
-                    d.items().map(
-                        lambda i: hl.if_else(
-                            i[0] == "downsampling",
-                            ("non_ukb_downsamplings", i[1]),
-                            (i[0], i[1]),
-                        )
-                    )
+                lambda d: hl.dict(
+                    hl.zip(d.keys(), d.values()).append(("subset", "non_ukb"))
                 )
             ),
             non_ukb_downsamplings=non_ukb_ds_freq_ht.downsamplings,

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -396,6 +396,7 @@ def generate_freq_ht(
     :param meta_ht: Table with sample metadata annotations.
     :return: Hail Table with frequency annotations.
     """
+    meta_ht = meta_ht.semi_join(mt.cols())
     additional_strata_expr = [
         {"gatk_version": meta_ht.gatk_version},
         {"gatk_version": meta_ht.gatk_version, "pop": meta_ht.pop},

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -413,38 +413,18 @@ def generate_freq_and_hists_ht(
             entry_agg_funcs={"high_ab_hets_by_group": (_high_ab_het, hl.agg.sum)},
         )
 
-        # Filter freq array field to only downsampling indices by using the freq_meta
-        # array field values.
-        def _select_non_ukb_entries(arr_expr):
-            return (
-                hl.zip(arr_expr, non_ukb_ds_freq_ht.freq_meta)
-                .filter(lambda i: i[1].keys().contains("downsampling"))
-                .map(lambda k: k[0])
-            )
-
-        non_ukb_ds_freq_ht = non_ukb_ds_freq_ht.annotate(
-            freq=_select_non_ukb_entries(non_ukb_ds_freq_ht.freq),
-            high_ab_hets_by_group=_select_non_ukb_entries(
-                non_ukb_ds_freq_ht.high_ab_hets_by_group
-            ),
-        )
-        # Filter freq_meta array field to dict entries with a "downsampling" key and
-        # update it to have "subset" key with "non_ukb" value. We don't want any other
-        # strata that are returned from annotate_freq, e.g. 'pop'. Also rename the
-        # downsamplings global field to "non_ukb_downsamplings" so we can merge two
-        # later and not lose the non_ukb downsampling information.
+        # Add "subset" key to freq_meta so we do not have any collisions on merging.
+        # Keep ancestry group and sex freq strata in here (basically duplicating the
+        # data for these groups since they are already captured above) so we can use
+        # the same code to merge the non_ukb and ukb freq HT arrays and capture the
+        # subset info without doing any extra manipulation.
         non_ukb_ds_freq_ht = non_ukb_ds_freq_ht.annotate_globals(
-            freq_meta=non_ukb_ds_freq_ht.freq_meta.filter(
-                lambda i: i.keys().contains("downsampling")
-            ).map(
+            freq_meta=non_ukb_ds_freq_ht.freq_meta.map(
                 lambda d: hl.dict(
                     hl.zip(d.keys(), d.values()).append(("subset", "non_ukb"))
                 )
             ),
             non_ukb_downsamplings=non_ukb_ds_freq_ht.downsamplings,
-            freq_meta_sample_count=_select_non_ukb_entries(
-                non_ukb_ds_freq_ht.freq_meta_sample_count
-            ),
         )
         non_ukb_ds_freq_ht = non_ukb_ds_freq_ht.checkpoint(
             new_temp_file("freq_non_ukb_ds", extension="ht")

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -221,7 +221,7 @@ def get_freq(
         ht_name += f".{intermediate_subset}"
         if test:
             ht_name += ".test"
-        ht_path = get_checkpoint_path(ht_name)
+        ht_path = get_checkpoint_path(ht_name, version=CURRENT_VERSION)
     else:
         if finalized:
             ht_name += ".final"


### PR DESCRIPTION
Misnamed the branch but this adds the non_ukb subset downsamplings as well as a couple other things, like the try, finally to copy the log on OOM failures, and also the freq_meta_sample_count to the globals. I opted for doing another pass through the data instead of adding more strata to the initial pass as it would almost double our aggregations and I figured we may end up with the 137 again. This extra pass was also discussed in slack back in May before we know how much more work freqs would be so I figured it was the preferred approach. This also prevents changes to  the gnomad_methods build strata and annotate_freq functions. The way the freq_meta is updated, adding the subst key, may change in another round since I need to annotate the subset frequencies onto the main freq table still. I'll make another PR for adding in the subset specific annotations/finalize option we discussed but wanted to get this to you.