### PR TITLE
Script to compute combined FAF of v4 genomes and exomes

### DIFF
--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -31,7 +31,9 @@ from gnomad_qc.v4.resources.annotations import (
     get_freq_comparison,
 )
 from gnomad_qc.v4.resources.basics import get_logging_path
-from gnomad_qc.v4.resources.release import get_combined_faf_release, release_sites
+from gnomad_qc.v4.resources.release import get_combined_faf_release
+# TODO: change to freq_ht when the freq_ht is finalized
+from gnomad_qc.v3.resources.release import release_sites
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger("compute_combined_faf")
@@ -341,7 +343,7 @@ def main(args):
     hl.init(log="/compute_combined_faf.log")
     test = args.test
     overwrite = args.overwrite
-    pops = list(POPS["v3"] & POPS["v4"])
+    pops = POPS["v3"] + POPS["v4"]
     faf_pops = [pop for pop in pops if pop not in POPS_TO_REMOVE_FOR_POPMAX]
     combine_faf_resources = get_combine_faf_resources(overwrite, test, args.public)
 

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -84,7 +84,7 @@ def pop_max_for_faf_expr(
             key=lambda f: (-f.faf, f.population),
         ),
         lambda fafs: hl.if_else(
-            hl.len(fafs) > 0,
+            (hl.len(fafs) > 0) & (fafs[0].faf > 0),
             hl.struct(faf95_max=fafs[0].faf, faf95_max_pop=fafs[0].population),
             hl.struct(
                 faf95_max=hl.missing(hl.tfloat), faf95_max_pop=hl.missing(hl.tstr)
@@ -103,7 +103,7 @@ def pop_max_for_faf_expr(
             key=lambda f: (-f.faf, f.population),
         ),
         lambda fafs: hl.if_else(
-            hl.len(fafs) > 0,
+            (hl.len(fafs) > 0) & (fafs[0].faf > 0),
             hl.struct(faf99_max=fafs[0].faf, faf99_max_pop=fafs[0].population),
             hl.struct(
                 faf99_max=hl.missing(hl.tfloat), faf99_max_pop=hl.missing(hl.tstr)
@@ -252,7 +252,6 @@ def get_joint_freq_and_faf(
     faf_meta_by_pop = hl.literal(faf_meta_by_pop)
 
     # Compute group max (popmax) on the merged exomes + genomes frequencies.
-    # TODO: can we just use the name 'popmax' instead of 'grpmax'?
     grpmax = pop_max_expr(freq, freq_meta, pops_to_exclude=faf_pops_to_exclude)
     grpmax = grpmax.annotate(faf95=faf[faf_meta_by_pop.get(grpmax.pop)].faf95)
 

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -91,11 +91,13 @@ def extract_freq_info(
         :return: Indices of populations to keep and their metadata.
         """
         meta = hl.eval(meta)
+        # for adj and raw, but raw is not in faf_meta for genomes release HT,
+        # so we will remove the duplicate idx with list(set(idx))
         idx = [0, 1]
         idx.extend(
             [i for i, m in enumerate(meta) if m.get("pop") in pop_list and len(m) == 2]
         )
-        meta = [meta[i] for i in idx]
+        meta = [meta[i] for i in list(set(idx))]
 
         return idx, meta
 

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -17,9 +17,9 @@ import hail as hl
 from gnomad.resources.grch38.gnomad import POPS, POPS_TO_REMOVE_FOR_POPMAX
 from gnomad.utils.annotations import (
     faf_expr,
+    gen_anc_faf_max_expr,
     merge_freq_arrays,
     pop_max_expr,
-    pop_max_for_faf_expr,
 )
 from gnomad.utils.release import make_faf_index_dict, make_freq_index_dict_from_meta
 from gnomad.utils.slack import slack_notifications
@@ -135,7 +135,7 @@ def extract_freq_info(
     faf_idx, faf_meta = _get_pop_meta_indices(ht.faf_meta, faf_pops)
 
     # Compute FAF max (fafmax)
-    ht = ht.annotate(fafmax=pop_max_for_faf_expr(ht.faf, ht.faf_meta))
+    ht = ht.annotate(fafmax=gen_anc_faf_max_expr(ht.faf, ht.faf_meta))
 
     # Rename filtered annotations with supplied prefix.
     ht = ht.select(
@@ -194,7 +194,7 @@ def get_joint_freq_and_faf(
     ht = ht.annotate(
         joint_freq=freq,
         joint_faf=faf,
-        joint_fafmax=pop_max_for_faf_expr(faf, hl.literal(faf_meta)),
+        joint_fafmax=gen_anc_faf_max_expr(faf, hl.literal(faf_meta)),
         joint_grpmax=grpmax,
     )
 

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -191,7 +191,12 @@ def get_joint_freq_and_faf(
     grpmax = grpmax.annotate(faf95=faf[faf_meta_by_pop.get(grpmax.pop)].faf95)
 
     # Annotate Table with all joint exomes + genomes computations.
-    ht = ht.annotate(joint_freq=freq, joint_faf=faf, joint_grpmax=grpmax)
+    ht = ht.annotate(
+        joint_freq=freq,
+        joint_faf=faf,
+        joint_fafmax=pop_max_for_faf_expr(faf, hl.literal(faf_meta)),
+        joint_grpmax=grpmax,
+    )
 
     ht = ht.annotate_globals(
         joint_freq_meta=freq_meta,
@@ -199,9 +204,6 @@ def get_joint_freq_and_faf(
         joint_faf_meta=faf_meta,
         joint_faf_index_dict=make_faf_index_dict(faf_meta),
     )
-
-    # Compute FAF max (fafmax) on the merged exomes + genomes frequencies.
-    ht = ht.annotate(joint_fafmax=pop_max_for_faf_expr(ht.joint_faf, ht.joint_faf_meta))
 
     return ht
 
@@ -422,12 +424,12 @@ def main(args):
             exomes_ht = extract_freq_info(exomes_ht, pops, faf_pops, "exomes")
             genomes_ht = extract_freq_info(genomes_ht, pops, faf_pops, "genomes")
             ht = get_joint_freq_and_faf(genomes_ht, exomes_ht)
-            ht.write(res.freq_ht.path, overwrite=overwrite)
+            ht.write(res.combo_freq_ht.path, overwrite=overwrite)
 
         if args.perform_contingency_table_test:
             res = combine_faf_resources.contingency_table_test
             res.check_resource_existence()
-            ht = res.freq_ht.ht()
+            ht = res.combo_freq_ht.ht()
             ht = ht.select(
                 # TODO: this step is very slow, need to optimize
                 # run the whole pipeline for gene PCSK9 took ~27 min, this step took ~24

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -81,7 +81,8 @@ def extract_freq_info(
     """
     # logger.info("Filtering Table to only variants that are PASS...")
     # ht = ht.filter(hl.len(ht.filters) == 0)
-    # TODO: we won't have this in the final freq_ht
+    # TODO: we don't have this in the final freq_ht, but we will read in
+    #  variant_qc table and filter to PASS when this table is ready.
 
     def _get_pop_meta_indices(
         meta: hl.ArrayExpression, pop_list: List[str]

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -290,7 +290,7 @@ def get_combine_faf_resources(
                 "exomes_ht": get_freq(test=test, finalized=False)},
             "create_release_sites_ht_genomes.py": {
                 # TODO: "genomes_freq_ht": get_freq(test=test, data_type='genomes', finalized=True)},
-                "genomes_ht": release_sites(public=True).versions["3.1.2"]},
+                "genomes_ht": release_sites()},
         },
     )
     contingency_table_test = PipelineStepResourceCollection(

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -1,7 +1,6 @@
 """Script containing annotation related resources."""
 from typing import Optional
 
-from gnomad.resources.grch37.gnomad import EXOME_RELEASES, GENOME_RELEASES
 from gnomad.resources.grch38.gnomad import SUBSETS
 from gnomad.resources.resource_utils import (
     DataException,
@@ -295,6 +294,7 @@ def get_downsampling(
 
 def get_freq(
     version: str = CURRENT_VERSION,
+    data_type: str = "exomes",
     test: bool = False,
     hom_alt_adjusted=False,
     chrom: Optional[str] = None,
@@ -305,6 +305,7 @@ def get_freq(
     Get the frequency annotation table for a specified release.
 
     :param version: Version of annotation path to return.
+    :param data_type: Data type of annotation resource. e.g. "exomes" or "genomes".
     :param test: Whether to use a tmp path for tests.
     :param hom_alt_adjusted: Whether to return the hom alt adjusted frequency table.
     :param chrom: Chromosome to return frequency table for. Entire Table will be
@@ -314,7 +315,7 @@ def get_freq(
     :param finalized: Whether to return the finalized frequency table. Default is True.
     :return: Hail Table containing subset or overall cohort frequency annotations.
     """
-    ht_name = f"gnomad.exomes.v{version}.frequencies"
+    ht_name = f"gnomad.{data_type}.v{version}.frequencies"
     if not finalized:
         if chrom:
             ht_name += f".{chrom}"
@@ -324,13 +325,13 @@ def get_freq(
         ht_name += f".{intermediate_subset}"
         if test:
             ht_name += ".test"
-        ht_path = f"{_annotations_root(version, test)}/temp/{ht_name}.ht"
+        ht_path = f"{_annotations_root(version, test, data_type)}/temp/{ht_name}.ht"
     else:
         if finalized:
             ht_name += ".final"
         if test:
             ht_name += ".test"
-        ht_path = f"{_annotations_root(version, test)}/{ht_name}.ht"
+        ht_path = f"{_annotations_root(version, test, data_type)}/{ht_name}.ht"
 
     return VersionedTableResource(
         version, {version: TableResource(ht_path) for version in VERSIONS}

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Optional
 
-from gnomad.resources.grch38.gnomad import combined_faf, coverage, public_release
+from gnomad.resources.grch38.gnomad import coverage, public_release
 from gnomad.resources.resource_utils import (
     DataException,
     TableResource,
@@ -79,13 +79,13 @@ def combined_faf_release_ht_path(
         bucket. Default is False.
     :return: File path for desired combined genome + exome FAF release Hail Table.
     """
-    if public:
-        if file_exists(combined_faf().versions[release_version].path):
-            return combined_faf().versions[release_version].path
-        else:
-            return f"gs://gnomad-public-requester-pays/release/{release_version}/ht/joint/gnomad.joint.v{release_version}.faf.ht"
-    else:
-        return f"gs://gnomad/release/{release_version}/ht/joint/gnomad.joint.v{release_version}.faf.ht"
+    # if public:
+    #     if file_exists(combined_faf().versions[release_version].path):
+    #         return combined_faf().versions[release_version].path
+    #     else:
+    #         return f"gs://gnomad-public-requester-pays/release/{release_version}/ht/joint/gnomad.joint.v{release_version}.faf.ht"
+    # else:
+    return f"gs://gnomad/release/{release_version}/ht/joint/gnomad.joint.v{release_version}.faf.ht"
 
 
 def get_combined_faf_release(public: bool = False) -> VersionedTableResource:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -55,6 +55,8 @@ pyyaml==6.0.1
     # via pre-commit
 snowballstemmer==2.2.0
     # via pydocstyle
+statsmodels==0.14.0
+    # via -r requirements-dev.in
 tomlkit==0.12.1
     # via pylint
 virtualenv==20.24.3


### PR DESCRIPTION
This is based on Julia's PR #403 with some changes to use the freq_ht instead of release_ht, calculate faf and grpmax when it's not present in the prefixed freq_ht, rename the popmax to grpmax for v4, and test on one gene: PCSK9 (chr1:55039447-55064852). 