### PR TITLE
change driver_memory to highmem in hl.init

### DIFF
--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -152,6 +152,7 @@ def main(args):
         default_reference="GRCh38",
         global_seed=args.hail_rand_seed,
         regions=["us-central1"],
+        driver_memory="highmem",
     )
 
     logger.info(f"Hail version as: {hl.version()}")


### PR DESCRIPTION
Set driver_memory to 'highmem' to avoid out of memory error in Hail Batch run. 