### PR TITLE
Modify code to export joint VCF

### DIFF
--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -1404,10 +1404,6 @@ def main(args):
             with hl.hadoop_open(res.vcf_header_path, "rb") as f:
                 header_dict = pickle.load(f)
 
-            if test:
-                if data_type != "joint":
-                    logger.info("Filtering to test partitions on chr20, X, and Y...")
-                    ht = filter_to_test(ht)
             if contig:
                 logger.info(f"Filtering to {contig}...")
                 ht = hl.filter_intervals(

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -1202,7 +1202,7 @@ def get_joint_filters(ht: hl.Table) -> hl.Table:
             )
             .when(
                 (hl.len(exomes_filters) != 0) & (hl.len(genomes_filters) != 0),
-                ["EXOMES_FILTERED", "GENOMES_FILTERED"],
+                ["BOTH_FILTERED"],
             )
             .default(["MISSING_FILTERS"])
         )

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -967,10 +967,7 @@ def prepare_vcf_header_dict(
     :param extra_description_text: Extra description text to add to INFO field.
     :return: Prepared VCF header dictionary.
     """
-    if data_type == "joint":
-        logger.info("Making FILTER dict for VCF...")
-        filter_dict = make_vcf_filter_dict(joint=True)
-    else:
+    if data_type != "joint":
         logger.info("Making FILTER dict for VCF...")
         filter_dict = make_vcf_filter_dict(
             hl.eval(ht.filtering_model.snv_cutoff.min_score),
@@ -1310,7 +1307,9 @@ def main(args):
                     }
                     dt_ht = dt_ht.annotate(info=dt_ht.info.rename(ordered_rename_dict))
                     if dt != "joint":
-                        dt_ht = dt_ht.annotate(info=dt_ht.info.annotate(**{f"{dt}_filters":dt_ht.filters})
+                        dt_ht = dt_ht.annotate(
+                            info=dt_ht.info.annotate(**{f"{dt}_filters": dt_ht.filters})
+                        )
                         dt_ht = dt_ht.select("info")
 
                     dt_ht = dt_ht.select_globals(
@@ -1363,7 +1362,7 @@ def main(args):
                     joint_included=joint_included,
                 )
             else:
-                header_dict = {"info": {}}
+                header_dict = {"filter": make_vcf_filter_dict(joint=True), "info": {}}
                 for dt in ["exomes", "genomes", "joint"]:
                     dt_ht = select_type_from_joint_ht(ht, dt)
                     temp_header_dict = prepare_vcf_header_dict(

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -1173,7 +1173,7 @@ def get_joint_filters(ht: hl.Table) -> hl.Table:
     """
     Transform exomes and genomes filters to joint filters.
 
-    :param ht: Input Table
+    :param ht: Input Table.
     :return: Table with joint filters transformed from exomes and genomes filters.
     """
     exomes_filters = ht.info.exomes_filters

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -1412,10 +1412,7 @@ def main(args):
                 header_dict = pickle.load(f)
 
             if test:
-                if data_type == "joint":
-                    logger.info("Filtering to the test region...")
-                    ht = ht
-                else:
+                if data_type != "joint":
                     logger.info("Filtering to test partitions on chr20, X, and Y...")
                     ht = filter_to_test(ht)
             if contig:

--- a/gnomad_qc/v4/create_release/validate_and_export_vcf.py
+++ b/gnomad_qc/v4/create_release/validate_and_export_vcf.py
@@ -1442,11 +1442,7 @@ def main(args):
                 rekey_new_reference(ht, export_reference),
                 output_path,
                 metadata=header_dict,
-                append_to_header=(
-                    append_to_vcf_header_path(data_type=data_type)
-                    if data_type != "joint"
-                    else None
-                ),
+                append_to_header=(append_to_vcf_header_path(data_type=data_type)),
                 tabix=True,
             )
 


### PR DESCRIPTION
This added (on top of VCF header PR #608): 
1. a function to get joint filters from exomes and genomes filters annotations; 
2. workarounds on fields that don't exist in joint HT; 
Test run: [5547c86f934e4c64af196761b1b6e41b](https://console.cloud.google.com/dataproc/jobs/5547c86f934e4c64af196761b1b6e41b?region=us-central1&project=broad-mpg-gnomad)