### PR TITLE
Add option to summary stats to get around memory errors

### DIFF
--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -1023,7 +1023,10 @@ if __name__ == "__main__":
         "--use-intermediate-mt-for-sample-counts",
         help=(
             "Use intermediate MatrixTable for per-sample variant counts. This is only "
-            "relevant when using --create-per-sample-counts-ht."
+            "relevant when using --create-per-sample-counts-ht. Note that the this "
+            "step is memory intensive and should be run on a cluster with n1-highmem-8 "
+            "workers and big-executors enabled. It also requires shuffling, so a "
+            "cluster with all workers is recommended."
         ),
         action="store_true",
     )

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -922,7 +922,7 @@ def main(args):
                     per_sample_res.path, overwrite=overwrite
                 )
             else:
-                create_per_sample_counts(ht).write(
+                create_per_sample_counts_ht(ht).write(
                     per_sample_res.path, overwrite=overwrite
                 )
 

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -504,7 +504,7 @@ def create_intermediate_mt_for_sample_counts(
     # belongs to the filter group.
     # The sample_idx_by_stat annotation contains a struct with arrays of sample indices
     # for each genotype level stat.
-    ac1 = mt.variant_ac[1] == 1
+    ac1 = ht.variant_ac[1] == 1
     ht = ht.select(
         filter_groups=ht.filter_groups.map(
             lambda x: hl.struct(

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -461,10 +461,10 @@ def create_intermediate_mt_for_sample_counts(
           a struct of arrays of sample indices for each genotype level stat. The stats
           are: non_ref, het, hom_var, high_ab_het_ref, over_gq_{gq}, and over_dp_{dp}.
         - Changes the `filter_groups` annotation from an array of booleans to an array
-          of structs where `group_filter` is the original filter group boolean value, 
+          of structs where `group_filter` is the original filter group boolean value,
           mapping to the filter_group_meta, and adds boolean annotations to the struct
           indicating whether the variant is included in each of the following variant
-          level stats: singleton, singleton_ti, singleton_tv, insertion, deletion, 
+          level stats: singleton, singleton_ti, singleton_tv, insertion, deletion,
           transition, and transversion.
     This structure creates a large intermediate Table that allows for memory efficient
     computation of per-sample stats counts. Smaller datasets do not require this
@@ -912,9 +912,6 @@ def main(args):
                 rare_variants_afs=rare_variants_afs,
             ).write(filtering_groups_res.path, overwrite=overwrite)
 
-        filter_groups_ht = get_summary_stats_filtering_groups(
-            data_type, test=test_gene
-        ).ht()
         if args.create_intermediate_mt_for_sample_counts or (
             create_per_sample_counts and not args.use_intermediate_mt_for_sample_counts
         ):
@@ -924,6 +921,10 @@ def main(args):
                     "created. Please run --create-filter-group-ht without "
                     "--test-gene or --test-n-partitions if it doesn't already exist."
                 )
+
+            filter_groups_ht = get_summary_stats_filtering_groups(
+                data_type, test=test_gene
+            ).ht()
 
             vds_load_func = (
                 get_gnomad_v4_vds

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -667,7 +667,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
             )
         )
     )
-    ht = ht.transmute_globals(summary_stats_meta=ht.filter_groups_meta)
+    ht = ht.transmute_globals(summary_stats_meta=ht.filter_group_meta)
 
     return ht
 

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -612,7 +612,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
 
     # Need the key_by because otherwise the repartitioning will not work, and will only
     # be as many partitions as the number of filter_groups.
-    n_partitions = max(int(n_partitions * n_samples * 0.001), 50)
+    n_partitions = max(int((n_partitions * n_samples) / 50000), 50)
     tmp_path = new_temp_file("stat_counts_explode_sample", "ht")
     ht.key_by("s").write(tmp_path)
     ht = hl.read_table(tmp_path, _n_partitions=n_partitions)

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -504,7 +504,7 @@ def create_intermediate_mt_for_sample_counts(
     # belongs to the filter group.
     # The sample_idx_by_stat annotation contains a struct with arrays of sample indices
     # for each genotype level stat.
-    ac1 = mt.variant_ac[1]
+    ac1 = mt.variant_ac[1] == 1
     ht = ht.select(
         filter_groups=ht.filter_groups.map(
             lambda x: hl.struct(

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -434,6 +434,7 @@ def create_intermediate_mt_for_sample_counts(
 
     This function creates an intermediate Table for use in
     `create_per_sample_counts_ht`. It does the following:
+
         - Filters to non-ref genotypes (likely unnecessary if the MT is already a
           variant data MT).
         - Annotates the rows with the filter group metadata from `filter_group_ht`.
@@ -569,6 +570,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
     occur when trying to aggregate the Table directly.
 
     The following steps are taken:
+
         - The Table is grouped by filter group (including all variant level stats) and
           aggregated to get the count of variants for each sample in each filter group.
           Leads to a Table where the number of rows is approximately the number of

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -557,6 +557,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
           aggregated to get the count of variants for each sample in each filter group.
           Leads to a Table where the number of rows is approximately the number of
           filter groups times the possible permutations of variant level stats.
+
             - Since this number can sometimes be too few partitions to get around the
               memory errors, we approximate a reasonable number of partitions as the
               number required to split the table into approximately 10,000 variants per
@@ -568,6 +569,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
               number of desired partitions.
             - Therefore, the number of random groups is the ideal number of partitions
               divided by the number of possible filter groups.
+
         - Sample IDs are mapped to the sample indices and the Table is exploded so that
           each row is counts for a sample and a filter group. The number of rows in the
           Table is approximately the number of samples times the number of rows in the

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -844,7 +844,7 @@ def main(args):
         by_subset=args.by_subset,
     )
     temp_intermediate_ht_path = get_checkpoint_path(
-        "per_sample_summary_stats_intermediate" + (".test" if test else ""), mt=True
+        "per_sample_summary_stats_intermediate" + (".test" if test else "")
     )
     if data_type != "exomes" and args.by_subset:
         raise ValueError("Stratifying by subset is only working on exomes data type.")

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -641,9 +641,11 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
 
     # After the explode, the number of rows is much larger, at approximately the number
     # of samples times the number of filter groups, so it's important to repartition the
-    # Table. This is done as a repartition on read, and the key_by is needed because
-    # otherwise the repartitioning will not work, and will only be as many partitions
-    # as the number of filter_groups.
+    # Table. In this case, we try to have about 50,000 rows per partition, which seems
+    # to work well, but only going as low as 50 partitions. The repartition is done as a
+    # repartition on read, and the key_by is needed because otherwise the
+    # repartitioning will not work, and will only be as many partitions as the number
+    # of filter_groups.
     n_partitions = max(int((n_filter_permutations * n_samples) / 50000), 50)
     tmp_path = new_temp_file("stat_counts_explode_sample", "ht")
     ht.key_by("s").write(tmp_path)

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -694,7 +694,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
             )
         )
     )
-    ht = ht.transmute_globals(summary_stats_meta=ht.filter_group_meta)
+    ht = ht.select_globals(summary_stats_meta=ht.filter_group_meta)
 
     n_partitions = max(int(n_samples * 0.001), min(50, n_samples))
     logger.info("Naive coalescing to %s partitions.", n_partitions)

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -555,9 +555,18 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
         - The Table is grouped by filter group (including all variant level stats) and
           aggregated to get the count of variants for each sample in each filter group.
           Leads to a Table where the number of rows is approximately the number of
-          filter groups times the possible permutations of variant level stats. If
-          this number is too small, it might be better to use
-          `create_per_sample_counts_ht`.
+          filter groups times the possible permutations of variant level stats.
+            - Since this number can sometimes be too few partitions to get around the
+              memory errors, we approximate a reasonable number of partitions as the
+              number required to split the table into approximately 10,000 variants per
+              partition.
+            - Then we artificially increase the number of aggregation groups by
+              assigning a random group number to each variant, so that when the Table
+              is grouped by both the filter group and the random group instead
+              of only the filter group, the number of rows will be approximately the
+              number of desired partitions.
+            - Therefore, the number of random groups is the ideal number of partitions
+              divided by the number of possible filter groups.
         - Sample IDs are mapped to the sample indices and the Table is exploded so that
           each row is counts for a sample and a filter group. The number of rows in the
           Table is approximately the number of samples times the number of rows in the

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -798,6 +798,8 @@ def main(args):
     test_partitions = (
         list(range(args.test_n_partitions)) if args.test_n_partitions else None
     )
+    if not autosomes_only:
+        raise NotImplementedError("The current implementation only supports autosomes")
 
     if create_filter_group:
         err_msg = ""

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -761,6 +761,7 @@ def compute_agg_sample_stats(
     ht = ht.annotate(
         filter_group_meta=ht.summary_stats[0], summary_stats=ht.summary_stats[1]
     )
+    ht = ht.key_by(*ht.key, "filter_group_meta")
 
     return ht
 

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -318,6 +318,10 @@ def get_summary_stats_filter_groups_ht(
         filter_groups=filter_groups_expr,
         variant_ac=[hl.missing(hl.tint32), ht.freq[0].AC],
         variant_af=ht.freq[0].AF,
+        **{
+            k: _qc_allele_type(ht.alleles[0], ht.alleles[1]) == v
+            for k, v in ALLELE_TYPE_MAP.items()
+        },
     )
     ht = ht.select_globals(filter_group_meta=final_meta)
     logger.info("Filter groups for summary stats: %s", filter_group_meta)

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -461,11 +461,11 @@ def create_intermediate_mt_for_sample_counts(
           a struct of arrays of sample indices for each genotype level stat. The stats
           are: non_ref, het, hom_var, high_ab_het_ref, over_gq_{gq}, and over_dp_{dp}.
         - Changes the `filter_groups` annotation from an array of booleans to an array
-          of structs with `group_filter` being the original filter group boolean value
-          and additional boolean annotations indicating whether the variant is included
-          in each of the following variant level stats: singleton, singleton_ti,
-          singleton_tv, insertion, deletion, transition, and transversion.
-
+          of structs where `group_filter` is the original filter group boolean value, 
+          mapping to the filter_group_meta, and adds boolean annotations to the struct
+          indicating whether the variant is included in each of the following variant
+          level stats: singleton, singleton_ti, singleton_tv, insertion, deletion, 
+          transition, and transversion.
     This structure creates a large intermediate Table that allows for memory efficient
     computation of per-sample stats counts. Smaller datasets do not require this
     intermediate step and can compute per-sample stats counts directly from the MT and
@@ -499,10 +499,10 @@ def create_intermediate_mt_for_sample_counts(
     )
 
     # Annotate the HT with the filter group metadata and the sample index by stat.
-    # The filter groups annotation contains an array of structs with boolean
-    # expressions for each variant level stat indicating whether the variant should be
-    # counted for that stat and a group_filter boolean indicating whether the variant
-    # belongs to the filter group.
+    # The filter groups annotation contains an array of structs with a group_filter
+    # boolean indicating whether the variant belongs to the filter group and boolean
+    # expressions for each variant level stat, i.e. singleton, indicating whether the
+    # variant should be counted for that stat.
     # The sample_idx_by_stat annotation contains a struct with arrays of sample indices
     # for each genotype level stat.
     ac1 = ht.variant_ac[1] == 1
@@ -556,7 +556,7 @@ def create_per_sample_counts_from_intermediate_ht(ht: hl.Table) -> hl.Table:
           aggregated to get the count of variants for each sample in each filter group.
           Leads to a Table where the number of rows is approximately the number of
           filter groups times the possible permutations of variant level stats. If
-          This number is too small, it might be better to use
+          this number is too small, it might be better to use
           `create_per_sample_counts_ht`.
         - Sample IDs are mapped to the sample indices and the Table is exploded so that
           each row is counts for a sample and a filter group. The number of rows in the

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -466,6 +466,7 @@ def create_intermediate_mt_for_sample_counts(
           indicating whether the variant is included in each of the following variant
           level stats: singleton, singleton_ti, singleton_tv, insertion, deletion,
           transition, and transversion.
+
     This structure creates a large intermediate Table that allows for memory efficient
     computation of per-sample stats counts. Smaller datasets do not require this
     intermediate step and can compute per-sample stats counts directly from the MT and

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -864,6 +864,9 @@ def main(args):
                 rare_variants_afs=rare_variants_afs,
             ).write(filtering_groups_res.path, overwrite=overwrite)
 
+        filter_groups_res = get_summary_stats_filtering_groups(
+            data_type, test=test_gene
+        )
         if args.create_intermediate_mt_for_sample_counts:
             logger.info("Creating intermediate MatrixTable for per-sample counts...")
 
@@ -874,9 +877,7 @@ def main(args):
                     "--test-gene or --test-n-partitions if it doesn't already exist."
                 )
 
-            filter_groups_ht = get_summary_stats_filtering_groups(
-                data_type, test=test_gene
-            ).ht()
+            filter_groups_ht = filter_groups_res.ht()
             vds_load_func = (
                 get_gnomad_v4_vds
                 if data_type == "exomes"
@@ -895,7 +896,7 @@ def main(args):
             ).variant_data
 
             create_intermediate_mt_for_sample_counts(
-                mt, filter_groups_ht, autosomes_only
+                mt, filter_groups_res.ht(), autosomes_only
             ).write(temp_intermediate_ht_path, overwrite=overwrite)
 
         if create_per_sample_counts:
@@ -922,9 +923,9 @@ def main(args):
                     per_sample_res.path, overwrite=overwrite
                 )
             else:
-                create_per_sample_counts_ht(ht).write(
-                    per_sample_res.path, overwrite=overwrite
-                )
+                create_per_sample_counts_ht(
+                    ht, filter_groups_res.ht(), autosomes_only
+                ).write(per_sample_res.path, overwrite=overwrite)
 
         if args.aggregate_sample_stats:
             logger.info("Computing aggregate sample statistics...")

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -382,7 +382,7 @@ def create_intermediate_mt_for_sample_counts(
         ht._entries,
     ).filter(lambda x: hl.is_defined(x[1]))
     stat_expr = {
-        "non_ref": lambda x: x[0],
+        "non_ref": lambda x: True,
         "het": lambda x: x[1].is_het(),
         "hom_var": lambda x: x[1].is_hom_var(),
         "high_ab_het_ref": lambda x: x[4],
@@ -662,8 +662,8 @@ def main(args):
         by_ancestry=args.by_ancestry,
         by_subset=args.by_subset,
     )
-    temp_intermediate_mt_path = get_checkpoint_path(
-        "per_sample_summary_stats_intermediate" + (".test" if test else ""), mt=True
+    temp_intermediate_ht_path = get_checkpoint_path(
+        "per_sample_summary_stats_intermediate" + (".test" if test else "")
     )
     if data_type != "exomes" and args.by_subset:
         raise ValueError("Stratifying by subset is only working on exomes data type.")
@@ -731,15 +731,13 @@ def main(args):
 
             create_intermediate_mt_for_sample_counts(
                 mt, filter_groups_ht, autosomes_only
-            ).write(temp_intermediate_mt_path, overwrite=overwrite)
+            ).write(temp_intermediate_ht_path, overwrite=overwrite)
 
         if create_per_sample_counts:
             logger.info(
                 "Calculating per-sample variant statistics for %s...", data_type
             )
-            ht = hl.read_table(temp_intermediate_mt_path)._filter_partitions(
-                range(1000)
-            )
+            ht = hl.read_table(temp_intermediate_ht_path)
             create_per_sample_counts_ht(ht).write(
                 per_sample_res.path, overwrite=overwrite
             )

--- a/gnomad_qc/v4/resources/assessment.py
+++ b/gnomad_qc/v4/resources/assessment.py
@@ -43,7 +43,7 @@ def get_summary_stats_filtering_groups(
         CURRENT_RELEASE,
         {
             version: TableResource(
-                f"{_assessment_root(version=version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.per_sample_filtering_groups.ht"
+                f"{_assessment_root(version=version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.per_sample_filtering_groups.6_6_24.ht"
             )
             for version in RELEASES
         },

--- a/gnomad_qc/v4/resources/assessment.py
+++ b/gnomad_qc/v4/resources/assessment.py
@@ -43,7 +43,7 @@ def get_summary_stats_filtering_groups(
         CURRENT_RELEASE,
         {
             version: TableResource(
-                f"{_assessment_root(version=version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.per_sample_filtering_groups.6_6_24.ht"
+                f"{_assessment_root(version=version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.per_sample_filtering_groups.ht"
             )
             for version in RELEASES
         },


### PR DESCRIPTION
Cluster for all tests:
```
hailctl dataproc start jg2 \
    --requester-pays-allow-all \
    --packages="git+https://github.com/broadinstitute/gnomad_methods.git@main","git+https://github.com/broadinstitute/gnomad_qc.git@main" \
    --max-idle 540m \
    --master-machine-type n1-highmem-16 \
    --worker-machine-type n1-highmem-8 \
    --no-off-heap-memory 
```


Test the full pipeline on a single gene of the test dataset:

Without intermediate:

Command:
```

hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-gene \
    --test-dataset \
    --create-filter-group-ht \
    --create-per-sample-counts-ht \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [c8799a90396749a3aa85a95ed40c4a59](https://console.cloud.google.com/dataproc/jobs/c8799a90396749a3aa85a95ed40c4a59/monitoring?region=us-central1&project=broad-mpg-gnomad)


With intermediate:

Command:
```

hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-gene \
    --test-dataset \
    --create-filter-group-ht \
    --create-intermediate-mt-for-sample-counts \
    --create-per-sample-counts-ht \
    --use-intermediate-mt-for-sample-counts \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [1b85d5dac9084822bc9dc2b6d674071e](https://console.cloud.google.com/dataproc/jobs/1b85d5dac9084822bc9dc2b6d674071e/monitoring?region=us-central1&project=broad-mpg-gnomad)



Create the full filter group HT to perform bigger tests:

Cluster update:
```
hailctl dataproc modify jg2 -w 2 -p 50
```

Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --create-filter-group-ht \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [0f5ce55eb58a4ff6a324946592725627](https://console.cloud.google.com/dataproc/jobs/0f5ce55eb58a4ff6a324946592725627/monitoring?region=us-central1&project=broad-mpg-gnomad)





Test the full pipeline on the whole test dataset:

Without intermediate:

Cluster update:
```
hailctl dataproc modify jg2 -w 2 -p 50
```

Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-dataset \
    --create-per-sample-counts-ht \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [08875c8767f44d3886225f3db0a1be59](https://console.cloud.google.com/dataproc/jobs/08875c8767f44d3886225f3db0a1be59/monitoring?region=us-central1&project=broad-mpg-gnomad)


With intermediate:

Cluster update:
```
hailctl dataproc modify jg2 -w 50 -p 0
```


Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-dataset \
    --create-intermediate-mt-for-sample-counts \
    --create-per-sample-counts-ht \
    --use-intermediate-mt-for-sample-counts \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [01b4b0553d7b48fa816b6aaded8cc39c](https://console.cloud.google.com/dataproc/jobs/01b4b0553d7b48fa816b6aaded8cc39c/monitoring?region=us-central1&project=broad-mpg-gnomad)



Test 50 partitions of the full dataset:

Without intermediate (Fails with memory error as expected):

Cluster update:
```
hailctl dataproc modify jg2 -w 2 -p 10
```

Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-n-partitions 50 \
    --create-per-sample-counts-ht \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [5181af782c4d485cbcc3000e7cd5c4ef](https://console.cloud.google.com/dataproc/jobs/5181af782c4d485cbcc3000e7cd5c4ef/monitoring?region=us-central1&project=broad-mpg-gnomad)


With intermediate:

Cluster update:
```
hailctl dataproc modify jg2 -w 10 -p 0
```


Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-n-partitions 50 \
    --create-intermediate-mt-for-sample-counts \
    --create-per-sample-counts-ht \
    --use-intermediate-mt-for-sample-counts \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [7a6b631aec4b4585896d0130ece526a6](https://console.cloud.google.com/dataproc/jobs/7a6b631aec4b4585896d0130ece526a6/monitoring?region=us-central1&project=broad-mpg-gnomad)












Test difficult partitions of the full dataset:

Without intermediate (Fails with memory error as expected):

Cluster update:
```
hailctl dataproc modify jg2 -w 2 -p 10
```

Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-difficult-partitions \
    --create-per-sample-counts-ht \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [4f6e2089a56d47f2bcca76b828eee454](https://console.cloud.google.com/dataproc/jobs/4f6e2089a56d47f2bcca76b828eee454/monitoring?region=us-central1&project=broad-mpg-gnomad)


With intermediate:

Cluster update:
```
hailctl dataproc modify jg2 -w 10 -p 0
```


Command:
```
hailctl dataproc submit jg2 gnomad_qc/v4/assessment/calculate_per_sample_stats.py \
    --data-type exomes \
    --test-difficult-partitions \
    --create-intermediate-mt-for-sample-counts \
    --create-per-sample-counts-ht \
    --use-intermediate-mt-for-sample-counts \
    --aggregate-sample-stats \
    --autosomes-only-stats \
    --pyfiles ../gnomad_methods/gnomad,gnomad_qc \
    --overwrite
```

Job: [36acd0457ca6484fa0da0aee84bc538f](https://console.cloud.google.com/dataproc/jobs/36acd0457ca6484fa0da0aee84bc538f/monitoring?region=us-central1&project=broad-mpg-gnomad)
