### PR TITLE
Add gen_anc_faf_max

### DIFF
--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -814,7 +814,7 @@ def correct_for_high_ab_hets(ht: hl.Table, af_threshold: float = 0.01) -> hl.Tab
 
 def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
     """
-    Compute filtering allele frequencies ('faf') and 'grpmax' with the AB-adjusted frequencies.
+    Compute filtering allele frequencies ('faf'), 'grpmax', and 'gen_anc_faf_max' with the AB-adjusted frequencies.
 
     :param ht: Hail Table containing 'freq', 'ab_adjusted_freq', 'high_ab_het'
         annotations.

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -818,7 +818,7 @@ def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
 
     :param ht: Hail Table containing 'freq', 'ab_adjusted_freq', 'high_ab_het'
         annotations.
-    :return: Hail Table with 'faf' and 'grpmax' annotations.
+    :return: Hail Table with 'faf', 'grpmax', and 'gen_anc_faf_max' annotations.
     """
     logger.info(
         "Filtering frequencies to just 'non_ukb' subset entries for 'faf' "
@@ -864,7 +864,7 @@ def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
         grpmax_exprs[dataset] = grpmax
         gen_anc_faf_max_exprs[dataset] = gen_anc_faf_max
 
-    logger.info("Annotating 'faf','grpmax', and 'gen_anc_faf_max'...")
+    logger.info("Annotating 'faf', 'grpmax', and 'gen_anc_faf_max'...")
     ht = ht.annotate(
         faf=hl.flatten(faf_exprs),
         grpmax=hl.struct(**grpmax_exprs),


### PR DESCRIPTION
This adds in the genetic ancestry group with the highest FAF per threshold and its value. This is different than grpmax which grabs the genetic ancestry group with the highest AF, and then also annotates its FAF. Highest AF does not equal highest FAF. 