### PR TITLE
Minor fix on POPS for different datatype

### DIFF
--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -17,6 +17,7 @@ from gnomad.assessment.validity_checks import (
 from gnomad.resources.grch38.gnomad import HGDP_POPS, POPS, SUBSETS, TGP_POPS
 from gnomad.sample_qc.ancestry import POP_NAMES
 from gnomad.utils.filtering import remove_fields_from_constant
+from gnomad.utils.release import make_freq_index_dict_from_meta
 from gnomad.utils.vcf import (
     ALLELE_TYPE_FIELDS,
     AS_FIELDS,
@@ -285,6 +286,15 @@ def select_type_from_joint_ht(ht: hl.Table, data_type: str) -> hl.Table:
     ht = ht.select(*row_fields)
     ht = ht.transmute_globals(**ht[f"{data_type}_globals"])
     ht = ht.transmute(**ht[data_type])
+    # if the freq_index_dict doesn't exist, create it
+    if "freq_index_dict" not in ht.globals.keys():
+        ht = ht.annotate_globals(
+            freq_index_dict=make_freq_index_dict_from_meta(ht.freq_meta)
+        )
+    if "faf_index_dict" not in ht.globals.keys():
+        ht = ht.annotate_globals(
+            faf_index_dict=make_freq_index_dict_from_meta(ht.faf_meta)
+        )
     return ht
 
 

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -132,7 +132,7 @@ SUBSETS = {
     "joint": [""],
 }
 
-# Exomes and genomes use the same pops for v4
+# Exomes doesn't have `ami` genetic ancestry group as genomes and joint do
 POPS = deepcopy(POPS["v4"]["exomes"])
 # Remove unnecessary pop names from POP_NAMES dict
 POPS = {pop: POP_NAMES[pop] for pop in POPS}
@@ -1146,10 +1146,13 @@ def main(args):
                         "only_het": dt_ht.info.only_het,
                     }
                 # TODO: Should we be adding filtering info to the joint HT?
+                pop_to_use = deepcopy(POPS)
+                if dt != "exomes":
+                    pop_to_use.update({"ami": "Amish"})
                 validate_release_t(
                     dt_ht,
                     subsets=SUBSETS[data_type],
-                    pops=POPS,
+                    pops=pop_to_use,
                     site_gt_check_expr=site_gt_check_expr,
                     verbose=args.verbose,
                     delimiter="_",

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -286,7 +286,6 @@ def select_type_from_joint_ht(ht: hl.Table, data_type: str) -> hl.Table:
     ht = ht.select(*row_fields)
     ht = ht.transmute_globals(**ht[f"{data_type}_globals"])
     ht = ht.transmute(**ht[data_type])
-    # if the freq_index_dict doesn't exist, create it
     if "freq_index_dict" not in ht.globals.keys():
         ht = ht.annotate_globals(
             freq_index_dict=make_freq_index_dict_from_meta(ht.freq_meta)


### PR DESCRIPTION
Two additions: 

1. add freq_index_dict, faf_index_dict if they're not present; 
2. pops by data type in the validate step;  

Test run: [ab9a4bfab51b40b08b9aa668138a6545](https://console.cloud.google.com/dataproc/jobs/ab9a4bfab51b40b08b9aa668138a6545?region=us-central1&project=broad-mpg-gnomad)