### PR TITLE
Update faf and popmax pops to remove to account for change in gnomad_methods

### DIFF
--- a/gnomad_qc/v3/annotations/generate_freq_data.py
+++ b/gnomad_qc/v3/annotations/generate_freq_data.py
@@ -304,13 +304,15 @@ def main(args):  # noqa: D103
 
             logger.info("Computing filtering allele frequencies and popmax...")
             faf, faf_meta = faf_expr(
-                mt.freq, mt.freq_meta, mt.locus, POPS_TO_REMOVE_FOR_POPMAX
+                mt.freq, mt.freq_meta, mt.locus, POPS_TO_REMOVE_FOR_POPMAX["v3"]
             )
             mt = mt.select_rows(
                 "InbreedingCoeff",
                 "freq",
                 faf=faf,
-                popmax=pop_max_expr(mt.freq, mt.freq_meta, POPS_TO_REMOVE_FOR_POPMAX),
+                popmax=pop_max_expr(
+                    mt.freq, mt.freq_meta, POPS_TO_REMOVE_FOR_POPMAX["v3"]
+                ),
             )
             mt = mt.annotate_globals(
                 faf_meta=faf_meta,

--- a/gnomad_qc/v3/create_release/prepare_vcf_data_release.py
+++ b/gnomad_qc/v3/create_release/prepare_vcf_data_release.py
@@ -119,7 +119,7 @@ MISSING_INFO_FIELDS = (
 POPS = {pop: POP_NAMES[pop] for pop in POPS}
 
 # Remove unnecessary pop names from FAF_POPS dict
-FAF_POPS = {pop: POP_NAMES[pop] for pop in FAF_POPS}
+FAF_POPS = {pop: POP_NAMES[pop] for pop in FAF_POPS["v3"]}
 
 # Get HGDP + TGP(KG) subset pop names
 HGDP_TGP_KEEP_POPS = TGP_POPS + HGDP_POPS

--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -8,6 +8,7 @@ existing annotations when given the AF threshold using a high AB het array. The 
 then computes the inbreeding coefficient using the raw call stats. Finally, it computes
 the filtering allele frequency and grpmax with the AB-adjusted frequencies.
 """
+
 import argparse
 import logging
 from copy import deepcopy
@@ -846,8 +847,8 @@ def generate_faf_grpmax(ht: hl.Table) -> hl.Table:
     grpmax_exprs = {}
     gen_anc_faf_max_exprs = {}
     for dataset, (freq, meta) in freq_metas.items():
-        faf, faf_meta = faf_expr(freq, meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX)
-        grpmax = pop_max_expr(freq, meta, POPS_TO_REMOVE_FOR_POPMAX)
+        faf, faf_meta = faf_expr(freq, meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX["v4"])
+        grpmax = pop_max_expr(freq, meta, POPS_TO_REMOVE_FOR_POPMAX["v4"])
         grpmax = grpmax.annotate(
             gen_anc=grpmax.pop,
             faf95=faf[

--- a/gnomad_qc/v4/annotations/generate_freq_genomes.py
+++ b/gnomad_qc/v4/annotations/generate_freq_genomes.py
@@ -11,7 +11,6 @@ other call stats related annotations, including: filtering allele frequencies ('
 'grpmax', 'gen_anc_faf_max' and 'InbreedingCoeff' as done in v4.0 exomes.
 """
 
-
 import argparse
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -1077,8 +1076,10 @@ def finalize_v4_genomes_callstats(
     )
 
     # Compute filtering allele frequency (faf), grpmax, and gen_anc_faf_max.
-    faf, faf_meta = faf_expr(ht.freq, freq_meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX)
-    grpmax = pop_max_expr(ht.freq, freq_meta, POPS_TO_REMOVE_FOR_POPMAX)
+    faf, faf_meta = faf_expr(
+        ht.freq, freq_meta, ht.locus, POPS_TO_REMOVE_FOR_POPMAX["v3"]
+    )
+    grpmax = pop_max_expr(ht.freq, freq_meta, POPS_TO_REMOVE_FOR_POPMAX["v3"])
     grpmax = grpmax.annotate(
         gen_anc=grpmax.pop,
         faf95=faf[

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -9,6 +9,7 @@ joint frequency, a joint FAF, and the following tests comparing the two frequenc
       contingency tables.
 
 """
+
 import argparse
 import logging
 from typing import Dict, List, Set
@@ -154,7 +155,7 @@ def extract_freq_info(
 def get_joint_freq_and_faf(
     genomes_ht: hl.Table,
     exomes_ht: hl.Table,
-    faf_pops_to_exclude: Set[str] = POPS_TO_REMOVE_FOR_POPMAX,
+    faf_pops_to_exclude: Set[str] = POPS_TO_REMOVE_FOR_POPMAX["v4"],
 ) -> hl.Table:
     """
     Get joint genomes and exomes frequency and FAF information.
@@ -512,7 +513,7 @@ def main(args):
     overwrite = args.overwrite
     apply_release_filters = args.apply_release_filters
     pops = list(set(POPS["v3"] + POPS["v4"]))
-    faf_pops = [pop for pop in pops if pop not in POPS_TO_REMOVE_FOR_POPMAX]
+    faf_pops = [pop for pop in pops if pop not in POPS_TO_REMOVE_FOR_POPMAX["v4"]]
     combine_faf_resources = get_combine_faf_resources(
         overwrite,
         test_gene,

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -141,9 +141,6 @@ SAMPLE_SUM_SETS_AND_POPS = {
     "genomes": {"hgdp": HGDP_POPS, "tgp": TGP_POPS},
 }
 
-# Remove unnecessary pop names from FAF_POPS dict
-FAF_POPS = {pop: POP_NAMES[pop] for pop in FAF_POPS}
-
 # Row annotaions and their associated global annotations for length comparison
 LEN_COMP_GLOBAL_ROWS = {
     "freq": ["freq_meta", "freq_index_dict", "freq_meta_sample_count"],
@@ -639,7 +636,7 @@ def populate_info_dict(
     info_dict: Dict[str, Dict[str, str]] = INFO_DICT,
     subset_list: List[str] = SUBSETS,
     pops: Dict[str, str] = POPS,
-    faf_pops: Dict[str, str] = FAF_POPS,
+    faf_pops: Dict[str, List[str]] = FAF_POPS,
     sexes: List[str] = SEXES,
     in_silico_dict: Dict[str, Dict[str, str]] = IN_SILICO_ANNOTATIONS_INFO_DICT,
     vrs_fields_dict: Dict[str, Dict[str, str]] = VRS_FIELDS_DICT,
@@ -666,7 +663,7 @@ def populate_info_dict(
     :param subset_pops: Dict of sample global genetic ancestry group names to use for all subsets in `subset_list` unless the subset
         is 'gnomad', in that case `gnomad_pops` is used. Default is POPS.
     :param gnomad_pops: Dict of sample global genetic ancestry group names for gnomAD data type. Default is POPS.
-    :param faf_pops: Dict with faf genentic ancestry group names (keys) and descriptions (values).  Default is FAF_POPS.
+    :param faf_pops: Dict with gnomAD version (keys) and faf genentic ancestry group names(values).  Default is FAF_POPS.
     :param sexes: gnomAD sample sexes used in VCF export. Default is SEXES.
     :param in_silico_dict: Dictionary of in silico predictor score descriptions.
     :param vrs_fields_dict: Dictionary with VRS annotations.
@@ -683,6 +680,11 @@ def populate_info_dict(
     vcf_info_dict.update(
         add_as_info_dict(info_dict=info_dict, as_fields=AS_FIELDS + AS_VQSR_FIELDS)
     )
+
+    # Remove unnecessary pop names from FAF_POPS dict depending on data type
+    # and version of FAF_POPS
+    faf_pops_version = "v4" if data_type == "exomes" else "v3"
+    faf_pops = {pop: POP_NAMES[pop] for pop in faf_pops[faf_pops_version]}
 
     for subset in subset_list:
         subset_pops = deepcopy(pops)

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -554,7 +554,7 @@ def populate_subset_info_dict(
     description_text: str,
     data_type: str = "exomes",
     pops: Dict[str, str] = POPS,
-    faf_pops: Dict[str, str] = FAF_POPS,
+    faf_pops: Dict[str, List[str]] = FAF_POPS,
     sexes: List[str] = SEXES,
     label_delimiter: str = "_",
 ) -> Dict[str, Dict[str, str]]:

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -682,7 +682,7 @@ def populate_info_dict(
     )
 
     # Remove unnecessary pop names from FAF_POPS dict depending on data type
-    # and version of FAF_POPS
+    # and version of FAF_POPS.
     faf_pops_version = "v4" if data_type == "exomes" else "v3"
     faf_pops = {pop: POP_NAMES[pop] for pop in faf_pops[faf_pops_version]}
 
@@ -942,11 +942,11 @@ def main(args):  # noqa: D103
     contig = args.contig
     resources = get_export_resources(overwrite, data_type, test)
 
-    # if contig and test:
-    #     raise ValueError(
-    #         "Test argument cannot be used with contig argument as test filters"
-    #         " to chr20, X, and Y."
-    #     )
+    if contig and test:
+        raise ValueError(
+            "Test argument cannot be used with contig argument as test filters"
+            " to chr20, X, and Y."
+        )
 
     try:
         if args.validate_release_ht:

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -569,7 +569,7 @@ def populate_subset_info_dict(
     :param description_text: Text describing the sample subset that should be added to the INFO description.
     :param data_type: One of "exomes" or "genomes". Default is "exomes".
     :param pops: Dict of sample global genetic ancestry names for the gnomAD data type. Default is POPS.
-    :param faf_pops: Dict with faf genetic ancestry names (keys) and descriptions (values). Default is dictionary of FAF_POPS and descriptions.
+    :param faf_pops: Dict with gnomAD version (keys) and faf genentic ancestry group names(values).  Default is FAF_POPS.
     :param sexes: gnomAD sample sexes used in VCF export. Default is SEXES.
     :param label_delimiter: String to use as delimiter when making group label combinations. Default is '_'.
     :return: Dictionary containing Subset specific INFO header fields.

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -940,11 +940,11 @@ def main(args):  # noqa: D103
     contig = args.contig
     resources = get_export_resources(overwrite, data_type, test)
 
-    if contig and test:
-        raise ValueError(
-            "Test argument cannot be used with contig argument as test filters"
-            " to chr20, X, and Y."
-        )
+    # if contig and test:
+    #     raise ValueError(
+    #         "Test argument cannot be used with contig argument as test filters"
+    #         " to chr20, X, and Y."
+    #     )
 
     try:
         if args.validate_release_ht:
@@ -1022,13 +1022,6 @@ def main(args):  # noqa: D103
 
         if args.export_vcf:
             contig = f"chr{contig}" if contig else None
-
-            if contig and test:
-                raise ValueError(
-                    "Test argument cannot be used with contig argument as test filters"
-                    " to chr20, X, and Y."
-                )
-
             logger.info(f"Exporting VCF{f' for {contig}' if contig else ''}...")
             res = resources.export_vcf
             res.check_resource_existence()
@@ -1038,16 +1031,18 @@ def main(args):  # noqa: D103
                 header_dict = pickle.load(f)
 
             if test:
-                logger.info("Filtering to PCSK9 region...")
-                # Keep only PCSK9.
-                ht = hl.filter_intervals(
-                    ht,
-                    [
-                        hl.parse_locus_interval(
-                            "chr1:55039447-55064852", reference_genome="GRCh38"
-                        )
-                    ],
-                )
+                logger.info("Filtering to test partitions...")
+                ht = filter_to_test(ht)
+                # logger.info("Filtering to PCSK9 region...")
+                # # Keep only PCSK9.
+                # ht = hl.filter_intervals(
+                #     ht,
+                #     [
+                #         hl.parse_locus_interval(
+                #             "chr1:55039447-55064852", reference_genome="GRCh38"
+                #         )
+                #     ],
+                # )
             if contig:
                 logger.info(f"Filtering to {contig}...")
                 ht = hl.filter_intervals(


### PR DESCRIPTION
This is to update the code to work with: https://github.com/broadinstitute/gnomad_methods/pull/658/files.

I had to change the VCF export code for v4 beyond just referencing the version since the code works for both genomes and exomes but genomes uses v3 faf pops while exomes will use v4. This is not pretty but its the least amount of code to add without major restructuring. We should probably rethink these global variables. 