### PR TITLE
Add genome vcf export

### DIFF
--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -813,6 +813,13 @@ def format_validated_ht_for_export(
         ds_fields = get_downsamplings_fields(ht)
         info_fields_to_drop.extend(ds_fields)
 
+    # Drop and info annotation with "hgdp" or "tgp" in the name for genome
+    if data_type == "genomes":
+        logger.info("Dropping hgdp and tgp annotations from info struct...")
+        info_fields_to_drop.extend(
+            [f for f in list(ht.info) if (("hgdp" in f) | ("tgp" in f))]
+        )
+
     logger.info("Add age_histogram bin edges to info fields to drop...")
     info_fields_to_drop.extend(["age_hist_het_bin_edges", "age_hist_hom_bin_edges"])
 

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -655,6 +655,7 @@ def populate_info_dict(
     :param in_silico_dict: Dictionary of in silico predictor score descriptions.
     :param vrs_fields_dict: Dictionary with VRS annotations.
     :param label_delimiter: String to use as delimiter when making group label combinations.
+    :param data_type: Data type to populate info dict for. One of "exomes" or "genomes". Default is "exomes".
     :return: Updated INFO dictionary for VCF export.
     """
     # Get existing info fields from predefined info_dict, e.g. `FS`,
@@ -731,7 +732,7 @@ def prepare_vcf_header_dict(
     :param pops: List of sample global genetic ancestry group names for gnomAD data type.
     :param format_dict: Dictionary describing MatrixTable entries. Used in header for VCF export.
     :param inbreeding_coeff_cutoff: InbreedingCoeff hard filter used for variants.
-    :param data_type: Data type to prepare VCF header for. One of "exomes" or "genomes". Default is "exomes". 
+    :param data_type: Data type to prepare VCF header for. One of "exomes" or "genomes". Default is "exomes".
     :return: Prepared VCF header dictionary.
     """
     logger.info("Making FILTER dict for VCF...")

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -731,7 +731,7 @@ def prepare_vcf_header_dict(
     :param pops: List of sample global genetic ancestry group names for gnomAD data type.
     :param format_dict: Dictionary describing MatrixTable entries. Used in header for VCF export.
     :param inbreeding_coeff_cutoff: InbreedingCoeff hard filter used for variants.
-    :param data_type: Data type to prepare VCF header for. One of "exomes" or "genomes".
+    :param data_type: Data type to prepare VCF header for. One of "exomes" or "genomes". Default is "exomes". 
     :return: Prepared VCF header dictionary.
     """
     logger.info("Making FILTER dict for VCF...")

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -814,7 +814,7 @@ def format_validated_ht_for_export(
         ds_fields = get_downsamplings_fields(ht)
         info_fields_to_drop.extend(ds_fields)
 
-    # Drop and info annotation with "hgdp" or "tgp" in the name for genome
+    # Drop any info annotation with "hgdp" or "tgp" in the name for genomes.
     if data_type == "genomes":
         logger.info("Dropping hgdp and tgp annotations from info struct...")
         info_fields_to_drop.extend(


### PR DESCRIPTION
This adds genomes to the VCF export code. The current test run will warn 
```WARNING (gnomad.assessment.validity_checks 841): faf95_grpmax in info field does not exist in VCF header!``` We plan on rerunning genomes so  faf95 is removed grpmax. 