### PR TITLE
Add option to filter to releasable trios for generating trio stats

### DIFF
--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -1098,10 +1098,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--releasable-trios-only",
-        help="Only include releasable "
-        "trios. This is only valid "
-        "when --generate-trio-stats "
-        "is true",
+        help="Only include releasable trios. This is only valid when --generate-trio-stats is true",
         action="store_true",
     )
     parser.add_argument(

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -837,9 +837,6 @@ def main(args):
     cdf_k = args.cdf_k
     releasable_trios_only = args.releasable_trios_only
 
-    if releasable_trios_only and not args.generate_trio_stats:
-        parser.error("--releasable-trios-only requires --generate-trio-stats")
-
     max_n_alleles = min_n_alleles = over_n_alleles = None
     if split_n_alleles is not None:
         if over_split_n_alleles:
@@ -1106,7 +1103,6 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         help="Calculate sibling variant sharing stats.",
         action="store_true",
     )
-
     variant_qc_annotation_args = parser.add_argument_group(
         "Variant QC annotation HT parameters"
     )

--- a/gnomad_qc/v4/resources/annotations.py
+++ b/gnomad_qc/v4/resources/annotations.py
@@ -117,18 +117,22 @@ def validate_vep_path(
     )
 
 
-def get_trio_stats(test: bool = False) -> VersionedTableResource:
+def get_trio_stats(
+    test: bool = False, releasable_only: bool = False
+) -> VersionedTableResource:
     """
     Get the gnomAD v4 trio stats VersionedTableResource.
 
-    :param test: Whether to use a tmp path for testing.
+    :param test: Whether to use a temporary path for testing.
+    :param releasable_only: Whether to use only releasable data.
     :return: gnomAD v4 trio stats VersionedTableResource.
     """
     return VersionedTableResource(
         CURRENT_ANNOTATION_VERSION,
         {
             version: TableResource(
-                f"{_annotations_root(version, test=test)}/gnomad.exomes.v{version}.trio_stats.ht"
+                f"{_annotations_root(version, test=test)}/gnomad.exomes.v{version}."
+                f"{'releasable.' if releasable_only else ''}trio_stats.ht"
             )
             for version in ANNOTATION_VERSIONS
         },


### PR DESCRIPTION
Update the `run_generate_trio_stats` function to filter the fam_ht to releasable trios (pat-mat-proband) only. It won't overwrite the existing output for all trios. 

**Tested:** 
5 trios from test VDS
[5650d7690333482f856e50c4105864ff](https://console.cloud.google.com/dataproc/jobs/5650d7690333482f856e50c4105864ff?region=us-central1&project=broad-mpg-gnomad)

3 releasable trios from test VDS
[f70603af341244ae81f23d868d9945c3](https://console.cloud.google.com/dataproc/jobs/f70603af341244ae81f23d868d9945c3?region=us-central1&project=broad-mpg-gnomad)