### PR TITLE
using high_quality instead of gnomad_high_quality from hgdp_tgp meta

### DIFF
--- a/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
+++ b/gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht_genomes.py
@@ -70,7 +70,7 @@ def import_updated_annotations(ht: hl.Table, subset_ht: hl.Table) -> hl.Table:
         | annot.gnomad_sample_filters.related_to_nonsubset
         | annot.gnomad_sample_filters.v4_exome_duplicate
     )
-    high_quality = annot.gnomad_high_quality
+    high_quality = annot.high_quality
     release = annot.gnomad_release
 
     ht1 = ht1.annotate(


### PR DESCRIPTION
In v3.1, `high_quality` means means NOT `hard_filtered` and NOT `gnomad_sample_filters.qc_metrics_filters`, and it was kept in hgdp_tgp_meta as `gnomad_high_quality`, in v4.0, `high_quality` means NOT `hard_filtered` and NOT `subcontinental_pca.outlier` from the subset. So, `gnomad_high_quality` in the subset meta shouldn't be copied to the full meta. Here, I corrected this. 






























































