### PR TITLE
Finalize freq HT

### DIFF
--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -899,16 +899,6 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
     """
     Create final freq Table with only desired annotations.
 
-    Drop the following annotations:
-        - 'age_high_ab_hist', all annotations from the split VDSs....
-
-    Rename the following annotations:
-        - 'ab_adjusted_freq' -> 'freq'
-        - decide if we want to store uncorrected? Probably,just rename it.
-
-    Filter the following from the 'freq' field:
-        - gatk versions
-
     .. note::
 
         `pre_adjustment_freq` is the frequency annotation before any high AB het
@@ -916,7 +906,7 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
         the AF adjustment threshold.
 
     :param ht: Hail Table containing all annotations.
-    :return: Hail Table with only desired annotations.
+    :return: Hail Table with final annotations.
     """
     logger.info("Dropping gatk_version from freq ht array annotations...")
     freq_meta, array_exprs = filter_arrays_by_meta(

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -806,7 +806,7 @@ def correct_for_high_ab_hets(ht: hl.Table, af_threshold: float = 0.01) -> hl.Tab
             hl.struct(**no_ab_adjusted_expr),
         ),
     )
-
+    ht = ht.annotate_globals(af_threshold_for_freq_adjustment=af_threshold)
     return ht
 
 

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -934,6 +934,7 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
         freq_meta_sample_count=array_exprs["freq_meta_sample_count"],
         faf_meta=ht.index_globals().faf_meta,
         faf_index_dict=ht.index_globals().faf_index_dict,
+        age_distribution=ht.index_globals().age_distribution,
     )
 
     return ht

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -846,10 +846,11 @@ def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
         faf, faf_meta = faf_expr(freq, meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX)
         grpmax = pop_max_expr(freq, meta, POPS_TO_REMOVE_FOR_POPMAX)
         grpmax = grpmax.annotate(
+            gen_anc=grpmax.pop,
             faf95=faf[
                 hl.literal(faf_meta).index(lambda y: y.values() == ["adj", grpmax.pop])
-            ].faf95
-        )
+            ].faf95,
+        ).drop("pop")
         # Add subset back to non_ukb faf meta.
         if dataset == "non_ukb":
             faf_meta = [{**x, **{"subset": "non_ukb"}} for x in faf_meta]
@@ -888,7 +889,6 @@ def compute_inbreeding_coeff(ht: hl.Table) -> hl.Table:
 def create_final_freq_ht(ht: hl.Table) -> hl.Table:
     """
     Create final freq Table with only desired annotations.
-
 
     :param ht: Hail Table containing all annotations.
     :return: Hail Table with final annotations.

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -924,6 +924,8 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
         {
             "freq": ht.ab_adjusted_freq,
             "freq_meta_sample_count": ht.index_globals().freq_meta_sample_count,
+            "high_ab_hets_by_group": ht.high_ab_hets_by_group,
+            "pre_adjustment_freq": ht.freq,
         },
         items_to_filter=["gatk_version"],
         keep=False,
@@ -941,8 +943,8 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
                 "age_hists": ht.ab_adjusted_age_hists,
             },
         ),
-        pre_adjustment_freq=ht.freq,
-        high_ab_hets_by_group=ht.high_ab_hets_by_group,
+        pre_adjustment_freq=array_exprs["pre_adjustment_freq"],
+        high_ab_hets_by_group=array_exprs["high_ab_hets_by_group"],
     )
 
     ht = ht.select_globals(
@@ -1081,6 +1083,9 @@ def main(args):
 
         if args.finalize_freq_ht:
             logger.info("Writing final frequency Table...")
+            res = resources.finalize_freq_ht
+            res.check_resource_existence()
+            ht = res.corrected_freq_ht.ht()
             ht = create_final_freq_ht(ht)
 
             logger.info("Final frequency HT schema...")

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -918,13 +918,28 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
         ),
     )
 
+    def _replace_pop_key_w_gen_anc(
+        meta: hl.expr.ArrayExpression,
+    ) -> hl.expr.ArrayExpression:
+        """
+        Replace 'pop' key with 'gen_anc' key in meta globals.
+
+        :param meta: Array of dicts.
+        :return: Array of dicts with 'pop' key replaced with 'gen_anc' key.
+        """
+        return meta.map(
+            lambda d: hl.dict(
+                d.items().map(lambda x: hl.if_else(x[0] == "pop", ("gen_anc", x[1]), x))
+            )
+        )
+
     g = ht.index_globals()
     ht = ht.select_globals(
         downsamplings=g.downsamplings,
-        freq_meta=freq_meta,
+        freq_meta=_replace_pop_key_w_gen_anc(freq_meta),
         freq_index_dict=make_freq_index_dict_from_meta(freq_meta),
         freq_meta_sample_count=array_exprs["freq_meta_sample_count"],
-        faf_meta=g.faf_meta,
+        faf_meta=_replace_pop_key_w_gen_anc(g.faf_meta),
         faf_index_dict=g.faf_index_dict,
         age_distribution=g.age_distribution,
     )


### PR DESCRIPTION
This finalizes the freq HT. It renames the original and  adjusted freq annotations. It also drops any 'gatk_version' index from freq_meta, freq, high_ab_hets_by_group, pre_adjusted_freq, and freq_meta_sample_count. For now this stores the pre_adjusted freq but I'm wondering if we need to here since we currently have the preadjustment HT. If we want all the information in one place, we would need to store the preadjustment histograms as well so I will need to add that in. Alternatively, if we plan on keeping the full preadjustment HT around, I'm not sure we need the predajustment/high AB hets on this table but it was in the functions docstring todo placeholder so I left it for now.