### PR TITLE
Pass data_type to included datasets path function

### DIFF
--- a/gnomad_qc/v4/create_release/create_release_sites_ht.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht.py
@@ -1,4 +1,5 @@
 """Script to create release sites HT for v4.0 exomes and genomes."""
+
 import argparse
 import json
 import logging
@@ -753,6 +754,7 @@ def join_hts(
     if "release" in tables:
         with hl.utils.hadoop_open(
             included_datasets_json_path(
+                data_type=data_type,
                 test=test,
                 release_version=hl.eval(
                     get_config(data_type=data_type)["release"]["ht"].version
@@ -768,7 +770,10 @@ def join_hts(
         }
     )
     with hl.utils.hadoop_open(
-        included_datasets_json_path(test=test, release_version=version), "w"
+        included_datasets_json_path(
+            data_type=data_type, test=test, release_version=version
+        ),
+        "w",
     ) as f:
         f.write(hl.eval(hl.json(included_datasets)))
 

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -1,4 +1,5 @@
 """Script containing release related resources."""
+
 import logging
 from typing import Optional
 
@@ -376,7 +377,7 @@ def included_datasets_json_path(
     :return: File path for release versions included datasets JSON
     """
     return (
-        f"{_release_root(release_version, test=test, data_type=data_type, extension='json')}/gnomad.exomes.v{release_version}.included_datasets.json"
+        f"{_release_root(release_version, test=test, data_type=data_type, extension='json')}/gnomad.{data_type}.v{release_version}.included_datasets.json"
     )
 
 


### PR DESCRIPTION
We dont have an included datasets json for v4.0 genomes. This will fix that moving forward.  We ran exomes last so the existing datasets file is correct. 