### PR TITLE
Add final release schema check

### DIFF
--- a/gnomad_qc/v4/create_release/create_release_sites_ht.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht.py
@@ -587,6 +587,7 @@ def get_select_global_fields(
 
     :param ht: Final joined HT with globals.
     :param data_type: Dataset's data type: 'exomes' or 'genomes'.
+    :param tables_for_join: List of tables to join into final release HT.
     :return: select mapping from global annotation name to `ht` annotation.
     """
     t_globals = []

--- a/gnomad_qc/v4/resources/constants.py
+++ b/gnomad_qc/v4/resources/constants.py
@@ -1,4 +1,5 @@
 """Script containing version and release constants."""
+
 VERSIONS = ["4.0", "4.1"]
 CURRENT_VERSION = "4.1"
 
@@ -30,8 +31,8 @@ CURRENT_VARIANT_QC_VERSION = "4.0"
 VARIANT_QC_RESULT_VERSIONS = {"exomes": ["4.0", "4.1"], "genomes": ["4.0"]}
 CURRENT_VARIANT_QC_RESULT_VERSION = {"exomes": "4.1", "genomes": "4.0"}
 
-RELEASES = ["4.0"]
-CURRENT_RELEASE = "4.0"
+RELEASES = ["4.0", "4.1"]
+CURRENT_RELEASE = "4.1"
 
 COVERAGE_RELEASES = {"exomes": ["4.0"], "genomes": ["3.0"]}
 CURRENT_COVERAGE_RELEASE = {"exomes": "4.0", "genomes": "3.0"}


### PR DESCRIPTION
We're removing joint freq and associated field from the v4.1 release. This doesnt need too much of a code change as the script was built for adding or removing tables in the join but there was one spot where I missed flexibility beforehand, setting the final schema order. This update checks if the joined HT fields exist in the defined FINALIZED_SCHEMA and removes them from the ordering if they do not, while also throwing a warning that they are not present. 