### PR TITLE
Make VRS batch code more general on input and output

### DIFF
--- a/gnomad_qc/v4/annotations/Dockerfile_vrs084
+++ b/gnomad_qc/v4/annotations/Dockerfile_vrs084
@@ -97,9 +97,9 @@ RUN python3 -m pip install --upgrade pip
 # Install hail and other python libraries
 # Including packages needed for VRS annotation functionality
 # Also include version for ga4gh.vrs-python to be most recent and supporting their new variant schema
-# Please update the constant VRS_VERSION in vrs_annotation_batch.py accordingly when GA4GH_VRS_VERSION is changed
+# Please update the constant VRS_PYTHON_VERSION in vrs_annotation_batch.py accordingly when GA4GH_VRS_PYTHON_VERSION is changed
 ENV HAIL_VERSION="0.2.122"
-ENV GA4GH_VRS_VERSION="0.8.4"
+ENV GA4GH_VRS_PYTHON_VERSION="0.8.4"
 RUN python3 --version
 RUN python3 -m pip install --ignore-installed PyYAML
 RUN python3 -m pip install \
@@ -115,7 +115,7 @@ RUN python3 -m pip install \
     pybedtools \
     dill \
     psycopg2 \
-    ga4gh.vrs[extras]==${GA4GH_VRS_VERSION}  \
+    ga4gh.vrs[extras]==${GA4GH_VRS_PYTHON_VERSION}  \
     seqrepo \
     click \
     git+https://github.com/broadinstitute/gnomad_methods.git@main \

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -167,18 +167,16 @@ def main(args):
 
     working_bucket = args.working_bucket
     data_type = args.data_type
-
-    input_path = v4_input_ht(data_type=data_type).path or args.input_path
-    output_vrs_path = (
-        v4_vrs_annotations(test=args.test, data_type=data_type).path
-        or args.output_vrs_path
-    )
-    output_vrs_anno_ori_path = (
-        v4_vrs_annotations(
+    if args.input_path is not None:
+        input_path = args.input_path
+        output_vrs_path = args.output_vrs_path
+        output_vrs_anno_ori_path = args.output_vrs_anno_ori_path
+    else:
+        input_path = v4_input_ht(data_type=data_type).path
+        output_vrs_path = v4_vrs_annotations(test=args.test, data_type=data_type).path
+        output_vrs_anno_ori_path = v4_vrs_annotations(
             test=args.test, data_type=data_type, original_annotations=True
         ).path
-        or args.output_vrs_anno_ori_path
-    )
 
     # Read in Hail Table, partition, and export to sharded VCF
     ht_original = hl.read_table(input_path)
@@ -417,18 +415,14 @@ if __name__ == "__main__":
         default=None,
         type=int,
     )
-    parser.add_argument(
+    input_args = parser.add_mutually_exclusive_group(required=True)
+    input_args.add_argument(
         "--data-type",
         help="Data type to annotate (exomes or genomes).",
         default="exomes",
         choices=["exomes", "genomes"],
     )
-    parser.add_argument(
-        "--test",
-        help="Fiter to only 200 partitions for testing purposes.",
-        action="store_true",
-    )
-    parser.add_argument(
+    input_args.add_argument(
         "--input-path",
         help="Full path of Hail Table to annotate.",
         type=str,
@@ -445,6 +439,11 @@ if __name__ == "__main__":
         help="Full path of Hail Table to write VRS annotations to.",
         type=str,
         default=None,
+    )
+    parser.add_argument(
+        "--test",
+        help="Fiter to only 200 partitions for testing purposes.",
+        action="store_true",
     )
     parser.add_argument(
         "--header-path",

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -204,7 +204,7 @@ def main(args):
         check_resource_existence(
             output_step_resources={
                 "--run-vrs": [
-                    v4_vrs_annotations(test=args.test).path,
+                    v4_vrs_annotations(test=args.test, data_type=args.data_type).path,
                 ],
             },
             overwrite=args.overwrite,
@@ -338,12 +338,12 @@ def main(args):
 
         # Checkpoint (write) resulting annotated table
         ht_annotated = ht_annotated.checkpoint(
-            v4_vrs_annotations(test=args.test).path,
+            v4_vrs_annotations(test=args.test, data_type=args.data_type).path,
             overwrite=args.overwrite,
         )
         logger.info(
             "Annotated Hail Table checkpointed to:"
-            f" {v4_vrs_annotations(test=args.test).path}"
+            f" {v4_vrs_annotations(test=args.test, data_type=args.data_type).path}"
         )
 
     if args.annotate_original:
@@ -352,7 +352,9 @@ def main(args):
         ).path
         check_resource_existence(
             input_step_resources={
-                "--run-vrs": [v4_vrs_annotations(test=args.test).path],
+                "--run-vrs": [
+                    v4_vrs_annotations(test=args.test, data_type=args.data_type).path
+                ],
             },
             output_step_resources={
                 "--annotate-original": [output_path],
@@ -361,7 +363,9 @@ def main(args):
         )
 
         # Output final Hail Tables with VRS annotations
-        ht_annotated = hl.read_table(v4_vrs_annotations(test=args.test).path)
+        ht_annotated = hl.read_table(
+            v4_vrs_annotations(test=args.test, data_type=args.data_type).path
+        )
 
         logger.info("Adding VRS IDs and GA4GH.VRS version to original Table")
         ht_final = ht_original.annotate(

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -17,6 +17,7 @@ gnomad_qc/gnomad_qc/v4/annotations/vrs_annotation_batch.py \
 --annotate-original \
 --overwrite \
 --backend-mode batch \
+--data-type exomes \
 --test
 """
 
@@ -164,7 +165,7 @@ def main(args):
 
     working_bucket = args.working_bucket
 
-    input_path = v4_input_ht().path
+    input_path = v4_input_ht(data_type=args.data_type).path
 
     # Read in Hail Table, partition, and export to sharded VCF
     ht_original = hl.read_table(input_path)
@@ -344,7 +345,9 @@ def main(args):
         )
 
     if args.annotate_original:
-        output_path = v4_vrs_annotations(test=args.test, original_annotations=True).path
+        output_path = v4_vrs_annotations(
+            test=args.test, data_type=args.data_type, original_annotations=True
+        ).path
         check_resource_existence(
             input_step_resources={
                 "--run-vrs": [v4_vrs_annotations(test=args.test).path],
@@ -400,6 +403,12 @@ if __name__ == "__main__":
         ),
         default=None,
         type=int,
+    )
+    parser.add_argument(
+        "--data-type",
+        help="Data type to annotate (exomes or genomes).",
+        default="exomes",
+        choices=["exomes", "genomes"],
     )
     parser.add_argument(
         "--test",

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -166,8 +166,9 @@ def main(args):
     ht_example.show()
 
     working_bucket = args.working_bucket
+    data_type = args.data_type
 
-    input_path = v4_input_ht(data_type=args.data_type).path
+    input_path = v4_input_ht(data_type=data_type).path
 
     # Read in Hail Table, partition, and export to sharded VCF
     ht_original = hl.read_table(input_path)
@@ -204,7 +205,7 @@ def main(args):
         check_resource_existence(
             output_step_resources={
                 "--run-vrs": [
-                    v4_vrs_annotations(test=args.test, data_type=args.data_type).path,
+                    v4_vrs_annotations(test=args.test, data_type=data_type).path,
                 ],
             },
             overwrite=args.overwrite,
@@ -338,22 +339,22 @@ def main(args):
 
         # Checkpoint (write) resulting annotated table
         ht_annotated = ht_annotated.checkpoint(
-            v4_vrs_annotations(test=args.test, data_type=args.data_type).path,
+            v4_vrs_annotations(test=args.test, data_type=data_type).path,
             overwrite=args.overwrite,
         )
         logger.info(
             "Annotated Hail Table checkpointed to:"
-            f" {v4_vrs_annotations(test=args.test, data_type=args.data_type).path}"
+            f" {v4_vrs_annotations(test=args.test, data_type=data_type).path}"
         )
 
     if args.annotate_original:
         output_path = v4_vrs_annotations(
-            test=args.test, data_type=args.data_type, original_annotations=True
+            test=args.test, data_type=data_type, original_annotations=True
         ).path
         check_resource_existence(
             input_step_resources={
                 "--run-vrs": [
-                    v4_vrs_annotations(test=args.test, data_type=args.data_type).path
+                    v4_vrs_annotations(test=args.test, data_type=data_type).path
                 ],
             },
             output_step_resources={
@@ -364,7 +365,7 @@ def main(args):
 
         # Output final Hail Tables with VRS annotations
         ht_annotated = hl.read_table(
-            v4_vrs_annotations(test=args.test, data_type=args.data_type).path
+            v4_vrs_annotations(test=args.test, data_type=data_type).path
         )
 
         logger.info("Adding VRS IDs and GA4GH.VRS version to original Table")

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -42,7 +42,9 @@ logger.setLevel(logging.INFO)
 # Define the version of ga4gh.vrs code this was run on,
 # as present in the Dockerfile
 # Please change this when the Dockerfile is updated
-VRS_VERSION = "0.8.4"
+VRS_SCHEMA_VERSION = "1.3.0"
+VRS_PYTHON_VERSION = "0.8.4"
+SEQREPO_VERSION = "2018-11-26"
 
 
 def init_job(
@@ -366,7 +368,13 @@ def main(args):
             info=hl.struct(vrs=ht_annotated[ht_original.locus, ht_original.alleles].vrs)
         )
 
-        ht_final = ht_final.annotate_globals(vrs_version=VRS_VERSION)
+        ht_final = ht_final.annotate_globals(
+            vrs_version=hl.struct(
+                vrs_schema_version=VRS_SCHEMA_VERSION,
+                vrs_python_version=VRS_PYTHON_VERSION,
+                seqrepo_version=SEQREPO_VERSION,
+            )
+        )
 
         logger.info(f"Outputting final table at: {output_path}")
         ht_final.write(output_path, overwrite=args.overwrite)

--- a/gnomad_qc/v4/annotations/vrs_annotation_batch.py
+++ b/gnomad_qc/v4/annotations/vrs_annotation_batch.py
@@ -168,6 +168,11 @@ def main(args):
     working_bucket = args.working_bucket
     data_type = args.data_type
     if args.input_path is not None:
+        if args.output_vrs_path is None or args.output_vrs_anno_ori_path is None:
+            raise ValueError(
+                "If --input-path is provided, --output-vrs-path and"
+                " --output-vrs-anno-ori-path must also be provided"
+            )
         input_path = args.input_path
         output_vrs_path = args.output_vrs_path
         output_vrs_anno_ori_path = args.output_vrs_anno_ori_path
@@ -419,7 +424,6 @@ if __name__ == "__main__":
     input_args.add_argument(
         "--data-type",
         help="Data type to annotate (exomes or genomes).",
-        default="exomes",
         choices=["exomes", "genomes"],
     )
     input_args.add_argument(
@@ -436,7 +440,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--output-vrs-anno-ori-path",
-        help="Full path of Hail Table to write VRS annotations to.",
+        help=(
+            "Full path of Hail Table to write VRS annotations with the original "
+            "annotations added back."
+        ),
         type=str,
         default=None,
     )


### PR DESCRIPTION
I added the options to launch the batch code on either exomes or genomes vep_ht input, but as of Hail 0.2.122, Hail Batch seems still flaky to run on >100k partitions, I tried on genomes but it failed, so I changed the code a bit to use input and output paths as we want. 
I also put the versions in globals. 