### PR TITLE
Add sex, freq_index_dict and faf_index_dict in joint release HT

### DIFF
--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -650,8 +650,12 @@ def create_final_combined_faf_release(
             stat_expr = hl.array([stat_expr])
 
         stat_expr = stat_expr.map(
-            lambda x: x.annotate(
-                **{a: hl.or_missing(~hl.is_nan(x[a]), x[a]) for a in x}
+            lambda x: x.select(
+                **{
+                    a: hl.or_missing(~hl.is_nan(x[a]), x[a])
+                    for a in x
+                    if a != "oddsratio_pooled"
+                }
             )
         )
 

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -125,6 +125,7 @@ def extract_freq_info(
         combine_operator="or",
         exact_match=True,
     )
+    freq_index_dict = make_freq_index_dict_from_meta(hl.literal(freq_meta))
     faf_meta, faf = filter_arrays_by_meta(
         ht.faf_meta,
         {"faf": ht.faf},
@@ -139,6 +140,7 @@ def extract_freq_info(
         {"group": ["adj"]},
         combine_operator="or",
     )
+    faf_index_dict = make_freq_index_dict_from_meta(hl.literal(faf_meta))
 
     # Select grpmax and fafmax
     grpmax_expr = ht.grpmax
@@ -170,8 +172,10 @@ def extract_freq_info(
     ht = ht.select_globals(
         **{
             f"{prefix}_freq_meta": freq_meta,
+            f"{prefix}_freq_index_dict": freq_index_dict,
             f"{prefix}_freq_meta_sample_count": array_exprs["freq_meta_sample_count"],
             f"{prefix}_faf_meta": faf_meta,
+            f"{prefix}_faf_index_dict": faf_index_dict,
             f"{prefix}_age_distribution": ht.age_distribution,
         }
     )
@@ -949,7 +953,12 @@ def main(args):
                 # CMH test on the entire Table.
                 n_part = ht.n_partitions()
                 logger.info(f"Number of partitions: {n_part}")
-                n_split = int(n_part / 10)
+                if n_part < 10:
+                    n_split = 1
+                else:
+                    n_split = int(n_part / 10)
+                # TODO: it fails if n_part < 10 when testing.
+                # n_part < 10
                 hts = []
                 for i in range(0, n_part, n_split):
                     # Min to ensure we do not try to read more partitions than exist in

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -128,7 +128,7 @@ def extract_freq_info(
     faf_meta, faf = filter_arrays_by_meta(
         ht.faf_meta,
         {"faf": ht.faf},
-        ["group", "gen_anc"],
+        ["group", "gen_anc", "sex"],
         combine_operator="or",
         exact_match=True,
     )

--- a/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
+++ b/gnomad_qc/v4/create_release/create_combined_faf_release_ht.py
@@ -126,6 +126,11 @@ def extract_freq_info(
         exact_match=True,
     )
     freq_index_dict = make_freq_index_dict_from_meta(hl.literal(freq_meta))
+    logger.info(
+        "Keeping only FAF for adj, adj by pop, adj by sex, and adj by pop/sex..."
+    )
+    # Exomes FAF was calculated for the whole gnomad and the ukb subset, we only
+    # want to include the whole dataset in the joint release.
     faf_meta, faf = filter_arrays_by_meta(
         ht.faf_meta,
         {"faf": ht.faf},


### PR DESCRIPTION
Changes:
1. Include "sex" in exomes and genomes faf; 
2. Add `freq_index_dict` and `faf_index_dict` in exomes and genomes globals; 
3. Fix failures on CMH test for testing (this change not working yet with Hail 0.2.128); 
4. Exclude pooled odds ratio from the stats; 

Now the joint HT is like this for faf meta: 
![Screenshot 2024-04-01 at 4 48 51 PM](https://github.com/broadinstitute/gnomad_qc/assets/44242118/08d30159-52e0-47b6-9ff0-ab06a6e0ce22)

