### PR TITLE
Write a new final filter Table with all variants for de novo release

### DIFF
--- a/gnomad_qc/v4/resources/variant_qc.py
+++ b/gnomad_qc/v4/resources/variant_qc.py
@@ -1,6 +1,6 @@
 """Script containing variant QC related resources."""
 
-from typing import Union
+from typing import Optional, Union
 
 from gnomad.resources.grch38 import (
     na12878_giab,
@@ -296,47 +296,24 @@ def get_variant_qc_result(
 
 
 def final_filter(
-    data_type: str = "exomes", test: bool = False
+    data_type: str = "exomes", test: bool = False, simplified: Optional[bool] = False
 ) -> VersionedTableResource:
     """
     Get finalized variant QC filtering Table.
 
     :param data_type: Whether to return 'exomes' or 'genomes' data. Default is exomes.
     :param test: Whether to use a tmp path for variant QC tests.
+    :param simplified: Whether to get the simplified version of the Table. The simplified version
+                       includes variants not in the release, with only "filters" fields.
+                       Default is False.
     :return: VersionedTableResource for final variant QC data.
     """
+    suffix = ".final_filter.simplified" if simplified else ".final_filter"
     return VersionedTableResource(
         CURRENT_VARIANT_QC_RESULT_VERSION[data_type],
         {
             version: TableResource(
-                f"{_variant_qc_root(version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.final_filter.ht"
-            )
-            for version in VARIANT_QC_RESULT_VERSIONS[data_type]
-        },
-    )
-
-
-def final_filter_simplified(
-    data_type: str = "exomes", test: bool = False
-) -> VersionedTableResource:
-    """
-    Get finalized variant QC filtering Table.
-
-    .. note::
-
-        This Table is simplified version of the final_filter Table, but including
-        varints that are not in the release, in order to get filters for de novo
-        variants release. It contains only "filters" fields.
-
-    :param data_type: Whether to return 'exomes' or 'genomes' data. Default is exomes.
-    :param test: Whether to use a tmp path for variant QC tests.
-    :return: VersionedTableResource for final variant QC data.
-    """
-    return VersionedTableResource(
-        CURRENT_VARIANT_QC_RESULT_VERSION[data_type],
-        {
-            version: TableResource(
-                f"{_variant_qc_root(version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.final_filter.simplified.ht"
+                f"{_variant_qc_root(version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}{suffix}.ht"
             )
             for version in VARIANT_QC_RESULT_VERSIONS[data_type]
         },

--- a/gnomad_qc/v4/resources/variant_qc.py
+++ b/gnomad_qc/v4/resources/variant_qc.py
@@ -1,6 +1,6 @@
 """Script containing variant QC related resources."""
 
-from typing import Optional, Union
+from typing import Union
 
 from gnomad.resources.grch38 import (
     na12878_giab,
@@ -296,19 +296,26 @@ def get_variant_qc_result(
 
 
 def final_filter(
-    data_type: str = "exomes", test: bool = False, simplified: Optional[bool] = False
+    data_type: str = "exomes",
+    all_variants: bool = False,
+    only_filters: bool = False,
+    test: bool = False,
 ) -> VersionedTableResource:
     """
     Get finalized variant QC filtering Table.
 
     :param data_type: Whether to return 'exomes' or 'genomes' data. Default is exomes.
-    :param test: Whether to use a tmp path for variant QC tests.
-    :param simplified: Whether to get the simplified version of the Table. The simplified version
-                       includes variants not in the release, with only "filters" fields.
-                       Default is False.
+    :param all_variants: Whether to return the Table with all variants. Default is
+        False.
+    :param only_filters: Whether to return the Table with only the 'filters' field.
+        Default is False.
+    :param test: Whether to use a tmp path for variant QC tests. Default is False.
     :return: VersionedTableResource for final variant QC data.
     """
-    suffix = ".final_filter.simplified" if simplified else ".final_filter"
+    suffix = (
+        f".final_filter{'.all_variants' if all_variants else ''}"
+        f"{'.only_filters' if only_filters else ''}"
+    )
     return VersionedTableResource(
         CURRENT_VARIANT_QC_RESULT_VERSION[data_type],
         {

--- a/gnomad_qc/v4/resources/variant_qc.py
+++ b/gnomad_qc/v4/resources/variant_qc.py
@@ -314,3 +314,30 @@ def final_filter(
             for version in VARIANT_QC_RESULT_VERSIONS[data_type]
         },
     )
+
+
+def final_filter_simplified(
+    data_type: str = "exomes", test: bool = False
+) -> VersionedTableResource:
+    """
+    Get finalized variant QC filtering Table.
+
+    .. note::
+
+        This Table is simplified version of the final_filter Table, but including
+        varints that are not in the release, in order to get filters for de novo
+        variants release. It contains only "filters" fields.
+
+    :param data_type: Whether to return 'exomes' or 'genomes' data. Default is exomes.
+    :param test: Whether to use a tmp path for variant QC tests.
+    :return: VersionedTableResource for final variant QC data.
+    """
+    return VersionedTableResource(
+        CURRENT_VARIANT_QC_RESULT_VERSION[data_type],
+        {
+            version: TableResource(
+                f"{_variant_qc_root(version, test=test, data_type=data_type)}/gnomad.{data_type}.v{version}.final_filter.simplified.ht"
+            )
+            for version in VARIANT_QC_RESULT_VERSIONS[data_type]
+        },
+    )

--- a/gnomad_qc/v4/variant_qc/final_filter.py
+++ b/gnomad_qc/v4/variant_qc/final_filter.py
@@ -18,7 +18,6 @@ from gnomad_qc.v4.resources.annotations import get_freq, get_info
 from gnomad_qc.v4.resources.variant_qc import (
     VQSR_FEATURES,
     final_filter,
-    final_filter_simplified,
     get_score_bins,
 )
 
@@ -544,7 +543,7 @@ def main(args):
         # Write out simplified final filtered table to path defined above in resources.
         ht = ht.select("filters")
         ht = ht.checkpoint(
-            final_filter_simplified(test=test).path, overwrite=args.overwrite
+            final_filter(test=test, simplified=True).path, overwrite=args.overwrite
         )
     else:
         # Write out final filtered table to path defined above in resources.

--- a/gnomad_qc/v4/variant_qc/final_filter.py
+++ b/gnomad_qc/v4/variant_qc/final_filter.py
@@ -407,6 +407,8 @@ def get_final_variant_qc_resources(
     test: bool,
     overwrite: bool,
     model_id: str,
+    all_variants: bool = False,
+    only_filters: bool = False,
 ) -> PipelineResourceCollection:
     """
     Get PipelineResourceCollection for all resources needed in the finalizing variant QC pipeline.
@@ -414,6 +416,9 @@ def get_final_variant_qc_resources(
     :param test: Whether to gather all resources for testing.
     :param overwrite: Whether to overwrite resources if they exist.
     :param model_id: Model ID to use for final variant QC.
+    :param all_variants: Whether to get the final filter resource for all variants.
+    :param only_filters: Whether to get the final filter resource with only the
+        'filters' field.
     :return: PipelineResourceCollection containing resources for all steps of finalizing
         variant QC pipeline.
     """
@@ -441,7 +446,13 @@ def get_final_variant_qc_resources(
     finalize_variant_qc = PipelineStepResourceCollection(
         "final_filter.py",
         input_resources=input_resources,
-        output_resources={"final_ht": final_filter(test=test)},
+        output_resources={
+            "final_ht": final_filter(
+                all_variants=all_variants,
+                only_filters=only_filters,
+                test=test,
+            )
+        },
     )
 
     # Add all steps to the finalizing variant QC pipeline resource collection.
@@ -459,12 +470,16 @@ def main(args):
     )
     test = args.test
     overwrite = args.overwrite
+    all_variants = args.all_variants
+    only_filters = args.only_filters
 
     # Call method to return final VQC resources from evaluation runs.
     final_vqc_resources = get_final_variant_qc_resources(
         test=test,
         overwrite=overwrite,
         model_id=args.model_id,
+        all_variants=all_variants,
+        only_filters=only_filters,
     )
     res = final_vqc_resources.finalize_variant_qc
     res.check_resource_existence()
@@ -477,17 +492,15 @@ def main(args):
     if test:
         bin_ht = bin_ht._filter_partitions(range(5))
 
-    # Note: For de novo variants release, we need to get "filters" for variants that
-    # are not in the release, so we write out another simplified final filter table.
-    if args.include_variants_not_in_release:
-        # Filter out AS_lowqual variants and variants not in the release.
-        bin_ht = bin_ht.filter(~res.info_ht.ht()[bin_ht.key].AS_lowqual)
-    else:
-        # Filter out AS_lowqual variants and variants not in the release.
-        bin_ht = bin_ht.filter(
-            ~res.info_ht.ht()[bin_ht.key].AS_lowqual
-            & (freq_ht[bin_ht.key].freq[1].AC > 0)
-        )
+    # Filter out AS_lowqual variants.
+    filter_expr = ~res.info_ht.ht()[bin_ht.key].AS_lowqual
+
+    # Note: For the de novo variants release, we need to get "filters" for variants
+    # that are not in the release, but otherwise we filter them out.
+    if not all_variants:
+        filter_expr &= freq_ht[bin_ht.key].freq[1].AC > 0
+
+    bin_ht = bin_ht.filter(filter_expr)
 
     # Name filter and score annotations based on model.
     if args.model_id.startswith("vqsr_"):
@@ -539,15 +552,12 @@ def main(args):
         filtering_model=ht.filtering_model.annotate(model_id=args.model_id)
     )
 
-    if args.include_variants_not_in_release:
-        # Write out simplified final filtered table to path defined above in resources.
+    # Select only the filters field if requested.
+    if only_filters:
         ht = ht.select("filters")
-        ht = ht.checkpoint(
-            final_filter(test=test, simplified=True).path, overwrite=args.overwrite
-        )
-    else:
-        # Write out final filtered table to path defined above in resources.
-        ht = ht.checkpoint(res.final_ht.path, overwrite=args.overwrite)
+
+    # Write out final filtered table to path defined above in resources.
+    ht = ht.checkpoint(res.final_ht.path, overwrite=args.overwrite)
 
     # Print out counts of variants in each filter group.
     logger.info("Counts of variants in each filter group:")
@@ -647,9 +657,18 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     parser.add_argument(
-        "--include-variants-not-in-release",
+        "--all-variants",
         help=(
-            "Whether to include variants not in the release in the final filter Table."
+            "Whether to write out a version of the final filter Table with all "
+            "variants, including those not in the release."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--only-filters",
+        help=(
+            "Whether to write out a version of the final filter Table with only the "
+            "'filters' field."
         ),
         action="store_true",
     )


### PR DESCRIPTION
Our original final filter table filtered out variants that are not in the release by freq_ht, we want to have non-missing filters for de novo variants (which weren't in the release because some probands were excluded due to relatedness). 
Test: [45ff85cc7538413ba0ea020cdb96f3ad](https://console.cloud.google.com/dataproc/jobs/45ff85cc7538413ba0ea020cdb96f3ad?region=us-central1&inv=1&invt=AbjExw&project=broad-mpg-gnomad)