### PR TITLE
Clean up and re-organize run_generate_trio_stats

### DIFF
--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -479,9 +479,11 @@ def run_generate_trio_stats(
     # Filter the variant data and reference data to only the trios.
     vmt = filter_mt_to_trios(vmt, fam_ht)
     rmt = rmt.filter_cols(hl.is_defined(vmt.cols()[rmt.col_key]))
+    vds = hl.vds.VariantDataset(reference_data=rmt, variant_data=vmt).checkpoint(
+        hl.utils.new_temp_file("trios", "vds")
+    )
 
-    mt = hl.vds.to_dense_mt(hl.vds.VariantDataset(rmt, vmt))
-    mt = mt.checkpoint(hl.utils.new_temp_file("trios_dense", "mt"))
+    mt = hl.vds.to_dense_mt(vds)
     mt = mt.transmute_entries(GT=mt.LGT)
     mt = annotate_adj(mt)
     mt = hl.trio_matrix(mt, pedigree=fam_ped, complete_trios=True)

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -9,7 +9,7 @@ from gnomad.assessment.validity_checks import count_vep_annotated_variants_per_i
 from gnomad.resources.grch38.gnomad import GROUPS
 from gnomad.resources.grch38.reference_data import ensembl_interval, get_truth_ht
 from gnomad.resources.resource_utils import TableResource
-from gnomad.sample_qc.relatedness import filter_mt_to_trios
+from gnomad.sample_qc.relatedness import filter_vds_to_trios
 from gnomad.utils.annotations import annotate_adj, annotate_allele_info
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.sparse_mt import (
@@ -459,14 +459,10 @@ def run_generate_trio_stats(
     """
     # Filter the VDS to autosomes.
     vds = hl.vds.filter_chromosomes(vds, keep_autosomes=True)
-    vmt = vds.variant_data
-    rmt = vds.reference_data
 
-    # Filter the variant data to bi-allelic sites.
-    vmt = vmt.filter_rows(hl.len(vmt.alleles) == 2)
     if releasable_only:
         logger.info("Filtering to only releasable trios...")
-        meta = vmt.cols()
+        meta = vds.variant_data.cols()
         fam_ht = fam_ht.annotate(
             id_releasable=meta[fam_ht.key].meta.project_meta.releasable,
             pat_releasable=meta[fam_ht.pat_id].meta.project_meta.releasable,
@@ -477,13 +473,18 @@ def run_generate_trio_stats(
         )
 
     # Filter the variant data and reference data to only the trios.
-    vmt = filter_mt_to_trios(vmt, fam_ht)
-    rmt = rmt.filter_cols(hl.is_defined(vmt.cols()[rmt.col_key]))
-    vds = hl.vds.VariantDataset(reference_data=rmt, variant_data=vmt).checkpoint(
-        hl.utils.new_temp_file("trios", "vds")
-    )
+    vds = filter_vds_to_trios(vds, fam_ht)
+
+    vmt = vds.variant_data
+    rmt = vds.reference_data
+
+    # Filter the variant data to bi-allelic sites.
+    vmt = vmt.filter_rows(hl.len(vmt.alleles) == 2)
+
+    vds = hl.vds.VariantDataset(reference_data=rmt, variant_data=vmt)
 
     mt = hl.vds.to_dense_mt(vds)
+
     mt = mt.transmute_entries(GT=mt.LGT)
     mt = annotate_adj(mt)
     mt = hl.trio_matrix(mt, pedigree=fam_ped, complete_trios=True)

--- a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py
@@ -9,7 +9,7 @@ from gnomad.assessment.validity_checks import count_vep_annotated_variants_per_i
 from gnomad.resources.grch38.gnomad import GROUPS
 from gnomad.resources.grch38.reference_data import ensembl_interval, get_truth_ht
 from gnomad.resources.resource_utils import TableResource
-from gnomad.sample_qc.relatedness import filter_vds_to_trios
+from gnomad.sample_qc.relatedness import filter_to_trios
 from gnomad.utils.annotations import annotate_adj, annotate_allele_info
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.sparse_mt import (
@@ -473,7 +473,7 @@ def run_generate_trio_stats(
         )
 
     # Filter the variant data and reference data to only the trios.
-    vds = filter_vds_to_trios(vds, fam_ht)
+    vds = filter_to_trios(vds, fam_ht)
 
     vmt = vds.variant_data
     rmt = vds.reference_data


### PR DESCRIPTION
This function has been changed accordingly with this [PR](https://github.com/broadinstitute/gnomad_methods/pull/739) in gnomad_methods. 
Note: as of 2024-10-29, the Hail v0.2.133 wasn't able to run: 
```
hailctl dataproc submit trio-stats gnomad_qc/v4/annotations/generate_variant_qc_annotations.py --generate-trio-stats --releasable-trios-only --overwrite
```
on the whole dataset, I had to roll back to Hail v0.2.120, the working version that we used in September 2023 to run on all the trios. 