### PR TITLE
Code to update v4 genome sample_qc metadata

### DIFF
--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -385,14 +385,16 @@ def get_logging_path(name: str, version: str = CURRENT_VERSION) -> str:
     return f"{qc_temp_prefix(version)}{name}.log"
 
 
-def add_meta(mt: hl.MatrixTable, meta_name: str = "meta") -> hl.MatrixTable:
+def add_meta(
+    mt: hl.MatrixTable, version: str = CURRENT_VERSION, meta_name: str = "meta"
+) -> hl.MatrixTable:
     """
     Add metadata to MT in 'meta_name' column.
 
     :param mt: MatrixTable to which 'meta_name' annotation should be added
     :return: MatrixTable with metadata added in a 'meta' column
     """
-    mt = mt.annotate_cols(**{meta_name: meta().ht()[mt.col_key]})
+    mt = mt.annotate_cols(**{meta_name: meta(version=version).ht()[mt.col_key]})
 
     return mt
 

--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -249,7 +249,7 @@ def get_gnomad_v4_vds(
         if test:
             meta_ht = gnomad_v4_testset_meta.ht()
         else:
-            meta_ht = meta.ht()
+            meta_ht = meta().ht()
         filter_expr = meta_ht.release
         if keep_controls:
             filter_expr |= hl.literal(TRUTH_SAMPLES_S).contains(meta_ht.s)
@@ -261,7 +261,7 @@ def get_gnomad_v4_vds(
 
     if annotate_meta:
         logger.info("Annotating VDS variant_data with metadata...")
-        meta_ht = meta.ht()
+        meta_ht = meta().ht()
         vds = hl.vds.VariantDataset(
             vds.reference_data,
             vds.variant_data.annotate_cols(meta=meta_ht[vds.variant_data.col_key]),
@@ -395,7 +395,7 @@ def add_meta(
     :param version: Version of metadata ht to use for annotations
     :return: MatrixTable with metadata added in a 'meta' column
     """
-    mt = mt.annotate_cols(**{meta_name: meta.versions[version].ht()[mt.col_key]})
+    mt = mt.annotate_cols(**{meta_name: meta().versions[version].ht()[mt.col_key]})
 
     return mt
 

--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -385,17 +385,14 @@ def get_logging_path(name: str, version: str = CURRENT_VERSION) -> str:
     return f"{qc_temp_prefix(version)}{name}.log"
 
 
-def add_meta(
-    mt: hl.MatrixTable, version: str = CURRENT_VERSION, meta_name: str = "meta"
-) -> hl.MatrixTable:
+def add_meta(mt: hl.MatrixTable, meta_name: str = "meta") -> hl.MatrixTable:
     """
     Add metadata to MT in 'meta_name' column.
 
     :param mt: MatrixTable to which 'meta_name' annotation should be added
-    :param version: Version of metadata ht to use for annotations
     :return: MatrixTable with metadata added in a 'meta' column
     """
-    mt = mt.annotate_cols(**{meta_name: meta().versions[version].ht()[mt.col_key]})
+    mt = mt.annotate_cols(**{meta_name: meta().ht()[mt.col_key]})
 
     return mt
 

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -61,8 +61,8 @@ def meta(
     )
 
 
-# This is used in `meta()` function anymore but is kept here to quickly get the current
-# existing versions of sample metadata.
+# This isn't used in `meta()` function anymore but is kept here to quickly get the
+# currently existing versions of sample metadata.
 _meta_versions = {
     "exomes": {
         "4.0": TableResource(

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -1,7 +1,8 @@
 """Script containing metadata related resources."""
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 
-from gnomad_qc.v4.resources.constants import CURRENT_VERSION, VERSIONS
+from gnomad_qc.resource_utils import check_resource_existence
+from gnomad_qc.v4.resources.constants import CURRENT_VERSION
 
 
 def _meta_root_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> str:
@@ -29,23 +30,31 @@ def meta_tsv_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> 
     )
 
 
-def meta(data_type: str = "exomes") -> VersionedTableResource:
+def meta(
+    version: str = CURRENT_VERSION, data_type: str = "exomes", overwrite: bool = False
+) -> TableResource:
     """
     Get the gnomAD v4 sample QC meta VersionedTableResource.
 
+    :param version: Version of meta that corresponds to its data type.
     :param data_type: Data type ("exomes" or "genomes"). Default is "exomes".
+    :param overwrite: Whether to overwrite existing resources.
     :return: gnomAD v4 sample meta VersionedTableResource.
     """
-    return VersionedTableResource(
-        CURRENT_VERSION,
-        {
-            version: TableResource(
-                path=(
-                    f"{_meta_root_path(version, data_type)}/gnomad.{data_type}.v{version}.sample_qc_metadata.ht"
-                )
-            )
-            for version in VERSIONS
+    # Check if the meta Table exists
+    check_resource_existence(
+        output_step_resources={
+            f"{data_type}_{version}": [
+                f"{_meta_root_path(version, data_type)}/gnomad.{data_type}.v{version}.sample_qc_metadata.ht"
+            ],
         },
+        overwrite=overwrite,
+    )
+
+    return TableResource(
+        path=(
+            f"{_meta_root_path(version, data_type)}/gnomad.{data_type}.v{version}.sample_qc_metadata.ht"
+        )
     )
 
 

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -9,7 +9,7 @@ def _meta_root_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -
     Retrieve the path to the root metadata directory.
 
     :param version: gnomAD version.
-    :param data_type: Data type (exomes or genomes), defaults to exomes.
+    :param data_type: Data type ("exomes" or "genomes"). Default is "exomes".
     :return: String representation of the path to the root metadata directory.
     """
     return f"gs://gnomad/v{version}/metadata/{data_type}"
@@ -20,8 +20,8 @@ def meta_tsv_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> 
     Get the path to the finalized sample metadata information after sample QC.
 
     :param version: gnomAD version.
-    :param data_type: Data type (exomes or genomes), defaults to exomes.
-    :return: String path to the finalized metadata.
+    :param data_type: Data type ("exomes" or "genomes"). Default is "exomes".
+    :return: String path to the finalized metadata TSV.
     """
     return (
         f"{_meta_root_path(version, data_type)}/gnomad.{data_type}."
@@ -33,9 +33,8 @@ def meta(data_type: str = "exomes") -> VersionedTableResource:
     """
     Get the gnomAD v4 sample QC meta VersionedTableResource.
 
-    :param data_type: Data type of annotation resource. e.g. "exomes" or "genomes".
-       Default is "exomes".
-    :return: gnomAD v4 meta VersionedTableResource.
+    :param data_type: Data type ("exomes" or "genomes"). Default is "exomes".
+    :return: gnomAD v4 sample meta VersionedTableResource.
     """
     return VersionedTableResource(
         CURRENT_VERSION,
@@ -50,6 +49,7 @@ def meta(data_type: str = "exomes") -> VersionedTableResource:
     )
 
 
+# The following variables only apply to "exomes" data.
 _project_meta_versions = {
     "4.0": TableResource(
         path="gs://gnomad/v4.0/metadata/exomes/gnomad.exomes.v4.0.project_meta.ht"

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -23,7 +23,10 @@ def meta_tsv_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> 
     :param data_type: Data type (exomes or genomes), defaults to exomes.
     :return: String path to the finalized metadata.
     """
-    return f"{_meta_root_path(version)}/gnomad.{data_type}.v{version}.metadata.tsv.gz"
+    return (
+        f"{_meta_root_path(version, data_type)}/gnomad.{data_type}."
+        f"v{version}.metadata.tsv.gz"
+    )
 
 
 def meta(data_type: str = "exomes") -> VersionedTableResource:

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -61,6 +61,21 @@ def meta(
     )
 
 
+# This is used in `meta()` function anymore but is kept here to quickly get the current
+# existing versions of sample metadata.
+_meta_versions = {
+    "exomes": {
+        "4.0": TableResource(
+            path="gs://gnomad/v4.0/metadata/exomes/gnomad.exomes.v4.0.sample_qc_metadata.ht"
+        ),
+    },
+    "genomes": {
+        "4.0": TableResource(
+            path="gs://gnomad/v4.0/metadata/genomes/gnomad.genomes.v4.0.sample_qc_metadata.ht"
+        ),
+    },
+}
+
 # The following variables only apply to "exomes" data.
 _project_meta_versions = {
     "4.0": TableResource(

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -31,24 +31,27 @@ def meta_tsv_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> 
 
 
 def meta(
-    version: str = CURRENT_VERSION, data_type: str = "exomes", overwrite: bool = False
+    version: str = CURRENT_VERSION,
+    data_type: str = "exomes",
 ) -> TableResource:
     """
     Get the gnomAD v4 sample QC meta VersionedTableResource.
 
-    :param version: Version of meta that corresponds to its data type.
+    Function will check that metadata exists for the requested gnomAD version and data type
+    and will throw an error if it already exists.
+
+    :param version: gnomAD version.
     :param data_type: Data type ("exomes" or "genomes"). Default is "exomes".
-    :param overwrite: Whether to overwrite existing resources.
     :return: gnomAD v4 sample meta VersionedTableResource.
     """
-    # Check if the meta Table exists
+    # Check if the meta Table exists for specified version and data type combination
     check_resource_existence(
         output_step_resources={
             f"{data_type}_{version}": [
                 f"{_meta_root_path(version, data_type)}/gnomad.{data_type}.v{version}.sample_qc_metadata.ht"
             ],
         },
-        overwrite=overwrite,
+        overwrite=False,
     )
 
     return TableResource(

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -38,7 +38,7 @@ def meta(
     Get the gnomAD v4 sample QC meta VersionedTableResource.
 
     Function will check that metadata exists for the requested gnomAD version and data type
-    and will throw an error if it already exists.
+    and will throw an error if it doesn't exist.
 
     :param version: gnomAD version.
     :param data_type: Data type ("exomes" or "genomes"). Default is "exomes".
@@ -46,7 +46,7 @@ def meta(
     """
     # Check if the meta Table exists for specified version and data type combination
     check_resource_existence(
-        output_step_resources={
+        input_step_resources={
             f"{data_type}_{version}": [
                 f"{_meta_root_path(version, data_type)}/gnomad.{data_type}.v{version}.sample_qc_metadata.ht"
             ],

--- a/gnomad_qc/v4/resources/meta.py
+++ b/gnomad_qc/v4/resources/meta.py
@@ -1,34 +1,51 @@
 """Script containing metadata related resources."""
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 
-from gnomad_qc.v4.resources.constants import CURRENT_VERSION
+from gnomad_qc.v4.resources.constants import CURRENT_VERSION, VERSIONS
 
 
-def _meta_root_path(version: str = CURRENT_VERSION) -> str:
+def _meta_root_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> str:
     """
     Retrieve the path to the root metadata directory.
 
-    :param version: gnomAD version
-    :return: String representation of the path to the root metadata directory
+    :param version: gnomAD version.
+    :param data_type: Data type (exomes or genomes), defaults to exomes.
+    :return: String representation of the path to the root metadata directory.
     """
-    return f"gs://gnomad/v{version}/metadata/exomes"
+    return f"gs://gnomad/v{version}/metadata/{data_type}"
 
 
-def meta_tsv_path(version: str = CURRENT_VERSION) -> str:
+def meta_tsv_path(version: str = CURRENT_VERSION, data_type: str = "exomes") -> str:
     """
     Get the path to the finalized sample metadata information after sample QC.
 
-    :param version: gnomAD version
-    :return: String path to the finalized metadata
+    :param version: gnomAD version.
+    :param data_type: Data type (exomes or genomes), defaults to exomes.
+    :return: String path to the finalized metadata.
     """
-    return f"{_meta_root_path(version)}/gnomad.exomes.v{version}.metadata.tsv.gz"
+    return f"{_meta_root_path(version)}/gnomad.{data_type}.v{version}.metadata.tsv.gz"
 
 
-_meta_versions = {
-    "4.0": TableResource(
-        path="gs://gnomad/v4.0/metadata/exomes/gnomad.exomes.v4.0.sample_qc_metadata.ht"
-    ),
-}
+def meta(data_type: str = "exomes") -> VersionedTableResource:
+    """
+    Get the gnomAD v4 sample QC meta VersionedTableResource.
+
+    :param data_type: Data type of annotation resource. e.g. "exomes" or "genomes".
+       Default is "exomes".
+    :return: gnomAD v4 meta VersionedTableResource.
+    """
+    return VersionedTableResource(
+        CURRENT_VERSION,
+        {
+            version: TableResource(
+                path=(
+                    f"{_meta_root_path(version, data_type)}/gnomad.{data_type}.v{version}.sample_qc_metadata.ht"
+                )
+            )
+            for version in VERSIONS
+        },
+    )
+
 
 _project_meta_versions = {
     "4.0": TableResource(
@@ -48,7 +65,6 @@ _gatk_versions = {
     )
 }
 
-meta = VersionedTableResource(CURRENT_VERSION, _meta_versions)
 project_meta = VersionedTableResource(CURRENT_VERSION, _project_meta_versions)
 picard_metrics = VersionedTableResource(CURRENT_VERSION, _picard_metric_versions)
 gatk_versions = VersionedTableResource(CURRENT_VERSION, _gatk_versions)

--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht.py
@@ -723,7 +723,7 @@ def main(args):
         **ht.index_globals(),
         date=datetime.now().isoformat(),
     )
-    ht = ht.checkpoint(meta.path, overwrite=args.overwrite)
+    ht = ht.checkpoint(meta().path, overwrite=args.overwrite)
 
     logger.info(
         "Release sample count: %s", ht.aggregate(hl.agg.count_where(ht.release))

--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
@@ -8,11 +8,11 @@ The main updates from v3.1 to v4.0 are due to the following updates in the HGDP 
 The 169 samples added were diverse HGDP/TGP samples in v3.1 that were unintentionally removed during sample outlier detection.
 
 The 110 samples were removed due to the following reasons:
-- Contamination flagged by CHARR.
+- Contamination flagged by CHARR (CHARR score stored in `freemix` column).
 - Subcontinental PCA outliers within the subset.
 - Updated relatedness results within the subset, re-evaluation of relatedness
   inference of the subset to the rest of gnomAD release samples, and removal of any
-  that are duplicates of v4.0 exomes release samples.
+  samples that are duplicates of v4.0 exomes release samples.
 
 All samples impacted (169 added, 110 released) are releasable; the updates we made here were to their sample QC status (high quality vs filtered).
 """
@@ -35,6 +35,11 @@ from gnomad_qc.v4.resources.sample_qc import hgdp_tgp_meta_updated
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger("create_v4_genomes_sample_meta")
 logger.setLevel(logging.INFO)
+
+N_DIFF_SAMPLES = 169 - 110
+"""
+The number of samples that have been updated between v3.1 and v4.0.
+"""
 
 
 def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
@@ -99,7 +104,7 @@ def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
         release_v3,
         release_v4,
     )
-    if release_v4 <= release_v3 or release_v4 != release_v3 + 169 - 110:
+    if release_v4 <= release_v3 or release_v4 != release_v3 + N_DIFF_SAMPLES:
         raise ValueError("Number of release samples in v4.0 is not as expected.")
 
     return ht
@@ -119,7 +124,10 @@ def main(args):
     logger.info("Updating annotations...")
     ht = import_updated_annotations(ht, subset_ht)
     logger.info("Writing HT and exporting TSV...")
-    ht.write(v4_meta(data_type="genomes").path, overwrite=args.overwrite)
+    ht.write(
+        v4_meta(data_type="genomes", overwrite=args.overwrite).path,
+        overwrite=args.overwrite,
+    )
     ht.export(v4_meta_tsv_path(data_type="genomes"), delimiter="\t")
 
 

--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
@@ -1,10 +1,20 @@
 """
 Script to create sample QC metadata HT for genomes.
 
-This script is used to create the sample QC metadata HT for genomes. The main updates
-from v3.1 to v4.0 are:
-Sample QC annotations for HGDP + TGP subset, this script directly merges the updated
-annotations from the subset meta HT to the full meta HT.
+The main updates from v3.1 to v4.0 are due to the following updates in the HGDP + TGP subset meta:
+- 169 samples added
+- 110 samples removed
+
+The 169 samples added were diverse HGDP/TGP samples in v3.1 that were unintentionally removed during sample outlier detection.
+
+The 110 samples were removed due to the following reasons:
+- Contamination flagged by CHARR.
+- Subcontinental PCA outliers within the subset.
+- Updated relatedness results within the subset, re-evaluation of relatedness
+  inference of the subset to the rest of gnomAD release samples, and removal of any
+  that are duplicates of v4.0 exomes release samples.
+
+All samples impacted (169 added, 110 released) are releasable; the updates we made here were to their sample QC status (high quality vs filtered).
 """
 
 
@@ -13,41 +23,36 @@ import logging
 
 import hail as hl
 from gnomad.resources.resource_utils import TableResource
+from gnomad.utils.slack import slack_notifications
 from hail.utils import new_temp_file
 
+from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v3.resources.basics import meta as v3_meta
 from gnomad_qc.v4.resources.meta import meta as v4_meta
 from gnomad_qc.v4.resources.meta import meta_tsv_path as v4_meta_tsv_path
 from gnomad_qc.v4.resources.sample_qc import hgdp_tgp_meta_updated
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
-logger = logging.getLogger("Create v4.0 genomes sample QC metadata HT.")
+logger = logging.getLogger("create_v4_genomes_sample_meta")
 logger.setLevel(logging.INFO)
-
-
-_meta_versions = {
-    "4.0": TableResource(
-        path="gs://gnomad/v4.0/metadata/exomes/gnomad.exomes.v4.0.sample_qc_metadata.ht"
-    ),
-}
 
 
 def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
     """
-    Import updated annotations from subset meta HT to full meta HT.
+    Import updated annotations from HGDP/TGP subset meta HT and annotate full meta HT.
 
-    :param ht: v3.1 genomes meta HT of genomes
-    :param subset_ht: Updated meta HT of HGDP + TGP subset
-    :return: Updated v4 genomes meta HT
+    :param ht: v3.1 genomes meta HT
+    :param subset_ht: Updated HGDP + TGP subset meta HT
+    :return: Updated v4.0 genomes meta HT
     """
     # Some HGDP/TGP samples in v3.1 meta HT have a prefix of "v3.1::" in the key 's',
     # but the project_meta.sample_id field does not have this prefix. This is used as
     # a temp key to join the subset meta HT.
     release_v3 = ht.filter(ht.release).count()
     ht1 = ht.filter(ht.subsets.hgdp | ht.subsets.tgp)
-    ht1 = ht1.naive_coalesce(5).checkpoint(new_temp_file("v4.0_genomes_meta", "ht"))
-    ht2 = ht.filter(~(ht.subsets.hgdp | ht.subsets.tgp))
-    ht2 = ht2.checkpoint(new_temp_file("v4.0_genomes_meta", "ht"))
+    ht1 = ht1.checkpoint(new_temp_file("genomes_meta", "ht"))
+    ht = ht.filter(~(ht.subsets.hgdp | ht.subsets.tgp))
+    ht = ht.checkpoint(new_temp_file("genomes_meta", "ht"))
 
     ht1 = ht1.key_by(ht1.project_meta.sample_id)
     annot = subset_ht[ht1.key]
@@ -76,7 +81,7 @@ def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
     )
 
     ht1 = ht1.key_by("s").drop("sample_id")
-    ht = ht1.union(ht2)
+    ht = ht1.union(ht)
 
     # Update gnomAD inferred population 'oth' to be 'remaining'.
     ht = ht.annotate(
@@ -90,18 +95,20 @@ def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
     )
     release_v4 = ht.filter(ht.release).count()
     logger.info(
-        "Number of genome release samples will change from %s in v3.1 to %s in v4.0.",
+        "Number of genome release samples will change from %s in v3.1 to %s in v4.0",
         release_v3,
         release_v4,
     )
+    if release_v4 <= release_v3 or release_v4 != release_v3 + 169 - 110:
+        raise ValueError("Number of release samples in v4.0 is not as expected.")
 
     return ht
 
 
 def main(args):
-    """Create v4.0 genomes sample QC metadata HT."""
+    """Create updated v4 genomes sample QC metadata HT."""
     hl.init(
-        log="/create_v4.0_genomes_meta.log",
+        log="/create_v4_genomes_meta.log",
         tmp_dir="gs://gnomad-tmp-4day",
     )
 
@@ -111,7 +118,7 @@ def main(args):
     subset_ht = hgdp_tgp_meta_updated.ht()
     logger.info("Updating annotations...")
     ht = import_updated_annotations(ht, subset_ht)
-    ht = ht.naive_coalesce(160)
+    logger.info("Writing HT and exporting TSV...")
     ht.write(v4_meta(data_type="genomes").path, overwrite=args.overwrite)
     ht.export(v4_meta_tsv_path(data_type="genomes"), delimiter="\t")
 
@@ -125,5 +132,13 @@ if __name__ == "__main__":
         help="Overwrite the existing meta HT.",
         action="store_true",
     )
+    parser.add_argument(
+        "--slack-channel", help="Slack channel to post results and notifications to."
+    )
     args = parser.parse_args()
-    main(args)
+
+    if args.slack_channel:
+        with slack_notifications(slack_token, args.slack_channel):
+            main(args)
+    else:
+        main(args)

--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
@@ -1,7 +1,10 @@
 """
 Script to create sample QC metadata HT for genomes.
 
-This script is used to create the sample QC metadata HT for genomes. It is run on the full genomes dataset, and the resulting HT is used to create the sample QC metadata HT for exomes.
+This script is used to create the sample QC metadata HT for genomes. The main updates
+from v3.1 to v4.0 are:
+Sample QC annotations for HGDP + TGP subset, this script directly merges the updated
+annotations from the subset meta HT to the full meta HT.
 """
 
 
@@ -10,9 +13,9 @@ import logging
 
 import hail as hl
 from gnomad.resources.resource_utils import TableResource
-from gnomad.utils.annotations import update_structured_annotations
 
 from gnomad_qc.v3.resources.basics import meta
+from gnomad_qc.v4.resources.meta import meta, meta_tsv_path
 from gnomad_qc.v4.resources.sample_qc import hgdp_tgp_meta_updated
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
@@ -90,7 +93,7 @@ def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
     return ht
 
 
-def mains(args):
+def main(args):
     """Create v4.0 genomes sample QC metadata HT."""
     hl.init(
         log="/create_v4.0_genomes_meta.log",
@@ -103,3 +106,18 @@ def mains(args):
     subset_ht = hgdp_tgp_meta_updated.ht()
     logger.info("Updating annotations...")
     ht = import_updated_annotations(ht, subset_ht)
+    ht.write(meta(data_type="genomes").path, overwrite=args.overwrite)
+    ht.export(meta_tsv_path(data_type="genomes"), delimiter="\t")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        """This script is used to create the sample QC metadata HT for genomes."""
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="Overwrite the existing meta HT.",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
@@ -1,0 +1,105 @@
+"""
+Script to create sample QC metadata HT for genomes.
+
+This script is used to create the sample QC metadata HT for genomes. It is run on the full genomes dataset, and the resulting HT is used to create the sample QC metadata HT for exomes.
+"""
+
+
+import argparse
+import logging
+
+import hail as hl
+from gnomad.resources.resource_utils import TableResource
+from gnomad.utils.annotations import update_structured_annotations
+
+from gnomad_qc.v3.resources.basics import meta
+from gnomad_qc.v4.resources.sample_qc import hgdp_tgp_meta_updated
+
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger = logging.getLogger("Create v4.0 genomes sample QC metadata HT.")
+logger.setLevel(logging.INFO)
+
+
+_meta_versions = {
+    "4.0": TableResource(
+        path="gs://gnomad/v4.0/metadata/exomes/gnomad.exomes.v4.0.sample_qc_metadata.ht"
+    ),
+}
+
+
+def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
+    """
+    Import updated annotations from subset meta HT to full meta HT.
+
+    :param ht: v3.1 genomes meta HT of genomes
+    :param subset_ht: Updated meta HT of HGDP + TGP subset
+    :return: Updated v4 genomes meta HT
+    """
+    # Some HGDP/TGP samples in v3.1 meta HT have a prefix of "v3.1::" in the key 's',
+    # but the project_meta.sample_id field does not have this prefix. This is used as
+    # a temp key to join the subset meta HT.
+    release_v3 = ht.filter(ht.release).count()
+    ht1 = ht.filter(ht.subsets.hgdp | ht.subsets.tgp)
+    ht2 = ht.filter(~(ht.subsets.hgdp | ht.subsets.tgp))
+
+    ht1 = ht1.key_by(ht1.project_meta.sample_id)
+
+    annot = subset_ht[ht1.key]
+    subpop = annot.hgdp_tgp_meta.population
+    freemix = annot.bam_metrics.freemix
+    hard_filters = annot.gnomad_sample_filters.hard_filters
+    hard_filtered = annot.gnomad_sample_filters.hard_filtered
+    release_related = (
+        annot.relatedness_inference.related
+        | annot.gnomad_sample_filters.related_to_nonsubset
+        | annot.gnomad_sample_filters.v4_exome_duplicate
+    )
+    high_quality = annot.gnomad_high_quality
+    release = annot.gnomad_release
+
+    ht1 = ht1.annotate(
+        project_meta=ht1.project_meta.annotate(project_subpop=subpop),
+        bam_metrics=ht1.bam_metrics.annotate(freemix=freemix),
+        sample_filters=ht1.sample_filters.annotate(
+            hard_filters=hard_filters,
+            hard_filtered=hard_filtered,
+            release_related=release_related,
+        ),
+        high_quality=high_quality,
+        release=release,
+    )
+
+    ht1 = ht1.key_by("s").drop("sample_id")
+    ht = ht1.union(ht2)
+
+    # Update gnomAD inferred population 'oth' to be 'remaining'.
+    ht = ht.annotate(
+        population_inference=ht.population_inference.annotate(
+            pop=hl.if_else(
+                ht.population_inference.pop == "oth",
+                "remaining",
+                ht.population_inference.pop,
+            )
+        )
+    )
+    release_v4 = ht.filter(ht.release).count()
+    logger.info(
+        "Number of release samples will change from %s to %s. ", release_v3, release_v4
+    )
+
+    return ht
+
+
+def mains(args):
+    """Create v4.0 genomes sample QC metadata HT."""
+    hl.init(
+        log="/create_v4.0_genomes_meta.log",
+        tmp_dir="gs://gnomad-tmp-4day",
+    )
+
+    logger.info("Importing v3.1 genomes meta HT...")
+    ht = meta.ht()
+    logger.info("Importing updated HGDP/TGP meta HT...")
+    subset_ht = hgdp_tgp_meta_updated.ht()
+    logger.info("Updating annotations...")
+    ht = import_updated_annotations(ht, subset_ht)

--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
@@ -125,7 +125,7 @@ def main(args):
     ht = import_updated_annotations(ht, subset_ht)
     logger.info("Writing HT and exporting TSV...")
     ht.write(
-        v4_meta(data_type="genomes", overwrite=args.overwrite).path,
+        v4_meta(data_type="genomes").path,
         overwrite=args.overwrite,
     )
     ht.export(v4_meta_tsv_path(data_type="genomes"), delimiter="\t")


### PR DESCRIPTION
This script is used to create the sample QC metadata HT for genomes. The main updates from v3.1 to v4.0 are:
Sample QC annotations for HGDP + TGP subset, this script directly merges the updated annotations from the subset meta HT to the full meta HT.