### PR TITLE
remove a note about command

### DIFF
--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -8,7 +8,7 @@ Example command to use `hailctl batch submit`:
 hailctl batch submit \
 --image-name us-central1-docker.pkg.dev/broad-mpg-gnomad/images/vrs084 \
 gnomad_qc/gnomad_qc/v4/annotations/vrs_annotation_batch.py \
--- \ # TODO: remove this when hailctl batch submit bug is fixed in hail 0.2.121
+-- \
 --billing-project gnomad-annot \
 --working-bucket gnomad-tmp-4day \
 --image us-central1-docker.pkg.dev/broad-mpg-gnomad/images/vrs084 \


### PR DESCRIPTION
We still need -- for hailctl batch submit, so I removed the note. 