### PR TITLE
Add cuKING to ignore-paths

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,4 +7,4 @@ disable=
   R,
   C
 
-ignore-paths=^gnomad_qc/v2/.*$
+ignore-paths=^gnomad_qc/v2/.*$,^gnomad_qc/v4/sample_qc/cuKING/.*$


### PR DESCRIPTION
I think this will fix our current pylint failures. I think it'sthe right behavior -- we don't want to be linting a repo we don't own. 