### PR TITLE
Flatten the gnomad/non_ukb structs in fafmax and grpmax

### DIFF
--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -63,7 +63,8 @@ REGION_FLAG_FIELDS = remove_fields_from_constant(
 )
 REGION_FLAG_FIELDS.append("non_par")
 REGION_FLAG_FIELDS = {
-    "exomes": REGION_FLAG_FIELDS + [
+    "exomes": REGION_FLAG_FIELDS
+    + [
         "fail_interval_qc",
         "outside_ukb_capture_region",
         "outside_broad_capture_region",
@@ -273,7 +274,7 @@ def unfurl_nested_annotations(
     )
 
     logger.info("Unfurling fafmax data...")
-    fafmax_idx = ht.fafmax
+    fafmax_idx = ht.fafmax.gnomad if data_type == "exomes" else ht.fafmax
     fafmax_dict = {f"fafmax_{f}": fafmax_idx[f] for f in fafmax_idx.keys()}
     expr_dict.update(fafmax_dict)
 

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -63,8 +63,7 @@ REGION_FLAG_FIELDS = remove_fields_from_constant(
 )
 REGION_FLAG_FIELDS.append("non_par")
 REGION_FLAG_FIELDS = {
-    "exomes": REGION_FLAG_FIELDS
-    + [
+    "exomes": REGION_FLAG_FIELDS + [
         "fail_interval_qc",
         "outside_ukb_capture_region",
         "outside_broad_capture_region",

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -244,14 +244,28 @@ def unfurl_nested_annotations(
     )
 
     logger.info("Adding grpmax data...")
-    grpmax_idx = ht.grpmax.gnomad if data_type == "exomes" else ht.grpmax
-    grpmax_dict = {"grpmax": grpmax_idx.gen_anc}
-    grpmax_dict.update(
-        {
-            f"{f if f != 'homozygote_count' else 'nhomalt'}_grpmax": grpmax_idx[f]
-            for f in [f for f in grpmax_idx._fields if f != "gen_anc"]
-        }
-    )
+    grpmax_idx = ht.grpmax
+    if data_type == "exomes":
+        grpmax_dict = {}
+        for s in grpmax_idx.keys():
+            grpmax_dict.update({f"{s}_grpmax": grpmax_idx[s].gen_anc})
+            grpmax_dict.update(
+                {
+                    f"{s}_{f if f != 'homozygote_count' else 'nhomalt'}_grpmax": (
+                        grpmax_idx[s][f]
+                    )
+                    for f in grpmax_idx[s].keys()
+                    if f != "gen_anc"
+                }
+            )
+    else:
+        grpmax_dict = {"grpmax": grpmax_idx.gen_anc}
+        grpmax_dict.update(
+            {
+                f"{f if f != 'homozygote_count' else 'nhomalt'}_grpmax": grpmax_idx[f]
+                for f in [f for f in grpmax_idx.keys() if f != "gen_anc"]
+            }
+        )
     expr_dict.update(grpmax_dict)
 
     logger.info("Adding joint grpmax data...")
@@ -274,8 +288,15 @@ def unfurl_nested_annotations(
     )
 
     logger.info("Unfurling fafmax data...")
-    fafmax_idx = ht.fafmax.gnomad if data_type == "exomes" else ht.fafmax
-    fafmax_dict = {f"fafmax_{f}": fafmax_idx[f] for f in fafmax_idx.keys()}
+    fafmax_idx = ht.fafmax
+    if data_type == "exomes":
+        fafmax_dict = {
+            f"fafmax_{s}_{f}": fafmax_idx[s][f]
+            for s in fafmax_idx.keys()
+            for f in fafmax_idx[s].keys()
+        }
+    else:
+        fafmax_dict = {f"fafmax_{f}": fafmax_idx[f] for f in fafmax_idx.keys()}
     expr_dict.update(fafmax_dict)
 
     logger.info("Unfurling joint faf data...")


### PR DESCRIPTION
These werent being flattened properly nor were we grabbing all the data for the VCF. They arent the prettiest implementation but grpmax has two renames within it and in order to keep the subset specific annotations together I added the for loop for the subsets. 