### PR TITLE
process SIFT and PolyPhen scores from vep_ht

### DIFF
--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -227,7 +227,7 @@ def create_pangolin_grch38_ht() -> hl.Table:
     generated for gnomAD v4 genomes (=v3 genomes) and v4 exomes variants in
     gene body only with code from developers at Invitae:
     https://github.com/invitae/pangolin. All v4 genomes variants (except ~20M
-    bug-affected and ~3M new variants from HGDP/TGP samples noted below) were run on
+    bug-affected and ~3M new variants from HGDP/TGP samples, noted below) were run on
     Pangolin v1.3.12, the others were run on Pangolin v1.4.4.
 
     :return: Hail Table with Pangolin score for splicing for GRCh38.

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -124,7 +124,10 @@ def create_spliceai_grch38_ht() -> hl.Table:
     indels_path = (
         "gs://gnomad-insilico/spliceai/spliceai_scores.masked.indel.hg38.vcf.bgz"
     )
-    v3_indels_path = "gs://gnomad-insilico/spliceai/spliceai_scores.masked.gnomad_v3_indel.hg38.vcf.gz"
+    v3_indels_path = (
+        "gs://gnomad-insilico/spliceai/spliceai_scores.masked"
+        ".gnomad_v3_indel.hg38.vcf.bgz"
+    )
     v4_indels_path = "gs://gnomad-insilico/spliceai/spliceai_scores.masked.gnomad_v4_new_indels.hg38.vcf.bgz"
     v3_v4_unscored_path = "gs://gnomad-insilico/spliceai/spliceai_scores.masked.gnomad_v3_v4_unscored_indels.hg38.vcf.bgz"
     header_file_path = "gs://gnomad-insilico/spliceai/spliceai.vcf.header"

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -191,6 +191,12 @@ def create_pangolin_grch38_ht() -> hl.Table:
     )
     v4_exomes = "gs://gnomad-insilico/pangolin/gnomad.v4.0.exomes.pangolin.vcf.bgz/*.gz"
 
+    # There was a bug in original Pangolin code, that would generate incorrect
+    # scores when a variant falls on multiple genes on the same strand. This bug
+    # was fixed before running v4 exomes, the affected ~20M variants have
+    # been rerun.
+    v4_bugfix = "gs://gnomad-insilico/pangolin/gnomad.v4.0.genomes.bugfix.pangolin.vcf.bgz/*.bgz"
+
     def import_pangolin_vcf(vcf_path: str) -> hl.Table:
         """
         Import Pangolin VCF to Hail Table.
@@ -209,6 +215,10 @@ def create_pangolin_grch38_ht() -> hl.Table:
 
     ht_g = import_pangolin_vcf(v4_genomes)
     ht_e = import_pangolin_vcf(v4_exomes)
+    ht_bugfix = import_pangolin_vcf(v4_bugfix)
+
+    ht_g_correct = ht_g.anti_join(ht_bugfix)
+    ht_g = ht_g_correct.union(ht_bugfix)
 
     logger.info(
         "Number of rows in genomes Pangolin HT: %s; "

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -251,12 +251,9 @@ def create_pangolin_grch38_ht() -> hl.Table:
     ht_g = ht_g_correct.union(ht_bugfix)
 
     logger.info(
-        "Number of rows in genomes Pangolin HT: %s; \n",
-        "Number of rows in raw exomes Pangolin HT: %s. \n",
-        "Number of rows in Pangolin HT for new variants of genomes: %s. \n",
-        ht_g.count(),
-        ht_e.count(),
-        ht_g_new.count(),
+        f"Number of rows in genomes Pangolin HT: {ht_g.count()};\n Number of rows in"
+        f" raw exomes Pangolin HT: {ht_e.count()};\n Number of rows in Pangolin HT for"
+        f" new variants of genomes: {ht_g_new.count()}.\n"
     )
 
     ht = ht_g.union(ht_e, ht_g_new)

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -114,10 +114,11 @@ def create_spliceai_grch38_ht() -> hl.Table:
         - gnomAD v3 indels: gnomad_v3_indel.spliceai_masked.vcf.bgz,
           computed on v3.1 indels by Illumina in 2020.
         - gnomAD v4 indels: gnomad_v4_new_indels.spliceai_masked.vcf.bgz,
-          computed on v4 by Illumina in February 2023.
+          computed on v4 indels that are new compared to v3 indels by Illumina in
+          February 2023.
         - gnomAD v3 and v4 unscored indels:
           spliceai_scores.masked.gnomad_v3_v4_unscored_indels.hg38.vcf.bgz,
-          another set of indels were not scored in v3 or v4 but  computed by Illumina in
+          another set of indels were not scored in v3 or v4 but computed by Illumina in
           September 2023.
 
     :return: Hail Table with SpliceAI scores for GRCh38.

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -251,8 +251,9 @@ def create_pangolin_grch38_ht() -> hl.Table:
     ht_g = ht_g_correct.union(ht_bugfix)
 
     logger.info(
-        "Number of rows in genomes Pangolin HT: %s; \n"
+        "Number of rows in genomes Pangolin HT: %s; \n",
         "Number of rows in raw exomes Pangolin HT: %s. \n",
+        "Number of rows in Pangolin HT for new variants of genomes: %s. \n",
         ht_g.count(),
         ht_e.count(),
         ht_g_new.count(),

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -195,7 +195,8 @@ def create_pangolin_grch38_ht() -> hl.Table:
     There's no precomputed score for all possible variants, the scores were
     generated for gnomAD v4 genomes (=v3 genomes) and v4 exomes variants in
     gene body only with code from developers at Invitae:
-    https://github.com/invitae/pangolin.
+    https://github.com/invitae/pangolin. Only +(v4_genomes - v4_bugfix) were run on
+    Pangolin v1.3.12, the others was run on Pangolin v1.4.4.
 
     :return: Hail Table with Pangolin score for splicing for GRCh38.
     """
@@ -299,7 +300,7 @@ def create_pangolin_grch38_ht() -> hl.Table:
         )
     )
     # TODO: get the version for genomes run in May 2023.
-    ht = ht.annotate_globals(pangolin_version="v1.4.4")
+    ht = ht.annotate_globals(pangolin_version=["v1.3.12", "v1.4.4"])
     logger.info(
         "\nNumber of variants indicating splice gain: %s;\n"
         "Number of variants indicating splice loss: %s; \n"

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -97,7 +97,7 @@ def create_cadd_grch38_ht() -> hl.Table:
     indel3 = indel3.anti_join(indel4)
 
     ht = snvs.union(indel3, indel4)
-    ht = ht.select(cadd=hl.struct(raw_score=ht.RawScore, phred=ht.PHRED))
+    ht = ht.select(cadd=hl.struct(phred=ht.PHRED, raw_score=ht.RawScore))
     ht = ht.annotate_globals(cadd_version="v1.6")
     return ht
 

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -277,6 +277,8 @@ def create_pangolin_grch38_ht() -> hl.Table:
             hl.max(ht.values.largest_ds_gene),
         )
     )
+    # TODO: update version when Invitae publishes new version
+    ht = ht.annotate_globals(pangolin_version="v1.0.1")
     logger.info(
         "\nNumber of variants indicating splice gain: %s;\n"
         "Number of variants indicating splice loss: %s; \n"

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -6,7 +6,7 @@ import hail as hl
 # move SIFT and PolyPhen to insilico_predictors in vep_ht
 # remove missing fields in vep_ht
 # drop vep from site HT and merge with vep_ht
-# remove old insilico predictors and replace with new ones (all 7)
+# remove old insilico predictors and replace with new ones (the left predictors)
 # update dbSNP to dbSNP 156
 # rerun inbreeding_coefficient with the callstats
 # update freq, freq_meta, freq_index_dict by integrating updates in HGDP/TGP

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -2,32 +2,18 @@
 import hail as hl
 from gnomad.utils.vep import filter_vep_transcript_csqs
 
-# TODO: steps to create release sites HT
-# input: VRS-annotated sites HT v3.1.4
-# move SIFT and PolyPhen to insilico_predictors in vep_ht
-# remove missing fields in vep_ht
-# drop vep from site HT and merge with vep_ht
-# remove old insilico predictors and replace with new ones (the left predictors)
-# update dbSNP to dbSNP 156
-# update freq, freq_meta, freq_index_dict by integrating updates in HGDP/TGP
-# rerun inbreeding_coefficient with the callstats from the new freq
-# replace oth with remaining in global fields
-# update global fields
-
 
 def get_sift_polyphen_from_vep(ht: hl.Table) -> hl.Table:
     """
-    Get SIFT and PolyPhen scores from VEP 105 annotations.
+    Get the max SIFT and PolyPhen scores from VEP 105 annotations.
 
-    .. note::
-     This function is to get a max of SIFT and PolyPhen scores from mane_select
-     transcripts, otherwise get a max of SIFT and PolyPhen scores from canonical
-     transcripts. It will also drop the SIFT and PolyPhen scores and predictions
-     from the transcript_consequences struct.
+     This retrieves the max of SIFT and PolyPhen scores for a variant's MANE Select
+     transcript or, if MANE Select does not exist, canonical transcript. This also
+     drops SIFT and PolyPhen scores and predictions from VEP's transcript_consequences
+     struct.
 
-    :param ht: VEP105 annotated Hail Table.
-    :return: Hail Table with VEP105 annotations and  SIFT and PolyPhen scores
-    extracted and stored in insilico_predictors struct.
+    :param ht: VEP 105 annotated Hail Table.
+    :return: Hail Table with SIFT and PolyPhen scores
     """
     mane = filter_vep_transcript_csqs(
         ht, synonymous=False, canonical=False, mane_select=True

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -28,7 +28,6 @@ def get_sift_polyphen_from_vep(vep_ht: hl.Table) -> hl.Table:
     :return: Hail Table with VEP105 annotations and  SIFT and PolyPhen scores
     extracted and stored in insilico_predictors struct.
     """
-
     ht = vep_ht.select(vep_ht.vep.transcript_consequences)
     ht = ht.explode("transcript_consequences")
     ht = ht.select(

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -1,6 +1,17 @@
 """Script to create release sites HT for v4 genomes."""
 import hail as hl
 
+# TODO:
+# input: VRS- and VEP105-annotated sites HT v3.1.4
+# move SIFT and Polyphen to insilico_predictors
+# remove missing fields in vep
+# remove old insilico predictors and replace with new ones (all 7)
+# update dbSNP to dbSNP 156
+# rerun inbreeding_coefficient with the callstats
+# update freq, freq_meta, freq_index_dict by integrating updates in HGDP/TGP
+# replace oth with remaining in global fields
+# update global fields
+
 
 def remove_missing_vep_fields(vep_expr: hl.StructExpression) -> hl.StructExpression:
     """

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -1,37 +1,5 @@
 """Script to create release sites HT for v4 genomes."""
-from typing import Tuple
-
 import hail as hl
-from gnomad.utils.vep import filter_vep_transcript_csqs
-
-
-def get_sift_polyphen_from_vep(
-    ht: hl.Table,
-) -> Tuple[hl.ArrayExpression, hl.ArrayExpression]:
-    """
-    Get the max SIFT and PolyPhen scores from VEP 105 annotations.
-
-     This retrieves the max of SIFT and PolyPhen scores for a variant's MANE Select
-     transcript or, if MANE Select does not exist, canonical transcript.
-
-    :param ht: VEP 105 annotated Hail Table.
-    :return: Tuple of max SIFT and PolyPhen scores.
-    """
-    mane = filter_vep_transcript_csqs(
-        ht, synonymous=False, canonical=False, mane_select=True
-    )
-    canonical = filter_vep_transcript_csqs(ht, synonymous=False, canonical=True)
-    ht = ht.annotate(
-        sift_mane=mane[ht.key].vep.transcript_consequences.sift_score,
-        polyphen_mane=mane[ht.key].vep.transcript_consequences.polyphen_score,
-        sift_canonical=canonical[ht.key].vep.transcript_consequences.sift_score,
-        polyphen_canonical=canonical[ht.key].vep.transcript_consequences.polyphen_score,
-    )
-
-    sift_max = hl.or_else(hl.max(ht.sift_mane), hl.max(ht.sift_canonical))
-    polyphen_max = hl.or_else(hl.max(ht.polyphen_mane), hl.max(ht.polyphen_canonical))
-
-    return sift_max, polyphen_max
 
 
 def remove_missing_vep_fields(vep_expr: hl.StructExpression) -> hl.StructExpression:

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -8,8 +8,8 @@ import hail as hl
 # drop vep from site HT and merge with vep_ht
 # remove old insilico predictors and replace with new ones (the left predictors)
 # update dbSNP to dbSNP 156
-# rerun inbreeding_coefficient with the callstats
 # update freq, freq_meta, freq_index_dict by integrating updates in HGDP/TGP
+# rerun inbreeding_coefficient with the callstats from the new freq
 # replace oth with remaining in global fields
 # update global fields
 

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -12,9 +12,7 @@ def get_sift_polyphen_from_vep(
     Get the max SIFT and PolyPhen scores from VEP 105 annotations.
 
      This retrieves the max of SIFT and PolyPhen scores for a variant's MANE Select
-     transcript or, if MANE Select does not exist, canonical transcript. This also
-     drops SIFT and PolyPhen scores and predictions from VEP's transcript_consequences
-     struct.
+     transcript or, if MANE Select does not exist, canonical transcript.
 
     :param ht: VEP 105 annotated Hail Table.
     :return: Tuple of max SIFT and PolyPhen scores.

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -1,8 +1,6 @@
 """Script to create release sites HT for v4 genomes."""
 import hail as hl
-
 from gnomad.utils.vep import filter_vep_transcript_csqs
-
 
 # TODO: steps to create release sites HT
 # input: VRS-annotated sites HT v3.1.4

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -31,15 +31,16 @@ def get_sift_polyphen_from_vep(ht: hl.Table) -> hl.Table:
     :return: Hail Table with VEP105 annotations and  SIFT and PolyPhen scores
     extracted and stored in insilico_predictors struct.
     """
-    mane = filter_vep_transcript_csqs(ht, synonymous=False, canonical=False,
-                                      mane_select=True)
+    mane = filter_vep_transcript_csqs(
+        ht, synonymous=False, canonical=False, mane_select=True
+    )
     canonical = filter_vep_transcript_csqs(ht, synonymous=False, canonical=True)
     ht = ht.annotate(
         sift_mane=mane[ht.key].vep.transcript_consequences.sift_score,
         polyphen_mane=mane[ht.key].vep.transcript_consequences.polyphen_score,
         sift_canonical=canonical[ht.key].vep.transcript_consequences.sift_score,
-        polyphen_canonical=canonical[
-            ht.key].vep.transcript_consequences.polyphen_score)
+        polyphen_canonical=canonical[ht.key].vep.transcript_consequences.polyphen_score,
+    )
 
     ht = ht.annotate(
         vep=ht.vep.annotate(
@@ -55,14 +56,13 @@ def get_sift_polyphen_from_vep(ht: hl.Table) -> hl.Table:
     )
     ht = ht.annotate(
         insilico_predictors=hl.struct(
-            sift_max=hl.or_else(hl.max(ht.sift_mane),
-                                hl.max(ht.sift_canonical)),
-            polyphen_max=hl.or_else(hl.max(ht.polyphen_mane),
-                                    hl.max(ht.polyphen_canonical))
+            sift_max=hl.or_else(hl.max(ht.sift_mane), hl.max(ht.sift_canonical)),
+            polyphen_max=hl.or_else(
+                hl.max(ht.polyphen_mane), hl.max(ht.polyphen_canonical)
+            ),
         )
     )
-    ht = ht.drop("sift_mane", "polyphen_mane", "sift_canonical",
-                 'polyphen_canonical')
+    ht = ht.drop("sift_mane", "polyphen_mane", "sift_canonical", "polyphen_canonical")
 
     ht = ht.annotate_globals(
         tool_versions=hl.struct(sift_version="5.2.2", polyphen_version="2.2.2")
@@ -70,8 +70,7 @@ def get_sift_polyphen_from_vep(ht: hl.Table) -> hl.Table:
     return ht
 
 
-def remove_missing_vep_fields(
-        vep_expr: hl.StructExpression) -> hl.StructExpression:
+def remove_missing_vep_fields(vep_expr: hl.StructExpression) -> hl.StructExpression:
     """
     Remove fields from VEP 105 annotations that have been excluded in past releases or are missing in all rows.
 
@@ -92,8 +91,7 @@ def remove_missing_vep_fields(
         "regulatory_feature_consequences",
     ]:
         vep_expr = vep_expr.annotate(
-            **{consequence: vep_expr[consequence].map(
-                lambda x: x.drop("minimised"))}
+            **{consequence: vep_expr[consequence].map(lambda x: x.drop("minimised"))}
         )
     return vep_expr
 
@@ -116,8 +114,7 @@ def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
         ),
         freq_index_dict=hl.dict(
             hl.zip(
-                ht.freq_index_dict.keys().map(
-                    lambda k: k.replace("oth", "remaining")),
+                ht.freq_index_dict.keys().map(lambda k: k.replace("oth", "remaining")),
                 ht.freq_index_dict.values(),
             )
         ),


### PR DESCRIPTION
In this PR, I removed the nested structs for insilico predictors, add the bug-fixed rerun for v4 genomes in Pangolin, most importantly, I put in a function to process SIFT and PolyPhen scores, I also started to organize the steps/to-dos to create v4 genome release. 
I also put the function in create_release code, because I want this to run as a pipeline. 