### PR TITLE
Calculate per callset stats on gnomAD v4.1 per sample variant counts

### DIFF
--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -279,7 +279,7 @@ def compute_per_callset_stats(ht: hl.Table, all_stats: bool = False) -> hl.Struc
             ]
         )
         queries = list(queries.intersection(top_level))
-    else: 
+    else:
         queries = list(top_level)
 
     sums = ["n_non_ref", "n_singleton", "n_snp", "n_indel"]
@@ -438,13 +438,15 @@ def main(args):
             ht = per_sample_res.ht().checkpoint(
                 hl.utils.new_temp_file("per_sample_counts", "ht")
             )
-            per_callset_expression = compute_per_callset_stats(ht,all_stats=args.callset_stats_all_levels)
+            per_callset_expression = compute_per_callset_stats(
+                ht, all_stats=args.callset_stats_all_levels
+            )
 
             per_callset_expression_path = per_sample_res = get_per_sample_counts(
-                test=test, data_type=data_type, suffix=args.custom_suffix).path.replace('.ht','_per_callset.tsv')
+                test=test, data_type=data_type, suffix=args.custom_suffix
+            ).path.replace(".ht", "_per_callset.tsv")
 
-            per_callset_expression.export(per_callset_expression_path,overwrite=True)
-
+            per_callset_expression.export(per_callset_expression_path, overwrite=True)
 
         if args.aggregate_sample_stats:
             logger.info("Computing aggregate sample statistics...")

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -266,6 +266,8 @@ def compute_per_callset_stats(ht: hl.Table, all_stats: bool = False) -> hl.Struc
     :return: Struct containing sums of a set of these above counts.
     """
     top_level = set([row_i for row_i in ht.row])
+
+    # Build queries, the list of stratifications to count within.
     if not all_stats:
         queries = set(
             [
@@ -282,8 +284,10 @@ def compute_per_callset_stats(ht: hl.Table, all_stats: bool = False) -> hl.Struc
     else:
         queries = list(top_level)
 
+    # Sums as the specific counts to sum up. Open to change. 
     sums = ["n_non_ref", "n_singleton", "n_snp", "n_indel"]
 
+    # Possible to do within a table, but prior table being keyed by samples made this difficult.
     sum_struct = hl.struct(
         **{
             f"{query_i}_{sum_i}": ht.aggregate(hl.agg.sum(ht[query_i][sum_i]))


### PR DESCRIPTION
IF WE WANT, calculate a set number of per callset stats from the whole of the gnomAD v4.1 per-sample variant count tables. Simple hl.agg.sum(). 

Would be very easy to also calculate it on all top-level stratifications or for all stats with type 'int64' . However, just counting what I know we want to count here. 

A lot of the work from prior PRs are already included in this PR, so something small like this should be all we need. LIkely!

We still need a scientific high-level chat if we want to calculate these though. This was very easy to put together!