### PR TITLE
Suggestions to calculate variants per sample in exomes and genomes

### DIFF
--- a/gnomad_qc/v4/create_release/calculate_variant_statistics.py
+++ b/gnomad_qc/v4/create_release/calculate_variant_statistics.py
@@ -261,7 +261,7 @@ def main(args):
             get_per_sample_counts(
                 test=test,
                 data_type=data_type,
-                suffix="stratified_agg",
+                suffix="aggregated_",
             ).path,
             overwrite=overwrite,
         )

--- a/gnomad_qc/v4/create_release/calculate_variant_statistics.py
+++ b/gnomad_qc/v4/create_release/calculate_variant_statistics.py
@@ -1,6 +1,7 @@
 """Script to get per-sample stats by variant type in v4."""
 import argparse
 import logging
+from typing import List
 
 import hail as hl
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
@@ -19,9 +20,6 @@ from gnomad_qc.v4.resources.temp_hail_methods import (
     vmt_sample_qc,
     vmt_sample_qc_variant_annotations,
 )
-
-# from hail.vds.sample_qc import vmt_sample_qc, vmt_sample_qc_variant_annotations
-
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -71,6 +69,11 @@ def create_per_sample_counts(
 
     # Create variant matrix table from VDS and annotate with all relevant info.
     vmt = vds.variant_data
+    logger.info("Variant MT created and checkpointing, without annotations")
+    vmt = vmt.checkpoint(
+        new_temp_file(f'vmt_{"TEST" if test else ""}', extension="mt"),
+        overwrite=overwrite,
+    )
 
     # Add extra Allele Count and Allele Type annotations to variant Matrix
     # Table, according to Hail standards, to help their computation.
@@ -94,11 +97,7 @@ def create_per_sample_counts(
 
     # NOTE: not size efficient, but we are never checkpointing THIS I don't believe
     vmt = vmt.annotate_rows(**ht[vmt.row_key])
-    logger.info("Variant MT created and checkpointing, with necessary annotations")
-    vmt = vmt.checkpoint(
-        new_temp_file(f'vmt_{"TEST" if test else ""}', extension="mt"),
-        overwrite=overwrite,
-    )
+
     arg_dict = {"all_variants": ~hl.is_missing(vmt.locus)}
 
     if pass_filters:
@@ -109,7 +108,7 @@ def create_per_sample_counts(
         arg_dict.update(
             {"broad_regions": ~vmt.region_flags.outside_broad_capture_region}
         )
-    if ukb_regions & broad_regions:
+    if ukb_regions and broad_regions:
         arg_dict.update(
             {
                 "ukb_and_broad_regions": (
@@ -147,144 +146,56 @@ def create_per_sample_counts(
     return sample_qc_ht
 
 
-def aggregate_and_stratify(
+def compute_stratified_agg_stats(
+    ht: hl.Table,
     data_type: str = "exomes",
-    test: bool = False,
-    overwrite: bool = False,
-    agg_variant_qc: bool = False,
-    agg_ukb_regions: bool = False,
-    agg_broad_regions: bool = False,
-    agg_lof: bool = False,
-    agg_rare_variants: bool = False,
-    counts_by_pop: bool = False,
-    suffix: str = None,
-    write_counts: bool = False,
-) -> None:
+    qc_metrics: List[str] = ["n_het", "n_hom_var", "n_non_ref", "n_singleton"],
+    strats: List[str] = ["all_variants"],
+    by_ancestry: bool = False,
+) -> hl.Table:
     """
-    Read in per-sample variant counts Table and output relevant summary stats.
+    Compute aggregate statistics for stratified sample QC metrics.
 
-    :param data_type: String to read in either "exomes" or "genomes".
-    :param test: Bool of whether or not to read in a test output.
-    :param Overwrite: Write over existing file.
-    :param agg_variant_qc: Stratify by variants which pass variant qc.
-    :param agg_ukb_regions: Stratify by variants in UKB regions.
-    :param agg_broad_regions: Stratify by variants in Broad regions.
-    :param agg_lof: Stratify by variants which are loss-of-function.
-    :param agg_rare_variants: Stratify by variants which have adj AF <0.1%.
-    :param counts_by_pop: Bool to calculate number of singletons, n_het, and n_hom by v4 pop.
-    :param suffix: String of suffix of Sample QC table to read in.
-    :param write_counts: Write out Hail dict of results.
+    :param ht: Table containing sample QC metrics.
+    :param data_type: String of either "exomes" or "genomes". Default is "exomes".
+    :param qc_metrics: List of sample QC metrics to compute aggregate statistics for.
+    :param strats: List of strata to compute aggregate statistics for.
+    :param by_ancestry: Boolean indicating whether to stratify by ancestry.
+    :return: Table containing aggregate statistics for stratified sample QC metrics.
     """
-    logger.info("Reading Sample QC HT in from resource")
-    sample_qc_ht = hl.read_table(
-        get_per_sample_counts(test=test, data_type=data_type, suffix=suffix).path
-    )
-    logger.info(
-        "via:"
-        f" {get_per_sample_counts(test=test, data_type=data_type, suffix=suffix).path}"
-    )
 
-    # Define internal method to return all desired counts in a struct.
-    # This code would be repeated in code otherwise.
-    def _count_struct(input_ht, input_strat):
-        ret_struct = hl.struct(
-            mean_nonref=hl.agg.mean(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_non_ref
-            ),
-            quantiles_nonref=hl.agg.approx_quantiles(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_non_ref,
-                qs=[0, 0.25, 0.50, 0.75, 1.0],
-            ),
-            mean_singletons=hl.agg.mean(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_singleton
-            ),
-            quantiles_singletons=hl.agg.approx_quantiles(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_singleton,
-                qs=[0, 0.25, 0.50, 0.75, 1.0],
-            ),
-            mean_het=hl.agg.mean(input_ht.aggregated_vmt_sample_qc[input_strat].n_het),
-            quantiles_het=hl.agg.approx_quantiles(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_het,
-                qs=[0, 0.25, 0.50, 0.75, 1.0],
-            ),
-            mean_hom=hl.agg.mean(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_hom_var
-            ),
-            quantiles_hom=hl.agg.approx_quantiles(
-                input_ht.aggregated_vmt_sample_qc[input_strat].n_hom_var,
-                qs=[0, 0.25, 0.50, 0.75, 1.0],
-            ),
+    def _get_metric_stats(ht, strat, metric):
+        metric_expr = ht.aggregated_vmt_sample_qc[strat][metric]
+        metric_mean = hl.agg.mean(metric_expr)
+        metric_quantiles = hl.agg.approx_quantiles(
+            metric_expr, [0.0, 0.25, 0.5, 0.75, 1.0]
         )
 
-        return ret_struct
+        return hl.struct(mean=metric_mean, quantiles=metric_quantiles)
 
-    # Print stats about an aggregation
-    # MUST be generated by _count_struct or have identical formatting
-    def _logger_struct(
-        input_struct: hl.struct, input_strat: str, input_pop: str = "ALL"
-    ) -> None:
-        logger.info(
-            f"For pop {input_pop} in stratification {input_strat}:"
-            f"\n\tmean nonref as {input_struct.mean_nonref}"
-            f"\n\tmean singletons as {input_struct.mean_singletons}"
-            f"\n\tmean het as {input_struct.mean_het}"
-            f"\n\tand mean hom as {input_struct.mean_hom}"
-        )
-
-    # Create list of calls to stratify by
-    stratifications = ["all_variants"]
-
-    if agg_variant_qc:
-        stratifications.append("pass_all_vqc")
-    if agg_ukb_regions:
-        stratifications.append("inside_ukb_regions")
-    if agg_broad_regions:
-        stratifications.append("inside_broad_regions")
-    if agg_rare_variants:
-        stratifications.append("rare_variants")
-    if agg_lof:
-        stratifications.append("is_lof")
-
-    # Column 'n_non_ref' is a per-sample metric of the number of variants called.
-    # Report some stats of interest from this table.
-
-    if counts_by_pop:
-        logger.info("Reading in meta HT.")
-        meta_ht = meta(data_type=data_type).ht()
-
-    # Dictionary to write out if user desires.
-    returned_counts = {}
-
-    for strat in stratifications:
-        logger.info(f"STRATIFICATION: {strat}")
-        called_per_distribution = sample_qc_ht.aggregate(
-            _count_struct(sample_qc_ht, strat)
-        )
-
-        _logger_struct(input_struct=called_per_distribution, input_strat=strat)
-
-        returned_counts[f"{strat}_all_samples"] = called_per_distribution
-
-        # Calculate number of singletons by inputed ancestry by stratification
-        if counts_by_pop:
-            # Add population inference, as keyed by 's'.
-            sample_qc_ht = sample_qc_ht.annotate(
-                pop=meta_ht[sample_qc_ht.s].population_inference.pop
-            )
-
-            # Aggregate and print outputs.
-            dictionary_results = sample_qc_ht.aggregate(
-                hl.agg.group_by(sample_qc_ht.pop, _count_struct(sample_qc_ht, strat))
-            )
-
-            for pop_record in dictionary_results.items():
-                pop_label = pop_record[0]
-                pop_struct = pop_record[1]
-                _logger_struct(
-                    input_struct=pop_struct, input_strat=strat, input_pop=pop_label
+    def _get_agg_expr(ht):
+        return hl.struct(
+            **{
+                strat: hl.struct(
+                    **{
+                        _metric: _get_metric_stats(ht, strat, _metric)
+                        for _metric in qc_metrics
+                    }
                 )
+                for strat in strats
+            }
+        )
 
-                returned_counts[f"{strat}_{pop_label}_specific"] = pop_struct
+    ht = ht.annotate_globals(all_samples=ht.aggregate(_get_agg_expr(ht)))
+
+    if by_ancestry:
+        meta_ht = meta(data_type=data_type).ht()
+        ht = ht.annotate(gen_anc=meta_ht[ht.s].population_inference.pop)
+        by_ancestry_agg = ht.aggregate(hl.agg.group_by(ht.gen_anc, _get_agg_expr(ht)))
+        by_ancestry_agg.pop(None)
+        ht = ht.annotate_globals(**by_ancestry_agg)
+
+    return ht
 
 
 def main(args):
@@ -300,46 +211,58 @@ def main(args):
     data_type = args.data_type
     test = args.test
     overwrite = args.overwrite
-    filter_variant_qc = args.filter_variant_qc
-    filter_ukb_regions = args.filter_ukb_regions
-    filter_broad_regions = args.filter_broad_regions
-    agg_variant_qc = args.agg_variant_qc
-    agg_ukb_regions = args.agg_ukb_regions
-    agg_broad_regions = args.agg_broad_regions
-    agg_lof = args.agg_lof
-    agg_rare_variants = args.agg_rare_variants
-    counts_by_pop = args.counts_by_pop
-    write_counts = args.write_counts
+    pass_filters = args.pass_filters
+    ukb_regions = args.filter_ukb_regions
+    broad_regions = args.filter_broad_regions
+    by_csqs = args.by_csqs
+    rare_variants = args.rare_variants
+    by_ancestry = args.by_ancestry
 
-    if args.create_per_sample_counts_resource:
+    # suffix = (
+    #     f"{'ukb_calling.' if ukb_regions else ''}"
+    #     f"{'broad_calling.' if broad_regions else ''}"
+    #     f"{'pass.' if pass_filters else ''}{args.custom_suffix if args.custom_suffix else ''}"
+    # )
+
+    if args.create_per_sample_counts:
         per_sample_ht = create_per_sample_counts(
             data_type=data_type,
             test=test,
-            pass_filters=filter_variant_qc,
-            ukb_regions=filter_ukb_regions,
-            broad_regions=filter_broad_regions,
-            by_csqs=True,
-            rare_variants=agg_rare_variants,
+            pass_filters=pass_filters,
+            ukb_regions=ukb_regions,
+            broad_regions=broad_regions,
+            by_csqs=by_csqs,
+            rare_variants=rare_variants,
         )
 
-        per_sample_ht = per_sample_ht.checkpoint(
-            get_per_sample_counts(test=test, data_type=data_type, suffix=suffix).path,
+        per_sample_ht.checkpoint(
+            get_per_sample_counts(test=test, data_type=data_type).path,
             overwrite=overwrite,
         )
 
-    if args.aggregate_and_stratify:
-        aggregate_and_stratify(
+    if args.stratify_and_aggregate:
+        per_sample_ht = get_per_sample_counts(test=test, data_type=data_type).ht()
+        stratified_agg_ht = compute_stratified_agg_stats(
+            per_sample_ht,
             data_type=data_type,
-            test=test,
+            strats=[
+                "all_variants",
+                "pass_filters",
+                "ukb_regions",
+                "broad_regions",
+                "rare_variants",
+                "lof",
+                "missense",
+                "synonymous",
+            ],
+            by_ancestry=by_ancestry,
+        )
+
+        stratified_agg_ht.checkpoint(
+            get_per_sample_counts(
+                test=test, data_type=data_type, agg_globals=True
+            ).path,
             overwrite=overwrite,
-            agg_variant_qc=agg_variant_qc,
-            agg_ukb_regions=agg_ukb_regions,
-            agg_broad_regions=agg_broad_regions,
-            agg_lof=agg_lof,
-            agg_rare_variants=agg_rare_variants,
-            counts_by_pop=counts_by_pop,
-            suffix=suffix,
-            write_counts=write_counts,
         )
 
 
@@ -366,60 +289,45 @@ if __name__ == "__main__":
         help="Data type (exomes or genomes) to produce summary stats for.",
     )
     parser.add_argument(
-        "--create-per-sample-counts-resource",
-        help="Run code and output to create_per_sample_counts_resource",
+        "--create-per-sample-counts",
+        help="Create per-sample counts resource",
         action="store_true",
     )
     parser.add_argument(
-        "--filter-variant-qc",
+        "--stratify-and-aggregate",
+        help="Run code to aggregate and stratify (exising?) sample qc table",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--pass-filters",
         help=(
-            "Only calculate per-sample variants for those variants that pass all"
+            "Calculate per-sample variants for those variants that pass all"
             " variant qc filters."
         ),
         action="store_true",
     )
     parser.add_argument(
         "--filter-ukb-regions",
-        help="Filter to variants only in UKB capture regions",
+        help="Filter to variants in UKB capture regions",
         action="store_true",
     )
     parser.add_argument(
         "--filter-broad-regions",
-        help="Filter to variants only in Broad capture regions",
+        help="Filter to variants in Broad capture regions",
         action="store_true",
     )
     parser.add_argument(
-        "--agg-broad-regions",
-        help="Stratify by variants in Broad regions.",
+        "--rare-variants",
+        help="Filter to variants with adj AF <0.1%.",
         action="store_true",
     )
     parser.add_argument(
-        "--agg-ukb-regions",
-        help="Stratify by variants in UKB regions.",
+        "--by-csqs",
+        help="Stratify by variants consequences.",
         action="store_true",
     )
     parser.add_argument(
-        "--agg-rare-variants",
-        help="Stratify by variants which have adj AF <0.1%.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--agg-lof",
-        help="Stratify by variants which are loss-of-function.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--agg-variant-qc",
-        help="Stratify by variants which pass variant qc.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--aggregate-and-stratify",
-        help="Run code to aggregate and stratify (exising?) sample qc table",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--counts-by-pop",
+        "--by-ancestry",
         help=(
             "Output statistics for number of singletons, n_het, and n_hom by population"
             " group"
@@ -431,11 +339,6 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Custom string to append to output names",
-    )
-    parser.add_argument(
-        "--write-counts",
-        action="store_true",
-        help="Write counts to dictionary in tmp dir",
     )
     args = parser.parse_args()
 

--- a/gnomad_qc/v4/create_release/calculate_variant_statistics.py
+++ b/gnomad_qc/v4/create_release/calculate_variant_statistics.py
@@ -4,7 +4,6 @@ import logging
 from typing import List
 
 import hail as hl
-from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.vep import (
     filter_vep_transcript_csqs,
@@ -12,8 +11,8 @@ from gnomad.utils.vep import (
 )
 from hail.utils.misc import new_temp_file
 
-import gnomad_qc.v4.resources.meta as meta
 from gnomad_qc.slack_creds import slack_token
+from gnomad_qc.v4.resources import meta
 from gnomad_qc.v4.resources.basics import get_gnomad_v4_vds
 from gnomad_qc.v4.resources.release import get_per_sample_counts, release_sites
 from gnomad_qc.v4.resources.temp_hail_methods import (
@@ -260,7 +259,9 @@ def main(args):
 
         stratified_agg_ht.checkpoint(
             get_per_sample_counts(
-                test=test, data_type=data_type, agg_globals=True
+                test=test,
+                data_type=data_type,
+                suffix="stratified_agg",
             ).path,
             overwrite=overwrite,
         )

--- a/gnomad_qc/v4/create_release/calculate_variant_statistics.py
+++ b/gnomad_qc/v4/create_release/calculate_variant_statistics.py
@@ -66,16 +66,11 @@ def create_per_sample_counts(
         logger.info("Test: filtering to variants on chr22")
         ht = ht.filter(ht.locus.contig == "chr22")
 
-    # logger.info("Filter VDS to variants in gnomAD release.")
-    # vds = hl.vds.filter_variants(vds, ht.select())
+    logger.info("Filter VDS to variants in gnomAD release.")
+    vds = hl.vds.filter_variants(vds, ht.select())
 
     # Create variant matrix table from VDS and annotate with all relevant info.
     vmt = vds.variant_data
-    logger.info("Variant MT created and checkpointing, without annotations")
-    vmt = vmt.checkpoint(
-        new_temp_file(f'vmt_{"TEST" if test else ""}_mt', extension="mt"),
-        overwrite=overwrite,
-    )
 
     # Add extra Allele Count and Allele Type annotations to variant Matrix
     # Table, according to Hail standards, to help their computation.
@@ -99,7 +94,11 @@ def create_per_sample_counts(
 
     # NOTE: not size efficient, but we are never checkpointing THIS I don't believe
     vmt = vmt.annotate_rows(**ht[vmt.row_key])
-
+    logger.info("Variant MT created and checkpointing, with necessary annotations")
+    vmt = vmt.checkpoint(
+        new_temp_file(f'vmt_{"TEST" if test else ""}', extension="mt"),
+        overwrite=overwrite,
+    )
     arg_dict = {"all_variants": ~hl.is_missing(vmt.locus)}
 
     if pass_filters:

--- a/gnomad_qc/v4/create_release/calculate_variant_statistics.py
+++ b/gnomad_qc/v4/create_release/calculate_variant_statistics.py
@@ -191,6 +191,7 @@ def compute_stratified_agg_stats(
         meta_ht = meta(data_type=data_type).ht()
         ht = ht.annotate(gen_anc=meta_ht[ht.s].population_inference.pop)
         by_ancestry_agg = ht.aggregate(hl.agg.group_by(ht.gen_anc, _get_agg_expr(ht)))
+        # Remove 'None' key, otherwise it can't be annotated to globals
         by_ancestry_agg.pop(None)
         ht = ht.annotate_globals(**by_ancestry_agg)
 

--- a/gnomad_qc/v4/resources/temp_hail_methods.py
+++ b/gnomad_qc/v4/resources/temp_hail_methods.py
@@ -1,10 +1,14 @@
-"""THIS IS A TEMPORARY FILE TO BE USED UNTIL THESE HAIL METHODS ARE RELEASED. 
-CODE WAS COPIED DIRECTLY FROM A PR IN GITHUB BROWSER ON 02/20 (iirc) AND SHOULD NOT BE RAN ON RELEASE."""
-import hail as hl
+"""
+THIS IS A TEMPORARY FILE TO BE USED UNTIL THESE HAIL METHODS ARE RELEASED.
+
+CODE WAS COPIED DIRECTLY FROM A PR IN GITHUB BROWSER ON 02/20 (iirc) AND SHOULD NOT BE RAN ON RELEASE.
+"""
 from typing import Optional, Sequence
+
+import hail as hl
 from hail.expr.expressions import Expression
 from hail.expr.functions import _allele_types, _num_allele_type
-from hail.utils.misc import divide_null, new_temp_file, wrap_to_list
+from hail.utils.misc import divide_null
 
 
 def vmt_sample_qc(
@@ -16,9 +20,19 @@ def vmt_sample_qc(
     dp: Optional["Expression"] = None,
     gq_bins: "Sequence[int]" = (0, 20, 60),
     dp_bins: "Sequence[int]" = (0, 1, 10, 20, 30),
-    dp_field: Optional[str] = None,
 ) -> "Expression":
-    """"""
+    """
+    Compute sample QC metrics.
+
+    :param global_gt: Global GT field.
+    :param gq: GQ field.
+    :param variant_ac: Variant AC field.
+    :param variant_atypes: Variant allele types.
+    :param dp: DP field. Default is None.
+    :param gq_bins: GQ bins. Default is (0, 20, 60).
+    :param dp_bins: DP bins. Default is (0, 1, 10, 20, 30).
+    :return: StructExpression with sample QC metrics.
+    """
     allele_types = _allele_types[:]
     allele_types.extend(["Transition", "Transversion"])
     allele_enum = {i: v for i, v in enumerate(allele_types)}
@@ -137,8 +151,13 @@ def vmt_sample_qc_variant_annotations(
     global_gt: "Expression",
     alleles: "Expression",
 ) -> "Expression":
-    """"""
+    """
+    Compute sample QC metrics from variant annotations.
 
+    :param global_gt: Global GT field.
+    :param alleles: Alleles field.
+    :return: StructExpression with sample QC metrics.
+    """
     allele_types = _allele_types[:]
     allele_types.extend(["Transition", "Transversion"])
     allele_enum = {i: v for i, v in enumerate(allele_types)}


### PR DESCRIPTION
I simplified the two functions and renamed a few things, I added in option to get the count of missense and synonymous variants. I also prefer to write the aggregated stats in the HT globals, I think it's better structured this way. We'll discuss if only output just one final HT, but make it two steps. 
I got the same number of all_variants the same as you for 1 sample, but number of variants passing filters are not again the same, I think the new Exome release seems changed, we need to confirm with Julia for that. 
My test run is here: [bcd45e3f472b4033bfac9532a022dafe](https://console.cloud.google.com/dataproc/jobs/bcd45e3f472b4033bfac9532a022dafe?region=us-central1&project=broad-mpg-gnomad)