### PR TITLE
Default to no joint_faf in release

### DIFF
--- a/gnomad_qc/v4/create_release/create_release_sites_ht.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht.py
@@ -83,6 +83,7 @@ TABLES_FOR_RELEASE = [
     "region_flags",
     "in_silico",
     "vep",
+    # "joint_faf",  # NOTE: joint_faf was only included in the v4.0 release.
 ]
 
 INSILICO_PREDICTORS = ["cadd", "revel", "spliceai", "pangolin", "phylop"]

--- a/gnomad_qc/v4/create_release/create_release_sites_ht.py
+++ b/gnomad_qc/v4/create_release/create_release_sites_ht.py
@@ -83,7 +83,6 @@ TABLES_FOR_RELEASE = [
     "region_flags",
     "in_silico",
     "vep",
-    "joint_faf",
 ]
 
 INSILICO_PREDICTORS = ["cadd", "revel", "spliceai", "pangolin", "phylop"]


### PR DESCRIPTION
Since we have decided to no longer include the joint_faf on release HTs, remove it from the default in release HT creation