### PR TITLE
Add HGDP +  1KG functions to determine relatedness to nonsubset and v4 duplicates

### DIFF
--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -112,7 +112,7 @@ def get_hgdp_tgp_related_to_nonsubset(
     ht = ht1.union(ht2)
     ht = ht.select(s=ht.s.replace("v3.1::", "")).key_by("s").distinct()
 
-    ht = ht.naive_coalese(1).checkpoint(new_temp_file("related_to_nonsubset_ht"))
+    ht = ht.naive_coalesce(1).checkpoint(new_temp_file("related_to_nonsubset_ht"))
     logger.info(
         "%d HGDP/1KG samples are related to samples outside the subset", ht.count()
     )
@@ -178,7 +178,7 @@ def get_hgdp_tgp_v4_exome_duplicates(
     ht = ht1.union(ht2)
     ht = ht.select(s=ht.s.replace("v3.1::", "")).key_by("s").distinct()
 
-    ht = ht.naive_coalese(1).checkpoint(new_temp_file("duplicate_in_v4_exomes"))
+    ht = ht.naive_coalesce(1).checkpoint(new_temp_file("duplicate_in_v4_exomes"))
     logger.info(
         "%d HGDP/1KG samples are duplicated in the v4 exomes release", ht.count()
     )

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -1,4 +1,4 @@
-"""Script to create release sites HT for v4 genomes."""
+"""Script to create release sites HT for v4.0 genomes."""
 
 import argparse
 import logging
@@ -128,13 +128,14 @@ def get_hgdp_tgp_v4_exome_duplicates(
     """
     Get the samples in the HGDP + 1KG subset that are duplicates of an exome in the v4.0 release.
 
-    .. note::
-
-        The duplicated samples are defined as samples that were HGDP + 1KG subset samples in the v3.1 release and are also in the v4.0 exomes release. The duplicated samples have to be removed because we will have combined frequencies from v4.0 exomes and genomes.
+    The duplicated samples are defined as samples that were HGDP + 1KG subset samples
+    in the v3.1 release and are also in the v4.0 exomes release. The duplicated samples
+    have to be removed because we will have combined frequencies rom v4.0 exomes and
+    genomes.
 
     :param v3_meta_ht: Table with the v3.1 release metadata.
     :param v4_meta_ht: Table with the v4.0 exomes release metadata.
-    :param rel_ht: Table with the v3.1.2 and v4 joint relatedness, it's based on
+    :param rel_ht: Table with the v3.1 and v4.0 joint relatedness, it's based on
         cuKING relatedness results.
     :return: Table with the samples in the HGDP + 1KG subset that are duplicates of an
         exome in the v4.0 exomes release.
@@ -188,6 +189,7 @@ def get_hgdp_tgp_v4_exome_duplicates(
 def get_v4_genomes_release_resources(overwrite: bool) -> PipelineResourceCollection:
     """
     Get PipelineResourceCollection for all resources needed to create the gnomAD v4.0 genomes release.
+
     :param overwrite: Whether to overwrite resources if they exist.
     :return: PipelineResourceCollection containing resources for all steps of the
         gnomAD v4.0 genomes release pipeline.
@@ -198,7 +200,7 @@ def get_v4_genomes_release_resources(overwrite: bool) -> PipelineResourceCollect
         overwrite=overwrite,
     )
 
-    # Create resource collection for each step of the v4 genomes release pipeline.
+    # Create resource collection for each step of the v4.0 genomes release pipeline.
     get_related_to_nonsubset = PipelineStepResourceCollection(
         "--get-related-to-nonsubset",
         input_resources={
@@ -219,7 +221,7 @@ def get_v4_genomes_release_resources(overwrite: bool) -> PipelineResourceCollect
         },
     )
 
-    # Add all steps to the gnomAD v4 genomes release pipeline resource collection.
+    # Add all steps to the gnomAD v4.0 genomes release pipeline resource collection.
     v4_genome_release_pipeline.add_steps(
         {
             "get_related_to_nonsubset": get_related_to_nonsubset,

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -193,15 +193,9 @@ def get_v4_genomes_release_resources(overwrite: bool) -> PipelineResourceCollect
         gnomAD v4 genomes release pipeline.
     """
     # Initialize gnomAD v4 genomes release pipeline resource collection.
-    hgdp_tgp_res = {
-        "meta_ht": hgdp_tgp_subset_annotations(sample=True).versions["3.1.2"],
-        "dense_mt": hgdp_tgp_subset(dense=True, public=True).versions["3.1.2"],
-        "sites_ht": release_sites(public=True).versions["3.1.2"],
-    }
     v4_genome_release_pipeline = PipelineResourceCollection(
         pipeline_name="gnomad_v4_genomes_release",
         overwrite=overwrite,
-        pipeline_resources={"Released HGDP + 1KG resources": hgdp_tgp_res},
     )
 
     # Create resource collection for each step of the v4 genomes release pipeline.

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -112,6 +112,7 @@ def get_hgdp_tgp_related_to_nonsubset(
     ht = ht1.union(ht2)
     ht = ht.select(s=ht.s.replace("v3.1::", "")).key_by("s").distinct()
 
+    ht = ht.naive_coalese(1).checkpoint(new_temp_file("related_to_nonsubset_ht"))
     logger.info(
         "%d HGDP/1KG samples are related to samples outside the subset", ht.count()
     )
@@ -177,6 +178,7 @@ def get_hgdp_tgp_v4_exome_duplicates(
     ht = ht1.union(ht2)
     ht = ht.select(s=ht.s.replace("v3.1::", "")).key_by("s").distinct()
 
+    ht = ht.naive_coalese(1).checkpoint(new_temp_file("duplicate_in_v4_exomes"))
     logger.info(
         "%d HGDP/1KG samples are duplicated in the v4 exomes release", ht.count()
     )
@@ -272,7 +274,7 @@ def main(args):
         ht.write(res.related_to_nonsubset_ht.path, overwrite=overwrite)
 
     if args.get_hgdp_tgp_v4_exome_duplicates:
-        res = v4_genome_release_resources.get_duplicated_to_exomes
+        res = v4_genome_release_resources.get_hgdp_tgp_v4_exome_duplicates
         res.check_resource_existence()
         ht = get_hgdp_tgp_v4_exome_duplicates(
             res.v3_meta_ht.ht(), res.v4_meta_ht.ht(), res.v4_relatedness_ht.ht()

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -1,5 +1,37 @@
 """Script to create release sites HT for v4 genomes."""
+
+import argparse
+import logging
+
 import hail as hl
+from gnomad.utils.slack import slack_notifications
+from hail.utils import new_temp_file
+
+from gnomad_qc.resource_utils import (
+    PipelineResourceCollection,
+    PipelineStepResourceCollection,
+)
+from gnomad_qc.slack_creds import slack_token
+from gnomad_qc.v3.resources.basics import meta as v3_meta
+from gnomad_qc.v3.resources.release import (
+    hgdp_tgp_subset,
+    hgdp_tgp_subset_annotations,
+    release_sites,
+)
+from gnomad_qc.v3.resources.sample_qc import relatedness as v3_relatedness
+from gnomad_qc.v4.resources.basics import meta as v4_meta
+from gnomad_qc.v4.resources.sample_qc import (
+    hgdp_tgp_duplicated_to_exomes,
+    hgdp_tgp_related_to_nonsubset,
+)
+from gnomad_qc.v4.resources.sample_qc import relatedness as v4_relatedness
+
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger = logging.getLogger(
+    "Create v4 genomes release sites HT with updated HGDP/TGP "
+    "metadata and new annotations"
+)
+logger.setLevel(logging.INFO)
 
 
 def remove_missing_vep_fields(vep_expr: hl.StructExpression) -> hl.StructExpression:
@@ -28,27 +60,207 @@ def remove_missing_vep_fields(vep_expr: hl.StructExpression) -> hl.StructExpress
     return vep_expr
 
 
-def replace_oth_with_remaining(ht: hl.Table) -> hl.Table:
+def get_hgdp_tgp_related_to_nonsubset(
+    v3_meta_ht: hl.Table, rel_ht: hl.Table
+) -> hl.Table:
     """
-    Replace 'oth' with 'remaining' in Global fields of a Table.
+    Get the samples in the HGDP + 1KG subset that were related to samples outside the subset in v3 release and were not included in the v3 release.
+
+    :param v3_meta_ht: Table with the v3.1 release metadata
+    :param rel_ht: Table with the v3.1 release relatedness, here we use the
+       results from pc_relate of the full dataset.
+    :return: Table with the samples in the HGDP + 1KG subset that are related
+       to samples outside the subset in v3 release.
+    """
+    v3_meta_ht = v3_meta_ht.select(
+        hgdp_tgp=v3_meta_ht.subsets.tgp | v3_meta_ht.subsets.hgdp,
+        release=v3_meta_ht.release,
+    ).select_globals()
+
+    # Samples that are either in the HGDP + 1KG subset or in the v3 release.
+    v3_meta_release_ht = v3_meta_ht.filter(v3_meta_ht.release | v3_meta_ht.hgdp_tgp)
+
+    rel_ht = rel_ht.annotate(
+        **{
+            f"{x}_meta": hl.struct(
+                v3_release=hl.coalesce(v3_meta_release_ht[rel_ht[x].s].release, False),
+                hgdp_tgp=hl.coalesce(v3_meta_release_ht[rel_ht[x].s].hgdp_tgp, False),
+            )
+            for x in ["i", "j"]
+        }
+    )
+
+    rel_ht = rel_ht.filter(
+        # Filter to pairs where at least one of the samples was in the v3 release.
+        (rel_ht.i_meta.v3_release | rel_ht.j_meta.v3_release)
+        # Filter to pairs with 2nd degree or closer relatedness.
+        & (rel_ht.relationship != "unrelated")
+        # Filter to pairs where one and only one of the samples is in the HGDP +
+        # 1KG subset.
+        & ((hl.int(rel_ht.i_meta.hgdp_tgp) + hl.int(rel_ht.j_meta.hgdp_tgp)) == 1)
+        # Exclude pairs where the HGDP/1KG sample in the pair is also a v3 release
+        # sample.
+        & ~(rel_ht.i_meta.hgdp_tgp & rel_ht.i_meta.v3_release)
+        & ~(rel_ht.j_meta.hgdp_tgp & rel_ht.j_meta.v3_release)
+    )
+
+    rel_ht = rel_ht.naive_coalesce(1)
+
+    rel_ht = rel_ht.checkpoint(
+        new_temp_file("hgdp_tgp_related_temp", extension="ht"), overwrite=True
+    )
+
+    ht1 = rel_ht.filter(rel_ht.i_meta.hgdp_tgp).key_by().select("i")
+    ht1 = ht1.select(s=ht1.i.s)
+
+    ht2 = rel_ht.filter(rel_ht.j_meta.hgdp_tgp).key_by().select("j")
+    ht2 = ht2.select(s=ht2.j.s)
+
+    ht = ht1.union(ht2)
+    ht = ht.select(s=ht.s.replace("v3.1::", "")).key_by("s").distinct()
+    return ht
+
+
+def get_hgdp_tgp_duplicated_to_exomes(
+    v3_meta: hl.Table,
+    v4_meta: hl.Table,
+    rel_ht: hl.Table,
+) -> hl.Table:
+    """
+    Get the samples in the HGDP + 1KG subset that were duplicated in the v4 exomes release.
 
     .. note::
-        This function renames v3 ancestry groups to match v4 exomes' ancestry groups.
-        The value of the key "pop" within `freq_meta` and the keys of `freq_index_dict`
-        that contain "oth" are replaced with "remaining".
 
-    :param ht: release sites Table to be modified.
-    :return: release sites Table with 'oth' replaced with 'remaining'.
+        The duplicated samples are defined as samples that were in the v3.1.2
+        subset release and are also in the v4 exomes release. The duplicated samples
+        have to be removed because we will have combined frequencies from v4 exomes
+        and genomes.
+
+    :param v3_meta: Table with the v3.1.2 release metadata
+    :param v4_meta: Table with the v4.0 exomes release metadata
+    :param rel_ht: Table with the v3.1.2 and v4 joint relatedness, it's based on
+        cuKing relatedness results.
+    :return: Table with the samples in the HGDP + 1KG subset that are duplicated in
+        the v4 exomes release.
     """
-    ht = ht.annotate_globals(
-        freq_meta=ht.freq_meta.map(
-            lambda d: d.map_values(lambda x: x.replace("oth", "remaining"))
-        ),
-        freq_index_dict=hl.dict(
-            hl.zip(
-                ht.freq_index_dict.keys().map(lambda k: k.replace("oth", "remaining")),
-                ht.freq_index_dict.values(),
-            )
-        ),
+    # get hgdp + 1kg subset samples in v3 meta
+    v3_meta = (
+        v3_meta.filter(v3_meta.subsets.hgdp | v3_meta.subsets.tgp)
+        .select()
+        .select_globals()
+    )
+
+    # get release samples in v4.0 exomes
+    v4_meta = v4_meta.filter(v4_meta.release).select().select_globals()
+
+    # Get samples that are in the v3 genomes and are also in the v4 exomes
+    rel_ht = rel_ht.filter(rel_ht.gnomad_v3_duplicate)
+
+    # Check if the duplicates are still included in v4 exomes release and these
+    # samples belong to the HGDP + 1KG subset.
+    ht = rel_ht.annotate(
+        in_v4_exomes_release=hl.is_defined(v4_meta[rel_ht.j.s]),
+        in_hgdp_tgp_subset=hl.is_defined(v3_meta[rel_ht.i.s]),
+    )
+
+    ht = ht.filter(ht.in_v4_exomes_release & ht.in_hgdp_tgp_subset)
+    ht = ht.key_by()
+    ht = ht.select(s=ht.i.s)
+    # in case some samples had a prefix in v3
+    ht = ht.select(s=ht.s.replace("v3.1::", "")).key_by("s").distinct()
+    logger.info(
+        "%d HGDP/TGP samples are duplicated in the v4 exomes release", ht.count()
     )
     return ht
+
+
+def get_v4_genomes_release_resources(overwrite: bool) -> PipelineResourceCollection:
+    """
+    Get PipelineResourceCollection for all resources needed to create the gnomAD v4 genomes release.
+
+    :param overwrite: Whether to overwrite resources if they exist.
+    :return: PipelineResourceCollection containing resources for all steps of the
+        gnomAD v4 genomes release pipeline.
+    """
+    # Initialize gnomAD v4 genomes release pipeline resource collection.
+    hgdp_tgp_res = {
+        "meta_ht": hgdp_tgp_subset_annotations(sample=True).versions["3.1.2"],
+        "dense_mt": hgdp_tgp_subset(dense=True, public=True).versions["3.1.2"],
+        "sites_ht": release_sites(public=True).versions["3.1.2"],
+    }
+    v4_genome_release_pipeline = PipelineResourceCollection(
+        pipeline_name="gnomad_v4_genomes_release",
+        overwrite=overwrite,
+        pipeline_resources={"Released HGDP + 1KG resources": hgdp_tgp_res},
+    )
+
+    # Create resource collection for each step of the v4 genomes release pipeline.
+
+    # Add all steps to the gnomAD v4 genomes release pipeline resource collection.
+    v4_genome_release_pipeline.add_steps({})
+
+    return v4_genome_release_pipeline
+
+
+def main(args):
+    """
+    Script to update call stats for HGDP + 1KG subset for v4.
+
+    This code is specifically designed for the update HGDP + 1KG subset in
+    v4 release HT. There are a few major changes compared to the v3 release:
+        - the following new sample filters are applied: hard filters, pop PC outliers,
+        relatedness within the subset and relatedness to the rest of the release.
+      - the new pop labels.
+      - the new split of the `Han` and `Papuan` samples.
+
+    In order to avoid re-calculating the callstats for the whole subset / whole
+    release, we will calculate the callstats for the samples that will be added
+    and subtracted, then merge the callstats with the old callstats in the
+    release HT.
+    """
+    overwrite = args.overwrite
+
+    hl.init(
+        log="/create_release_v4_genomes.log",
+        default_reference="GRCh38",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
+    v4_genome_release_resources = get_v4_genomes_release_resources(overwrite=overwrite)
+
+    if args.get_related_to_nonsubset:
+        ht = get_hgdp_tgp_related_to_nonsubset(v3_meta.ht(), v3_relatedness.ht())
+        ht.write(hgdp_tgp_related_to_nonsubset.path, overwrite=overwrite)
+
+    if args.get_duplicated_to_exomes:
+        ht = get_hgdp_tgp_duplicated_to_exomes(
+            v3_meta.ht(), v4_meta.ht(), v4_relatedness().ht()
+        )
+        ht.write(hgdp_tgp_duplicated_to_exomes.path, overwrite=overwrite)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="This script updates AFs for HGDP + 1KG subset for v4 release HT."
+    )
+    parser.add_argument("--overwrite", help="Overwrite data", action="store_true")
+    parser.add_argument(
+        "--slack-channel", help="Slack channel to post results and notifications to."
+    )
+    parser.add_argument(
+        "--get-related-to-nonsubset",
+        help="Get the relatedness to nonsubset samples.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--get-duplicated-to-exomes",
+        help="Get the duplicated samples to exomes.",
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+
+    if args.slack_channel:
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
+    else:
+        main(args)

--- a/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht_genomes.py
@@ -28,7 +28,7 @@ from gnomad_qc.v4.resources.sample_qc import relatedness as v4_relatedness
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(
-    "Create v4 genomes release sites HT with updated HGDP/TGP "
+    "Create v4.0 genomes release sites HT with updated HGDP/TGP "
     "metadata and new annotations"
 )
 logger.setLevel(logging.INFO)
@@ -89,10 +89,10 @@ def get_hgdp_tgp_related_to_nonsubset(
     )
 
     rel_ht = rel_ht.filter(
-        # Filter to pairs where at least one of the samples was in the v3.1 release.
-        (rel_ht.i_meta.v3_release | rel_ht.j_meta.v3_release)
         # Filter to pairs with 2nd degree or closer relatedness.
-        & (rel_ht.relationship != "unrelated")
+        (rel_ht.relationship != "unrelated")
+        # Filter to pairs where at least one of the samples was in the v3.1 release.
+        & (rel_ht.i_meta.v3_release | rel_ht.j_meta.v3_release)
         # Filter to pairs where one and only one of the samples is in the HGDP +
         # 1KG subset.
         & ((hl.int(rel_ht.i_meta.hgdp_tgp) + hl.int(rel_ht.j_meta.hgdp_tgp)) == 1)
@@ -126,21 +126,18 @@ def get_hgdp_tgp_v4_exome_duplicates(
     rel_ht: hl.Table,
 ) -> hl.Table:
     """
-    Get the samples in the HGDP + 1KG subset that are duplicates of an exome in the v4 release.
+    Get the samples in the HGDP + 1KG subset that are duplicates of an exome in the v4.0 release.
 
     .. note::
 
-        The duplicated samples are defined as samples that were in the v3.1.2
-        subset release and are also in the v4 exomes release. The duplicated samples
-        have to be removed because we will have combined frequencies from v4 exomes
-        and genomes.
+        The duplicated samples are defined as samples that were HGDP + 1KG subset samples in the v3.1 release and are also in the v4.0 exomes release. The duplicated samples have to be removed because we will have combined frequencies from v4.0 exomes and genomes.
 
-    :param v3_meta_ht: Table with the v3.1.2 release metadata.
+    :param v3_meta_ht: Table with the v3.1 release metadata.
     :param v4_meta_ht: Table with the v4.0 exomes release metadata.
     :param rel_ht: Table with the v3.1.2 and v4 joint relatedness, it's based on
         cuKING relatedness results.
     :return: Table with the samples in the HGDP + 1KG subset that are duplicates of an
-        exome in the v4 exomes release.
+        exome in the v4.0 exomes release.
     """
     # Get HGDP + 1KG subset samples in v3.1 meta.
     v3_meta_ht = v3_meta_ht.filter(v3_meta_ht.subsets.hgdp | v3_meta_ht.subsets.tgp)
@@ -148,7 +145,7 @@ def get_hgdp_tgp_v4_exome_duplicates(
     # Get release samples in v4.0 exomes.
     v4_meta_ht = v4_meta_ht.filter(v4_meta_ht.release)
 
-    # Get samples that are in the v3.1 genomes and are also in the v4 exomes.
+    # Get samples that are in the v3.1 genomes and are also in the v4.0 exomes.
     rel_ht = rel_ht.filter(rel_ht.gnomad_v3_duplicate)
 
     # Check if the duplicates are included in the v4.0 exomes release and belong to the
@@ -182,7 +179,7 @@ def get_hgdp_tgp_v4_exome_duplicates(
 
     ht = ht.naive_coalesce(1).checkpoint(new_temp_file("duplicate_in_v4_exomes"))
     logger.info(
-        "%d HGDP/1KG samples are duplicated in the v4 exomes release", ht.count()
+        "%d HGDP/1KG samples are duplicated in the v4.0 exomes release", ht.count()
     )
 
     return ht.select_globals()
@@ -190,13 +187,12 @@ def get_hgdp_tgp_v4_exome_duplicates(
 
 def get_v4_genomes_release_resources(overwrite: bool) -> PipelineResourceCollection:
     """
-    Get PipelineResourceCollection for all resources needed to create the gnomAD v4 genomes release.
-
+    Get PipelineResourceCollection for all resources needed to create the gnomAD v4.0 genomes release.
     :param overwrite: Whether to overwrite resources if they exist.
     :return: PipelineResourceCollection containing resources for all steps of the
-        gnomAD v4 genomes release pipeline.
+        gnomAD v4.0 genomes release pipeline.
     """
-    # Initialize gnomAD v4 genomes release pipeline resource collection.
+    # Initialize gnomAD v4.0 genomes release pipeline resource collection.
     v4_genome_release_pipeline = PipelineResourceCollection(
         pipeline_name="gnomad_v4_genomes_release",
         overwrite=overwrite,
@@ -288,7 +284,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="This script creates v4 genomes release HT."
+        description="This script creates v4.0 genomes release HT."
     )
     parser.add_argument("--overwrite", help="Overwrite data", action="store_true")
     parser.add_argument(

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1008,14 +1008,14 @@ def get_sample_qc_field_def_json_path(version: str = CURRENT_VERSION) -> str:
     return f"{get_sample_qc_root(version)}/additional_resources/gnomad.exomes.v{version}.sample_qc_field_definitions.json"
 
 
-# Table with the HGDP+ 1KG/TGP samples that are not related within the
+# Table with the HGDP + 1KG/TGP samples that are not related within the
 # subset but are related to any v3.1 release sample outside the subset and
 # were not included in the v3.1 release.
 hgdp_tgp_related_to_nonsubset = TableResource(
     path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_related_to_nonsubset.ht",
 )
 
-# List of HGDP+ 1KG/TGP samples that are duplicated in the v4.0 exome release.
+# List of HGDP + 1KG/TGP samples that are duplicated in the v4.0 exome release.
 hgdp_tgp_duplicated_to_exomes = TableResource(
     path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_duplicated_in_exomes.ht",
 )

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1006,3 +1006,16 @@ def get_sample_qc_field_def_json_path(version: str = CURRENT_VERSION) -> str:
     :return: Path to sample QC field definitions JSON.
     """
     return f"{get_sample_qc_root(version)}/additional_resources/gnomad.exomes.v{version}.sample_qc_field_definitions.json"
+
+
+# Table with the HGDP+ 1KG/TGP samples that are not related within the
+# subset but are related to any v3.1 release sample outside the subset and
+# were not included in the v3.1 release.
+hgdp_tgp_related_to_nonsubset = TableResource(
+    path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_related_to_nonsubset.ht",
+)
+
+# List of HGDP+ 1KG/TGP samples that are duplicated in the v4.0 exome release.
+hgdp_tgp_duplicated_to_exomes = TableResource(
+    path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_duplicated_in_exomes.ht",
+)


### PR DESCRIPTION
Starting to get in functions from this PR: https://github.com/broadinstitute/gnomad_qc/pull/390 in a more modular way. 

This contains the functions for determining related HGDP + 1KG samples to other v3 or v4 release samples and should therefore not be added to the v4 genome set.

The first commit is basically a copy from the above PR, and any commits after that are my suggested changes.