### PR TITLE
Get REVEL score for variants in missing MANE transcripts

### DIFF
--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -592,7 +592,6 @@ def get_revel_for_unmatched_transcripts() -> None:
         ht = ht.annotate(REVEL_max=revel[ht.key].REVEL_max)
         # Filter out variants without a REVEL score
         ht = ht.filter(hl.is_defined(ht.REVEL_max))
-        print(ht.count())
         ht.export(
             "gs://gnomad-insilico/revel/gnomad.v4.1."
             f"{data_type}.revel_unmatched_transcripts.tsv.bgz"

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -515,12 +515,12 @@ def get_revel_for_unmatched_transcripts() -> None:
 
     ..note:
 
-        REVEL was computed using transcripts from Ensembl v64. In gnomAD v4.0 and
-        v4.1 release Table, we used transcript information from Ensembl v105 in addition
-        to variant information (locus and alleles combination) to ascertain variant
-        REVEL scores, We also only reported scores for MANE select or canonical
-        transcripts. This means that variants within 2,414 MANE select transcripts
-        present in gnomAD v4.0/v4.1 but not present in Ensembl v64 were missing REVEL scores.
+        REVEL was computed using transcripts from Ensembl v64. In the gnomAD v4.0
+        and v4.1 release Tables, transcript information from Ensembl v105 and variant
+        information (locus and alleles combination) were used to ascertain variant
+        REVEL scores for MANE select or canonical transcripts only. This means that
+        variants within 2,414 MANE select transcripts in gnomAD v4.0 and v4.1 are
+        missing REVEL scores because they are not present in Ensembl v64.
 
         To address this, we annotated the variants within the 2,414 genes with the
         maximum REVEL score found at the specific locus and allele, rather than the
@@ -574,7 +574,7 @@ def get_revel_for_unmatched_transcripts() -> None:
 
     # Get genes missing revel scores
     genes = hl.import_table(
-        "gs://gnomad-insilico/Ensembl105MANE_without_REVEL.txt",
+        "gs://gnomad-insilico/revel/Ensembl105MANE_without_REVEL.txt",
         impute=True,
         comment="#",
     )

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -514,21 +514,21 @@ def get_revel_for_unmatched_transcripts() -> None:
     Create Tables with alternative REVEL scores for variants in v4.1 release.
 
     ..note:
-        REVEL was computed using transcripts from Ensembl v64. However, in gnomAD
-        v4.0 and v4.1, we used transcript information from Ensembl v105 in addition
+
+        REVEL was computed using transcripts from Ensembl v64. In gnomAD v4.0 and
+        v4.1 release Table, we used transcript information from Ensembl v105 in addition
         to variant information (locus and alleles combination) to ascertain variant
         REVEL scores, We also only reported scores for MANE select or canonical
-        transcripts. Please refer to create_revel_grch38_ht() function above. This
-        means that variants within 2,414 MANE select transcripts present in gnomAD
-        v4.0/v4.1 but not present in Ensembl v64 were missing REVEL scores.
+        transcripts. This means that variants within 2,414 MANE select transcripts
+        present in gnomAD v4.0/v4.1 but not present in Ensembl v64 were missing REVEL scores.
 
-        To address this, we annotated REVEL scores for variants within those 2,
-        414 transcripts using locus and allele information only (taking the maximum
-        score if a variant had multiple scores). These files contain only variants
-        from these 2,414 genes. The exomes TSV adds REVEL scores for 1,936,321 out of
-        2,284,296 (87.77%) missense variants that were previously missing REVEL
-        scores in gnomAD v4.0. The genomes TSV adds REVEL scores for 528,204 out of
-        620,799 ( 85.08%) missense variants that were previously missing REVEL scores.
+        To address this, we annotated the variants within the 2,414 genes with the
+        maximum REVEL score found at the specific locus and allele, rather than the
+        score for the MANE Select transcript.
+
+        The exomes TSV adds REVEL scores to 1,936,321 out of 2,284,296 (87.77%)
+        missense variants within the 2,414 genes. The genomes TSV adds REVEL scores
+        to 528,204 out of 620,799 ( 85.08%) missense variants within the 2,414 genes.
     """
 
     def _process_revel():
@@ -586,7 +586,7 @@ def get_revel_for_unmatched_transcripts() -> None:
         ht = ht.checkpoint(hl.utils.new_temp_file(f"{data_type}_tmp_filtered", "ht"))
         # Join REVEL scores with release sites
         ht = ht.annotate(REVEL_max=revel[ht.key].REVEL_max)
-        # Filter out variants with missing REVEL scores
+        # Filter out variants without a REVEL score
         ht = ht.filter(hl.is_defined(ht.REVEL_max))
         ht.export(
             "gs://gnomad-insilico/revel/gnomad.v4.1."
@@ -645,8 +645,6 @@ def main(args):
             "Get REVEL score for variants in missing MANE transcripts in v4.1"
             " release..."
         )
-        # This will create a table with REVEL scores for variants in v4.1 release
-        # that don't have a score in release Table.
         get_revel_for_unmatched_transcripts()
     if args.phylop:
         logger.info("Creating PhyloP Hail Table for GRCh38...")

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -558,9 +558,13 @@ def get_revel_for_unmatched_transcripts() -> None:
     def _filter_release_ht(data_type, genes_list):
         """Filter release sites to only include genes with missing revel scores."""
         ht = release_sites(data_type=data_type).ht()
-        ht = process_consequences(ht)
+        ht = process_consequences(ht, has_polyphen=False)
         ht = filter_vep_transcript_csqs(
-            ht, synonymous=False, genes=genes_list, csqs=["missense_variant"]
+            ht,
+            synonymous=False,
+            mane_select=True,
+            genes=genes_list,
+            csqs=["missense_variant"],
         )
         ht = ht.select(
             gene_id=ht.vep.transcript_consequences.gene_id,
@@ -588,6 +592,7 @@ def get_revel_for_unmatched_transcripts() -> None:
         ht = ht.annotate(REVEL_max=revel[ht.key].REVEL_max)
         # Filter out variants without a REVEL score
         ht = ht.filter(hl.is_defined(ht.REVEL_max))
+        print(ht.count())
         ht.export(
             "gs://gnomad-insilico/revel/gnomad.v4.1."
             f"{data_type}.revel_unmatched_transcripts.tsv.bgz"

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -645,7 +645,6 @@ def main(args):
             " release..."
         )
         get_revel_for_unmatched_transcripts()
-
     if args.phylop:
         logger.info("Creating PhyloP Hail Table for GRCh38...")
         ht = create_phylop_grch38_ht()

--- a/gnomad_qc/v4/annotations/insilico_predictors.py
+++ b/gnomad_qc/v4/annotations/insilico_predictors.py
@@ -5,11 +5,12 @@ import logging
 import hail as hl
 from gnomad.resources.resource_utils import NO_CHR_TO_CHR_CONTIG_RECODING
 from gnomad.utils.slack import slack_notifications
-from gnomad.utils.vep import filter_vep_transcript_csqs
+from gnomad.utils.vep import filter_vep_transcript_csqs, process_consequences
 from hail.utils import new_temp_file
 
 from gnomad_qc.slack_creds import slack_token
 from gnomad_qc.v4.resources.annotations import get_insilico_predictors
+from gnomad_qc.v4.resources.release import release_sites
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -508,6 +509,90 @@ def create_phylop_grch38_ht() -> hl.Table:
     return ht
 
 
+def get_revel_for_unmatched_transcripts() -> None:
+    """Create Tables with REVEL scores for variants in v4.1 release in Ensembl v105 MANE Select transcripts that are not found in REVEL (Ensembl v64)."""
+
+    def _process_revel():
+        """Process REVEL scores."""
+        revel_csv = "gs://gnomad-insilico/revel/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz"
+
+        ht = hl.import_table(
+            revel_csv,
+            delimiter=",",
+            min_partitions=1000,
+            types={"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
+        )
+
+        ht = ht.drop("hg19_pos", "aaref", "aaalt")
+        # drop variants that have no position in GRCh38 when lifted over from GRCh37
+        ht = ht.filter(ht.grch38_pos.contains("."), keep=False)
+        ht = ht.transmute(chr="chr" + ht.chr)
+        ht = ht.select(
+            locus=hl.locus(ht.chr, hl.int(ht.grch38_pos), reference_genome="GRCh38"),
+            alleles=hl.array([ht.ref, ht.alt]),
+            REVEL=ht.REVEL,
+            Transcript_stable_ID=ht.Ensembl_transcriptid.strip().split(";"),
+        )
+        ht = ht.key_by("locus", "alleles")
+        ht = ht.group_by("locus", "alleles").aggregate(
+            REVEL_max=hl.agg.max(revel.REVEL)
+        )
+        return ht
+
+    def _filter_release_ht(data_type, genes_list):
+        ht = release_sites(data_type=data_type).ht()
+        ht = process_consequences(ht)
+        ht = filter_vep_transcript_csqs(
+            ht, synonymous=False, genes=genes_list, csqs=["missense_variant"]
+        )
+        ht = ht.select(
+            gene_id=ht.vep.transcript_consequences.gene_id,
+            most_severe_consequence=ht.vep.transcript_consequences.most_severe_consequence,
+        )
+        return ht
+
+    # Get the max REVEL score for each variant
+    revel = _process_revel()
+    revel = revel
+    revel = revel.checkpoint(hl.utils.new_temp_file("revel_tmp", "ht"))
+
+    # Get genes missing revel scores
+    genes = hl.import_table(
+        "gs://gnomad-insilico/Ensembl105MANE_without_REVEL.txt",
+        impute=True,
+        comment="#",
+    )
+    genes_list = genes.Gene_stable_ID.collect()
+
+    # Filter exomes and genomes release sites to only include genes with missing revel
+    # scores and annotated as "missense_variant"
+    exomes = _filter_release_ht("exomes", genes_list)
+    exomes = exomes.checkpoint(hl.utils.new_temp_file("exomes_tmp_filtered", "ht"))
+
+    genomes = _filter_release_ht("genomes", genes_list)
+    genomes = genomes.checkpoint(hl.utils.new_temp_file("genomes_tmp_filtered", "ht"))
+
+    # Join REVEL scores with exomes and genomes release sites
+    exomes = exomes.annotate(REVEL_max=revel[exomes.key].REVEL_max)
+    genomes = genomes.annotate(REVEL_max=revel[genomes.key].REVEL_max)
+
+    # Filter out variants with missing REVEL scores
+    exomes = exomes.filter(hl.is_defined(exomes.REVEL_max))
+    # Check if this example variant now has a REVEL score
+    exomes.filter(
+        (exomes.locus.contig == "chr1") & (exomes.locus.position == 173856729)
+    ).show()
+    genomes = genomes.filter(hl.is_defined(genomes.REVEL_max))
+
+    # Write to file
+    exomes.export(
+        "gs://gnomad-insilico/revel/gnomad_v4.1_exomes_REVEL_for_genes_unmatching_transcripts.tsv.bgz"
+    )
+    genomes.export(
+        "gs://gnomad-insilico/revel/gnomad_v4.1_genomes_REVEL_for_genes_unmatching_transcripts.tsv.bgz"
+    )
+
+
 def main(args):
     """Generate Hail Tables with in silico predictors."""
     hl.init(
@@ -554,6 +639,13 @@ def main(args):
             overwrite=args.overwrite,
         )
         logger.info("REVEL Hail Table for GRCh38 created.")
+    if args.revel_unmatched_transcripts:
+        logger.info(
+            "Get REVEL score for variants in missing MANE transcripts in v4.1"
+            " release..."
+        )
+        get_revel_for_unmatched_transcripts()
+
     if args.phylop:
         logger.info("Creating PhyloP Hail Table for GRCh38...")
         ht = create_phylop_grch38_ht()


### PR DESCRIPTION
This adds in a function to create Tables with REVEL scores for variants in v4.1 release in Ensembl v105 MANE Select transcripts that are not found in REVEL (Ensembl v64).