### PR TITLE
Move PCA files to under ancestry_inference

### DIFF
--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1,4 +1,5 @@
 """Script containing sample QC related resources."""
+
 from typing import Optional
 
 from gnomad.resources.resource_utils import (
@@ -581,7 +582,7 @@ def _get_ancestry_pca_ht_path(
     :return: Path to requested ancestry PCA file.
     """
     return (
-        f"{get_sample_qc_root(version, test, data_type)}/gnomad.{data_type}.v{version}.pca_{part}{'_with_unreleasable_samples' if include_unreleasable_samples else ''}.ht"
+        f"{get_sample_qc_root(version, test, data_type)}/ancestry_inference/gnomad.{data_type}.v{version}.pca_{part}{'_with_unreleasable_samples' if include_unreleasable_samples else ''}.ht"
     )
 
 


### PR DESCRIPTION
This change will give access to the pca scores, loadings, and eigenvalue files which will move to under the ancestry_inference subdirectory.