### PR TITLE
Fix the NA bug in frequency adjustments

### DIFF
--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -797,7 +797,7 @@ def correct_for_high_ab_hets(ht: hl.Table, af_threshold: float = 0.01) -> hl.Tab
         "high_ab_hets_by_group",
         *FREQ_ROW_FIELDS,
         **hl.if_else(
-            (hl.is_defined(ht.freq[0].AF)) & (ht.freq[0].AF > 0.01),
+            (hl.is_defined(ht.freq[0].AF)) & (ht.freq[0].AF > af_threshold),
             hl.struct(
                 ab_adjusted_freq=call_stats_expr,
                 **qual_hist_expr,

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -797,13 +797,14 @@ def correct_for_high_ab_hets(ht: hl.Table, af_threshold: float = 0.01) -> hl.Tab
         "high_ab_hets_by_group",
         *FREQ_ROW_FIELDS,
         **hl.if_else(
-            (hl.is_defined(ht.freq[0].AF)) & (ht.freq[0].AF > af_threshold),
+            ht.freq[0].AF > af_threshold,
             hl.struct(
                 ab_adjusted_freq=call_stats_expr,
                 **qual_hist_expr,
                 ab_adjusted_age_hists=ht.high_ab_het_adjusted_age_hists,
             ),
             hl.struct(**no_ab_adjusted_expr),
+            missing_false=True,
         ),
     )
     ht = ht.annotate_globals(af_threshold_for_freq_adjustment=af_threshold)

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -797,7 +797,7 @@ def correct_for_high_ab_hets(ht: hl.Table, af_threshold: float = 0.01) -> hl.Tab
         "high_ab_hets_by_group",
         *FREQ_ROW_FIELDS,
         **hl.if_else(
-            ht.freq[0].AF > af_threshold,
+            (hl.is_defined(ht.freq[0].AF)) & (ht.freq[0].AF > 0.01),
             hl.struct(
                 ab_adjusted_freq=call_stats_expr,
                 **qual_hist_expr,


### PR DESCRIPTION
For any site with an adj AF of NA, the script was setting all fields to NA. This came down to the hl.if_else statement on the AF threshold -- If the conditional in hl.if_else is missing (AF[0] is often NA), everything got set to NA which was very unexpected but I guess NA is just that. I'll rerun the combine, adjustment, and finalize step of freq once this and the [merge_histogram bug](https://github.com/broadinstitute/gnomad_methods/pull/614) go in.