### PR TITLE
Add support for including mermaid flowcharts at the top of the sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
     "myst_parser",
-    'sphinxarg.ext',
+    "sphinxarg.ext",
+    "sphinxcontrib.mermaid",
 ]
 
 # README.md contains developer documentation for building docs

--- a/docs/flowcharts/v4/index.mmd
+++ b/docs/flowcharts/v4/index.mmd
@@ -1,0 +1,8 @@
+flowchart LR;
+  sample_qc["<a class="reference internal" href='sample_qc/index.html'>sample_qc</a>"];
+  annotations["<a class="reference internal" href='annotations/index.html'>annotations</a>"];
+  variant_qc["<a class="reference internal" href='variant_qc/index.html'>variant_qc</a>"];
+  create_release["<a class="reference internal" href='create_release/index.html'>create_release</a>"];
+  sample_qc --> annotations;
+  annotations --> variant_qc;
+  variant_qc --> create_release;

--- a/docs/generate_api_reference.py
+++ b/docs/generate_api_reference.py
@@ -19,52 +19,31 @@ ROOT_PACKAGE_PATH = os.path.join(REPOSITORY_ROOT_PATH, "gnomad_qc")
 
 DOCS_DIRECTORY = os.path.join(REPOSITORY_ROOT_PATH, "docs")
 
+FLOWCHART_DIRECTORY = os.path.join(DOCS_DIRECTORY, "flowcharts")
+
 EXCLUDE_PACKAGES = []
 
 EXCLUDE_TOP_LEVEL_PACKAGES = [
     "gnomad_qc.v2", "gnomad_qc.v3", "gnomad_qc.example_notebooks"
 ]
 
+PACKAGE_DOC_TEMPLATE = """{title}
 
-def module_doc_path(module):
-    """Get the path for a module's documentation file."""
-    return os.path.join(
-        DOCS_DIRECTORY,
-        "api_reference",
-        re.sub(r"\.py$", ".rst", os.path.relpath(module.__file__, ROOT_PACKAGE_PATH)),
-    )
+{package_doc}
 
+{flowchart}
 
-def package_doc_path(package):
-    """Get the path for a package's documentation file."""
-    return os.path.join(
-        DOCS_DIRECTORY,
-        "api_reference",
-        os.path.relpath(package.__path__[0], ROOT_PACKAGE_PATH),
-        "index.rst",
-    )
+.. toctree::
+    :maxdepth: 2
 
-
-def write_file(path, contents):
-    """Write a file after ensuring that the target directory exists."""
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as out:
-        out.write(contents)
-
-
-def format_title(title):
-    """
-    Format title for reST.
-
-    reST requires header text to have an underline at least as long as the text.
-    """
-    underline = "=" * len(title)
-    return f"{title}\n{underline}"
-
+    {module_links}
+"""
 
 MODULE_DOC_TEMPLATE = """{title}
 
 {module_doc}
+
+{flowchart}
 
 {argparse_doc}
 
@@ -84,6 +63,89 @@ ARGPARSE_TEMPLATE = """
 
 """
 
+MERMAID_TEMPLATE = """
+.. mermaid:: {mmd_path}
+"""
+
+
+def module_doc_path(module):
+    """Get the path for a module's documentation file."""
+    return os.path.join(
+        DOCS_DIRECTORY,
+        "api_reference",
+        re.sub(r"\.py$", ".rst", os.path.relpath(module.__file__, ROOT_PACKAGE_PATH)),
+    )
+
+
+def module_flowchart_path(module, local=False):
+    """
+    Get the path for a module's mermaid flowchart file.
+
+    If local is True, returns the absolute path to the file.
+    If local is False, returns the path relative to the module's documentation file.
+
+    :param module: Module to get flowchart path for.
+    :param local: Whether to return the absolute path to the file.
+    :return: Path to the module's mermaid flowchart file.
+    """
+    mmd_path = os.path.join(
+        FLOWCHART_DIRECTORY,
+        re.sub(r"\.py$", ".mmd", os.path.relpath(module.__file__, ROOT_PACKAGE_PATH))
+    )
+    if local:
+        return mmd_path
+    else:
+        return os.path.relpath(mmd_path, os.path.split(module_doc_path(module))[0])
+
+
+def package_doc_path(package):
+    """Get the path for a package's documentation file."""
+    return os.path.join(
+        DOCS_DIRECTORY,
+        "api_reference",
+        os.path.relpath(package.__path__[0], ROOT_PACKAGE_PATH),
+        "index.rst",
+    )
+
+
+def package_flowchart_path(package, local=False):
+    """
+    Get the path for a package's mermaid flowchart file.
+
+    If local is True, returns the absolute path to the file.
+    If local is False, returns the path relative to the package's documentation file.
+
+    :param package: Package to get flowchart path for.
+    :param local: Whether to return the absolute path to the file.
+    :return: Path to the package's mermaid flowchart file.
+    """
+    mmd_path = os.path.join(
+        FLOWCHART_DIRECTORY,
+        os.path.relpath(package.__path__[0], ROOT_PACKAGE_PATH),
+        "index.mmd"
+    )
+    if local:
+        return mmd_path
+    else:
+        return os.path.relpath(mmd_path, os.path.split(package_doc_path(package))[0])
+
+
+def write_file(path, contents):
+    """Write a file after ensuring that the target directory exists."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as out:
+        out.write(contents)
+
+
+def format_title(title):
+    """
+    Format title for reST.
+
+    reST requires header text to have an underline at least as long as the text.
+    """
+    underline = "=" * len(title)
+    return f"{title}\n{underline}"
+
 
 def write_module_doc(module_name):
     """Write API reference documentation file for a module."""
@@ -94,26 +156,21 @@ def write_module_doc(module_name):
     else:
         argparse_doc = ""
 
+    if os.path.exists(module_flowchart_path(module, local=True)):
+        flowchart = MERMAID_TEMPLATE.format(mmd_path=package_flowchart_path(module))
+    else:
+        flowchart = ""
+
     doc = MODULE_DOC_TEMPLATE.format(
         module_name=module_name,
         title=format_title(module_name),
         module_doc=module.__doc__ or "",
+        flowchart=flowchart,
         argparse_doc=argparse_doc,
     )
 
     doc_path = module_doc_path(module)
     write_file(doc_path, doc)
-
-
-PACKAGE_DOC_TEMPLATE = """{title}
-
-{package_doc}
-
-.. toctree::
-    :maxdepth: 2
-
-    {module_links}
-"""
 
 
 def write_package_doc(package_name):
@@ -134,15 +191,20 @@ def write_package_doc(package_name):
             write_module_doc(full_module_name)
             module_links.append(f"{module.name} <{module.name}>")
 
+    if os.path.exists(package_flowchart_path(package, local=True)):
+        flowchart = MERMAID_TEMPLATE.format(mmd_path=package_flowchart_path(package))
+    else:
+        flowchart = ""
+
     doc = PACKAGE_DOC_TEMPLATE.format(
         title=format_title(package_name),
         package_doc=package.__doc__ or "",
+        flowchart=flowchart,
         module_links="\n    ".join(module_links),
     )
 
     doc_path = package_doc_path(package)
     write_file(doc_path, doc)
-
 
 
 if __name__ == "__main__":
@@ -159,6 +221,7 @@ if __name__ == "__main__":
     root_doc = PACKAGE_DOC_TEMPLATE.format(
         title=format_title("gnomad_qc"),
         package_doc="",
+        flowchart="",
         module_links="\n    ".join(
             f"{pkg.split('.')[1]} <{pkg.split('.')[1]}/index>"
             for pkg in top_level_packages

--- a/docs/generate_api_reference.py
+++ b/docs/generate_api_reference.py
@@ -86,6 +86,7 @@ def module_flowchart_path(module, local=False):
 
     :param module: Module to get flowchart path for.
     :param local: Whether to return the absolute path to the file.
+        Default is False.
     :return: Path to the module's mermaid flowchart file.
     """
     mmd_path = os.path.join(
@@ -117,6 +118,7 @@ def package_flowchart_path(package, local=False):
 
     :param package: Package to get flowchart path for.
     :param local: Whether to return the absolute path to the file.
+        Default is False.
     :return: Path to the package's mermaid flowchart file.
     """
     mmd_path = os.path.join(

--- a/docs/requirements.docs.in
+++ b/docs/requirements.docs.in
@@ -5,4 +5,5 @@ urllib3<2
 sphinx-argparse
 sphinx-autodoc-typehints
 sphinx-rtd-theme
+sphinxcontrib-mermaid
 Jinja2

--- a/docs/requirements.docs.txt
+++ b/docs/requirements.docs.txt
@@ -79,6 +79,8 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
+sphinxcontrib-mermaid==0.9.2
+    # via -r docs/requirements.docs.in
 sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9


### PR DESCRIPTION
As of now I have only added one very simple flowchart, but others can be added to the docs/flowcharts directory to be included at the top of each sphinx documentation page. 