### PR TITLE
Reformat files after Black updated to 24.3.0

### DIFF
--- a/gnomad_qc/example_notebooks/ancestry_classification_using_gnomad_rf.ipynb
+++ b/gnomad_qc/example_notebooks/ancestry_classification_using_gnomad_rf.ipynb
@@ -112,12 +112,14 @@
    "source": [
     "import onnx\n",
     "import hail as hl\n",
-    "from gnomad.sample_qc.ancestry import apply_onnx_classification_model, assign_population_pcs\n",
+    "from gnomad.sample_qc.ancestry import (\n",
+    "    apply_onnx_classification_model,\n",
+    "    assign_population_pcs,\n",
+    ")\n",
     "from gnomad.utils.filtering import filter_to_adj\n",
     "\n",
     "from gnomad_qc.v2.resources.basics import get_gnomad_meta\n",
-    "from gnomad_qc.v4.resources.basics import get_checkpoint_path\n",
-    "\n"
+    "from gnomad_qc.v4.resources.basics import get_checkpoint_path"
    ]
   },
   {
@@ -162,10 +164,14 @@
    "outputs": [],
    "source": [
     "# v3.1 PCA loadings.\n",
-    "gnomad_v3_loadings = \"gs://gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.pca_loadings.ht\"\n",
+    "gnomad_v3_loadings = (\n",
+    "    \"gs://gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.pca_loadings.ht\"\n",
+    ")\n",
     "\n",
     "# v3.1 ONNX RF model.\n",
-    "gnomad_v3_onnx_rf = \"gs://gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.onnx\"\n",
+    "gnomad_v3_onnx_rf = (\n",
+    "    \"gs://gcp-public-data--gnomad/release/3.1/pca/gnomad.v3.1.RF_fit.onnx\"\n",
+    ")\n",
     "\n",
     "# Test dataset to apply projection and genetic ancestry group assignment to.\n",
     "# This will be the path to your dataset VDS.\n",
@@ -174,7 +180,9 @@
     "# v3.1 output paths.\n",
     "test_mt_output_path = get_checkpoint_path(\"example_gnomad_v3.1_ancestry_rf\", mt=True)\n",
     "test_scores_output_path = get_checkpoint_path(\"example_gnomad_v3.1_ancestry_rf.scores\")\n",
-    "gnomad_v3_assignment_path = get_checkpoint_path(\"example_gnomad_v3.1_ancestry_rf.assignment\")"
+    "gnomad_v3_assignment_path = get_checkpoint_path(\n",
+    "    \"example_gnomad_v3.1_ancestry_rf.assignment\"\n",
+    ")"
    ]
   },
   {
@@ -193,10 +201,14 @@
    "outputs": [],
    "source": [
     "# v2.1 ONNX RF model.\n",
-    "gnomad_v2_onnx_rf = \"gs://gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.RF_fit.onnx\"\n",
+    "gnomad_v2_onnx_rf = (\n",
+    "    \"gs://gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.RF_fit.onnx\"\n",
+    ")\n",
     "\n",
     "# v2.1 output path.\n",
-    "gnomad_v2_assignment_path = get_checkpoint_path(\"example_gnomad_v2.1_ancestry_rf.assignment\")"
+    "gnomad_v2_assignment_path = get_checkpoint_path(\n",
+    "    \"example_gnomad_v2.1_ancestry_rf.assignment\"\n",
+    ")"
    ]
   },
   {
@@ -380,8 +392,7 @@
     "# Reduce variant data to only annotations needed for split and densify.\n",
     "# This includes annotations needed for our standard genotype filter ('adj').\n",
     "vds = hl.vds.VariantDataset(\n",
-    "    vds.reference_data, \n",
-    "    vds.variant_data.select_entries(\"LA\", \"LGT\", \"GQ\", \"DP\", \"LAD\")\n",
+    "    vds.reference_data, vds.variant_data.select_entries(\"LA\", \"LGT\", \"GQ\", \"DP\", \"LAD\")\n",
     ")\n",
     "\n",
     "# Split multiallelics.\n",
@@ -428,9 +439,7 @@
    "outputs": [],
    "source": [
     "mt = mt.checkpoint(\n",
-    "    test_mt_output_path, \n",
-    "    overwrite=not read_if_exists, \n",
-    "    _read_if_exists=read_if_exists\n",
+    "    test_mt_output_path, overwrite=not read_if_exists, _read_if_exists=read_if_exists\n",
     ")"
    ]
   },
@@ -460,14 +469,16 @@
    "source": [
     "# Project new genotypes onto loadings.\n",
     "v3_pcs_ht = hl.experimental.pc_project(\n",
-    "    mt.GT, v3_loading_ht.loadings, v3_loading_ht.pca_af,\n",
+    "    mt.GT,\n",
+    "    v3_loading_ht.loadings,\n",
+    "    v3_loading_ht.pca_af,\n",
     ")\n",
     "\n",
     "# Checkpoint PC projection results.\n",
     "v3_pcs_ht = v3_pcs_ht.checkpoint(\n",
-    "    test_scores_output_path, \n",
-    "    overwrite=not read_if_exists, \n",
-    "    _read_if_exists=read_if_exists\n",
+    "    test_scores_output_path,\n",
+    "    overwrite=not read_if_exists,\n",
+    "    _read_if_exists=read_if_exists,\n",
     ")"
    ]
   },
@@ -525,12 +536,12 @@
     "    pc_cols=v3_pcs_ht.scores[:v3_num_pcs],\n",
     "    fit=v3_onx_fit,\n",
     "    min_prob=v3_min_prob,\n",
-    "    apply_model_func = apply_onnx_classification_model,\n",
+    "    apply_model_func=apply_onnx_classification_model,\n",
     ")\n",
     "ht = ht.checkpoint(\n",
-    "    gnomad_v3_assignment_path, \n",
-    "    overwrite=not read_if_exists, \n",
-    "    _read_if_exists=read_if_exists\n",
+    "    gnomad_v3_assignment_path,\n",
+    "    overwrite=not read_if_exists,\n",
+    "    _read_if_exists=read_if_exists,\n",
     ")\n",
     "\n",
     "ht.aggregate(hl.agg.counter(ht.pop))"
@@ -585,9 +596,9 @@
     "    apply_model_func=apply_onnx_classification_model,\n",
     ")\n",
     "ht = ht.checkpoint(\n",
-    "    gnomad_v2_assignment_path, \n",
-    "    overwrite=not read_if_exists, \n",
-    "    _read_if_exists=read_if_exists\n",
+    "    gnomad_v2_assignment_path,\n",
+    "    overwrite=not read_if_exists,\n",
+    "    _read_if_exists=read_if_exists,\n",
     ")\n",
     "\n",
     "ht.aggregate(hl.agg.counter(ht.pop))"

--- a/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
+++ b/gnomad_qc/v4/assessment/calculate_per_sample_stats.py
@@ -248,8 +248,7 @@ def process_test_args(
             )
         if err_msg:
             raise ValueError(
-                err_msg
-                + " For a quick test of both --create-filter-group-ht and "
+                err_msg + " For a quick test of both --create-filter-group-ht and "
                 "--create-per-sample-counts-ht, use '--test-gene --test-dataset'. "
                 "The full run of the --create-filter-group-ht step is relatively "
                 "quick and once tests are complete on the filter group creation, "


### PR DESCRIPTION
After merging #584, [checks](https://github.com/broadinstitute/gnomad_qc/actions/runs/10633552159/job/29478854802) failed and needed to run  ``pip install "black[jupyter]"`` and reformat these notebooks. 