### PR TITLE
Add post-v4.0 freq VDS split fix to ensure all hom refs are kept in all samples

### DIFF
--- a/gnomad_qc/v4/annotations/generate_freq.py
+++ b/gnomad_qc/v4/annotations/generate_freq.py
@@ -957,8 +957,8 @@ def create_final_freq_ht(ht: hl.Table) -> hl.Table:
 
 
 # This function was added post-v4.0 and was not used in the v4.0 release.
-# It is here for reference on how a VDS should be split to ensure all reference
-# data is retained across all variant sites.
+# It is here for reference on how a VDS should be split by subsets of samples 
+# to ensure all reference data is retained across all variant sites.
 def split_vds(
     vds: hl.vds.VariantDataset, strata_expr: hl.expr.Expression
 ) -> Dict[str, hl.vds.VariantDataset]:


### PR DESCRIPTION
This fixes the existing 4.0 code so all hom ref calls are kept in the subsets after the split and densify. I tried to document extensively to make sure future users knew this wasnt used in v4.0 but would have the desired  freq outcome if it were. 