### PR TITLE
Remove sift and polyphen from VCF export

### DIFF
--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -503,6 +503,8 @@ def prepare_ht_for_validation(
 
     logger.info("Constructing INFO field")
     # Remove SIFT and Polyphen from CSQ fields or they will be inserted with
+    # missing values by vep_struct_to_csq. These fields are processed separately
+    # as in silico annotations.
     csq_fields = "|".join(
         [
             c

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -502,8 +502,7 @@ def prepare_ht_for_validation(
     )
 
     logger.info("Constructing INFO field")
-    # Remove SIFT and Polyphen from csq fields or they will be inserted with
-    # missing values by vep_struct_to_csq
+    # Remove SIFT and Polyphen from CSQ fields or they will be inserted with
     csq_fields = "|".join(
         [
             c

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -40,7 +40,12 @@ from gnomad.utils.vcf import (
     make_vcf_filter_dict,
     rekey_new_reference,
 )
-from gnomad.utils.vep import VEP_CSQ_HEADER, vep_struct_to_csq
+from gnomad.utils.vep import (
+    CURRENT_VEP_VERSION,
+    VEP_CSQ_FIELDS,
+    VEP_CSQ_HEADER,
+    vep_struct_to_csq,
+)
 
 from gnomad_qc.resource_utils import (
     PipelineResourceCollection,
@@ -497,12 +502,22 @@ def prepare_ht_for_validation(
     )
 
     logger.info("Constructing INFO field")
+    # Remove SIFT and Polyphen from csq fields or they will be inserted with
+    # missing values by vep_struct_to_csq
+    csq_fields = "|".join(
+        [
+            c
+            for c in VEP_CSQ_FIELDS[CURRENT_VEP_VERSION].split("|")
+            if c != "PolyPhen" and c != "SIFT"
+        ]
+    )
+
     ht = ht.annotate(
         region_flag=ht.region_flags,
         release_ht_info=ht.info,
         info=info_struct,
         rsid=hl.str(";").join(ht.rsid),
-        vep=vep_struct_to_csq(ht.vep, has_polyphen_sift=False),
+        vep=vep_struct_to_csq(ht.vep, csq_fields=csq_fields, has_polyphen_sift=False),
     )
     # Add variant annotations to INFO field
     # This adds the following:


### PR DESCRIPTION
A user found that the number of v4's VCF VEP fields(48) do not match the header(46). This is a result of using default parameters in the function that creates a string out of the vep struct. The default call uses the default VEP_CSQ_FIELDS  list which contains SIFT and Polyphen. It then inserts missing values  in the "validated_ht"  after not finding the fields in the VEP annotation. This "validated_ht" is then used for VCF export. 

This PR fixes the exported VCF fields by removing SIFT and Polyphen from the `csq_fields` passed to the `vep_struct_to_csq` function, resulting in the correct number of vep fields in the VCF. 