### PR TITLE
Add site quality histograms for v4

### DIFF
--- a/gnomad_qc/v4/create_release/make_var_annot_hists.py
+++ b/gnomad_qc/v4/create_release/make_var_annot_hists.py
@@ -1,0 +1,216 @@
+# noqa: D100
+
+import argparse
+import json
+import logging
+
+import hail as hl
+from gnomad.resources.resource_utils import DataException
+from gnomad.utils.annotations import create_frequency_bins_expr, get_annotations_hists
+from gnomad.utils.file_utils import file_exists
+
+from gnomad_qc.v4.resources.release import (
+    annotation_hists_params_path,
+    qual_hists_json_path,
+    release_ht_path,
+)
+
+logging.basicConfig(
+    format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+LOG10_ANNOTATIONS = ["AS_VarDP", "QUALapprox", "AS_QUALapprox"]
+"""
+List of annotations to log scale when creating histograms.
+"""
+
+
+def create_frequency_bins_expr_inbreeding(
+    AF: hl.expr.NumericExpression,
+) -> hl.expr.StringExpression:
+    """
+    Create bins for frequencies in preparation for aggregating QUAL by frequency bin.
+
+    Uses bins of < 0.0005 and >= 0.0005
+
+    NOTE: Frequencies should be frequencies from raw data.
+    Used when creating site quality distribution json files.
+
+    :param AF: Field in input that contains the allele frequency information
+    :return: Expression containing bin name
+    :rtype: hl.expr.StringExpression
+    """
+    bin_expr = (
+        hl.case()
+        .when(AF < 0.0005, "under_0.0005")
+        .when(AF >= 0.0005, "over_0.0005")
+        .or_missing()
+    )
+    return bin_expr
+
+
+def main(args):  # noqa: D103
+    hl.init(
+        default_reference="GRCh38",
+        log="/variant_histograms.log",
+        tmp_dir="gs://gnomad-tmp-4day/variant_histograms",
+    )
+    data_type = args.data_type
+    test = args.test
+
+    logger.info(
+        "Loading ANNOTATIONS_HISTS dictionary with metric histogram parameters..."
+    )
+    if not file_exists(annotation_hists_params_path(data_type=data_type)):
+        raise DataException(
+            "Annotation hists JSON file not found. Need to create this JSON before"
+            "running script. Use previous release's JSON as a starting point for "
+            "determining metrics histogram bounds."
+        )
+
+    with hl.hadoop_open(annotation_hists_params_path(data_type=data_type)) as a:
+        ANNOTATIONS_HISTS = json.loads(a.read())
+
+    # NOTE: histogram aggregations on these metrics are done on the entire
+    # callset (not just PASS variants), on raw data # noqa
+    logger.info("Loading release Hail Table...")
+    ht = hl.read_table(release_ht_path(data_type=data_type, public=False))
+
+    if test:
+        # Keep only PCSK9.
+        logger.info("Filtering to PCSK9 region...")
+        ht = hl.filter_intervals(
+            ht,
+            [
+                hl.parse_locus_interval(
+                    "chr1:55039447-55064852", reference_genome="GRCh38"
+                )
+            ],
+        )
+
+    ht = ht.select(freq=ht.freq, info=ht.info.select(*ANNOTATIONS_HISTS))
+
+    inbreeding_bin_ranges = ANNOTATIONS_HISTS["inbreeding_coeff"]
+
+    # Remove InbreedingCoeff from ANNOTATIONS_HISTS. It requires different ranges
+    # by allele frequency and needs to be handled differently. It is stored as a
+    # dictionary in annotation_hists_path
+    ANNOTATIONS_HISTS = {
+        k: v for k, v in ANNOTATIONS_HISTS.items() if k != "inbreeding_coeff"
+    }
+
+    logger.info("Getting info annotation histograms...")
+    hist_ranges_expr = get_annotations_hists(ht, ANNOTATIONS_HISTS, LOG10_ANNOTATIONS)
+
+    # Note: This evaluates the minimum and maximum values for each metric of interest
+    # to help determine the bounds of the hists. Run this first, then update values in
+    # annotation_hists_path JSON if necessary after examining data in a notebook
+    if args.determine_bounds:
+        logger.info(
+            "Evaluating minimum and maximum values for each metric of interest. Maximum"
+            " values capped at 1e10."
+        )
+        minmax_dict = {}
+        for metric in ANNOTATIONS_HISTS:
+            minmax_dict[metric] = hl.struct(
+                min=hl.agg.min(ht.info[metric]),
+                max=hl.if_else(
+                    hl.agg.max(ht.info[metric]) < 1e10,
+                    hl.agg.max(ht.info[metric]),
+                    1e10,
+                ),
+            )
+        minmax = ht.aggregate(hl.struct(**minmax_dict))
+        logger.info(f"Metrics bounds: {minmax}")
+    else:
+        logger.info(
+            "Aggregating hists over ranges defined in the annotation_hists_path JSON"
+            " file. --determine_bounds can be used to help define these ranges if"
+            " initial results seem off..."
+        )
+        hists = ht.aggregate(
+            hl.array(
+                [
+                    hist_expr.annotate(metric=hist_metric)
+                    for hist_metric, hist_expr in hist_ranges_expr.items()
+                ]
+            )
+            .extend(
+                hl.array(
+                    hl.agg.group_by(
+                        create_frequency_bins_expr(AC=ht.freq[1].AC, AF=ht.freq[1].AF),
+                        hl.agg.hist(
+                            hl.log10(ht.info.QUALapprox),
+                            *ANNOTATIONS_HISTS["QUALapprox"],
+                        ),
+                    )
+                ).map(lambda x: x[1].annotate(metric="QUALapprox-" + x[0]))
+            )
+            .extend(
+                hl.array(
+                    hl.agg.group_by(
+                        create_frequency_bins_expr(AC=ht.freq[1].AC, AF=ht.freq[1].AF),
+                        hl.agg.hist(
+                            hl.log10(ht.info.AS_QUALapprox),
+                            *ANNOTATIONS_HISTS["AS_QUALapprox"],
+                        ),
+                    )
+                ).map(lambda x: x[1].annotate(metric="AS_QUALapprox-" + x[0]))
+            ),
+            _localize=False,
+        )
+
+        # Defining hist range and bins for allele frequency groups because they
+        # needed different ranges
+        ht = ht.annotate(af_bin=create_frequency_bins_expr_inbreeding(AF=ht.freq[1].AF))
+        inbreeding_hists = [
+            ht.aggregate(
+                hl.agg.filter(
+                    ht.af_bin == x,
+                    hl.agg.hist(
+                        ht.info.inbreeding_coeff,
+                        *inbreeding_bin_ranges[x],
+                    ),
+                )
+            ).annotate(metric="inbreeding_coeff" + "-" + x)
+            for x in inbreeding_bin_ranges
+        ]
+
+        hists = hl.eval(hl.json(hists))
+        inbreeding_hists = hl.eval(hl.json(inbreeding_hists))
+
+        # Note: The following removes '}' from the JSON stored in hists and '{' from the JSON stored in
+        # inbreeding_hists then joins them together to be written out as a single JSON
+        hists = hists[:-1] + "," + inbreeding_hists[1:]
+
+        output_path = qual_hists_json_path(data_type=data_type, test=test)
+        logger.info("Writing output to %s ...", output_path)
+        with hl.hadoop_open(output_path, "w") as f:
+            f.write(hists)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--determine_bounds",
+        help=(
+            "Determine min/max values for each variant metric and prints them to stdout"
+            " (to be used in hand-tooled histogram ranges). Note that this should only"
+            " be run if the defaults do not result in well-behaved histograms."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--data-type", help="Data type", default="exomes", choices=["exomes", "genomes"]
+    )
+    parser.add_argument(
+        "--test",
+        help="Use test resources and test on PCSK9 region",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/gnomad_qc/v4/create_release/make_var_annot_hists.py
+++ b/gnomad_qc/v4/create_release/make_var_annot_hists.py
@@ -164,8 +164,8 @@ def main(args):  # noqa: D103
             _localize=False,
         )
 
-        # Defining hist range and bins for allele frequency groups because they
-        # needed different ranges
+        # # Defining hist range for inbreeding coefficient and bins for allele frequency
+        # groups because they needed different ranges
         ht = ht.annotate(af_bin=create_frequency_bins_expr_inbreeding(AF=ht.freq[1].AF))
         inbreeding_hists = [
             ht.aggregate(

--- a/gnomad_qc/v4/create_release/make_var_annot_hists.py
+++ b/gnomad_qc/v4/create_release/make_var_annot_hists.py
@@ -33,7 +33,7 @@ def create_frequency_bins_expr_inbreeding(
     AF: hl.expr.NumericExpression,
 ) -> hl.expr.StringExpression:
     """
-    Create bins for frequencies in preparation for aggregating QUAL by frequency bin.
+    Create bins for frequencies in preparation for aggregating Inbreedind Coefficient by frequency bin.
 
     Uses bins of < 0.0005 and >= 0.0005
 

--- a/gnomad_qc/v4/create_release/make_var_annot_hists.py
+++ b/gnomad_qc/v4/create_release/make_var_annot_hists.py
@@ -132,6 +132,8 @@ def main(args):  # noqa: D103
             " file. --determine_bounds can be used to help define these ranges if"
             " initial results seem off..."
         )
+        # NOTE: QUALApprox and AS_QUALApprox are log10 scaled and also split into
+        # frequency bins
         hists = ht.aggregate(
             hl.array(
                 [

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -83,26 +83,44 @@ def _release_root(
     )
 
 
-def annotation_hists_path(release_version: str = CURRENT_RELEASE) -> str:
+def annotation_hists_params_path(
+    release_version: str = CURRENT_RELEASE,
+    data_type: str = "exomes",
+) -> str:
     """
-    Return path to file containing ANNOTATIONS_HISTS dictionary.
+    Return path to file containing dictionary of parameters for site metric histograms.
 
-    Dictionary contains histogram values for each metric.
+    The keys of the dictionary are the names of the site quality metrics
+    while the values are: [lower bound, upper bound, number  of bins].
     For example, "InbreedingCoeff": [-0.25, 0.25, 50].
 
+    :param release_version: Release version. Defaults to CURRENT RELEASE.
+    :param data_type: Data type of annotation resource. e.g. "exomes" or "genomes".
+        Default is "exomes".
+    :param test: Whether to use a tmp path for testing. Default is False.
     :return: Path to file with annotation histograms
     """
-    return f"gs://gnomad/release/{release_version}/json/annotation_hists.json"
+    return (
+        f"{_release_root(version=release_version, data_type=data_type, extension='json')}/gnomad.{data_type}.v{release_version}_annotation_hist_params.json"
+    )
 
 
-def qual_hists_json_path(release_version: str = CURRENT_RELEASE) -> str:
+def qual_hists_json_path(
+    release_version: str = CURRENT_RELEASE,
+    data_type: str = "exomes",
+    test: bool = False,
+) -> str:
     """
     Fetch filepath for qual histograms JSON.
 
     :param release_version: Release version. Defaults to CURRENT RELEASE
+    :param data_type: Data type 'exomes' or 'genomes'. Default is 'exomes'.
+    :param test: Whether to use a tmp path for testing. Default is False.
     :return: File path for histogram JSON
     """
-    return f"gs://gnomad/release/{release_version}/json/gnomad.exomes.v{release_version}.json"
+    return (
+        f"{_release_root(release_version, test, data_type, extension='json')}/gnomad.{data_type}.v{release_version}_qual_hists.json"
+    )
 
 
 def get_combined_faf_release(test: bool = False) -> VersionedTableResource:


### PR DESCRIPTION
This adds the site quality metric histograms for v4. It is essentially a copy and paste from v3. 

v4 exome metric histogram parameters have been discussed here:  https://atgu.slack.com/archives/CRA2TKTV0/p1698085670870479 

This function will work on genomes but we will need to confirm the v4 genome ranges still look ok using the v3 ranges and then copy the file if they do, or modify it and put it in the v4 location if they need updates. 

These histograms are displayed on the variant pages and the variants specific metric gets a line added by the browser 
![Screenshot 2023-10-23 at 2 08 16 PM](https://github.com/broadinstitute/gnomad_qc/assets/15892871/b418222a-9bc3-4963-9af3-d0ae9cf35a61)

Exome test run here:
https://console.cloud.google.com/dataproc/jobs/a97858c504b244e3a9bb37f5e6439549/monitoring?region=us-central1&project=broad-mpg-gnomad