### PR TITLE
Generate de novo release

### DIFF
--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -157,10 +157,10 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> hl.Table:
                 AC_high_conf=hl.agg.count_where(
                     (ht.de_novo_call_info.confidence == "HIGH") & ht.adj_trio
                 ),
-                # We're adding some MEDIUM confidence calls to high-quality because
-                # we found the rate of some coding consequences didn't meet the
-                # expectations, based on the distribution of p_de_novo values at
-                # MEDIUM level, we chose a reasonable threshold of 0.9.
+                # We included some some MEDIUM confidence calls in the set of high-quality variants because
+                # the numbers of de novos for some coding consequences didn't meet the expected rates from the literature.
+                # To increase our de novo detection rates, we assessed the distribution of p_de_novo values for MEDIUM confidence de novos
+                # and chose to include MEDIUM confidence de novos with p >= 0.9.
                 AC_medium_conf_P_0_9=hl.agg.count_where(
                     (ht.de_novo_call_info.confidence == "MEDIUM")
                     & (ht.de_novo_call_info.p_de_novo >= 0.9)

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -285,16 +285,18 @@ def main(args):
         priors_ht = public_release("exomes").ht()
         ped = hl.Pedigree.read(pedigree().path, delimiter="\t")
 
-        ht = get_releasable_de_novo_calls_ht(mt, priors_ht, ped, test)
+        ht = get_releasable_de_novo_calls_ht(
+            mt, priors_ht, ped, test, n_partitions=args.n_partitions
+        )
         ht.write(
             trio_denovo_ht(
-                releasable=True, test=test, n_partitions=args.n_partitions
+                test=test,
             ).path,
             overwrite=overwrite,
         )
 
     if args.generate_final_hts:
-        ht = hl.read_table(trio_denovo_ht(releasable=True, test=test).path)
+        ht = hl.read_table(trio_denovo_ht(test=test).path)
         ht, ht_high = aggregate_and_annotate_de_novos(ht)
         ht.naive_coalesce(500).write(
             release_de_novo(test=test, by_confidence="all").path,

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -161,6 +161,8 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
                 ),
             ),
             p_de_novo_stats=hl.agg.stats(ht.de_novo_call_info.p_de_novo),
+            mixed_site=hl.agg.collect(ht.mixed_site)[0],
+            # the mixed_site info should stay the same for each variant.
         )
         .key_by("locus", "alleles")
     )

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -109,8 +109,11 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
        and are not excluded by variant QC. Includes all confidence levels.
 
        - **Filtered high-quality coding de novos**: A subset of filtered de novos, further restricted to:
+
           - HIGH confidence, or MEDIUM confidence with a high P-value
+
           - Coding consequence
+
           - gnomAD v4.1 exomes allele frequency (AF) and callset allele count (AC) filters.
 
     :param ht: De novo calls Table.

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -255,7 +255,7 @@ def restructure_for_tsv(ht: hl.Table) -> hl.Table:
     Restructure the de novo release HT for TSV export.
 
     .. note::
-       This function will only be used for the TSV of high confidence coding de novos.
+       This function will only be used for the TSV of high-quality coding de novos.
 
     :param ht: De novo release HT.
     :return: Restructured HT.

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -136,8 +136,8 @@ def get_releasable_de_novo_calls_ht(
     )
     mt = annotate_adj(mt)
 
-    # Many of our larger datasets have the PL and AD fields for homref genotypes
-    # intentionally removed to save storage space and costs. We need to approximate the
+    # V3 and v4 VDS have the PL and AD fields for homref genotypes intentionally
+    # removed to save storage space and costs. We need to approximate the
     # AD and PL fields when missing.
     mt = mt.annotate_entries(
         AD=hl.or_else(mt.AD, [mt.DP, 0]),

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -122,6 +122,7 @@ def get_releasable_de_novo_calls_ht(
         logger.info("Filtering to chr20 for testing...")
         mt = hl.filter_intervals(mt, [hl.parse_locus_interval("chr20")])
 
+    # The split MT was made by adding these extra annotations .
     mt = mt.annotate_rows(
         n_unsplit_alleles=hl.len(mt.alleles),
         mixed_site=(
@@ -152,22 +153,6 @@ def get_releasable_de_novo_calls_ht(
     ht = tm.entries()
 
     ht = ht.annotate(
-        is_de_novo=call_de_novo(
-            ht.locus,
-            ht.proband_entry,
-            ht.father_entry,
-            ht.mother_entry,
-            is_xx_expr=ht.is_xx,
-        )
-    )
-
-    ht = (
-        ht.filter(ht.is_de_novo)
-        .naive_coalesce(1000)
-        .checkpoint(new_temp_file("de_novo_calls", "ht"))
-    )
-
-    ht = ht.annotate(
         de_novo_call_info=get_de_novo_expr(
             locus_expr=ht.locus,
             alleles_expr=ht.alleles,
@@ -179,6 +164,7 @@ def get_releasable_de_novo_calls_ht(
         )
     )
 
+    ht = ht.filter(ht.de_novo_call_info.is_de_novo).naive_coalesce(1000)
     return ht
 
 

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -187,7 +187,7 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
         gnomAD_v4_exomes_AF=freq_ht[ht.key].freq[0].AF,
     ).drop("vep")
 
-    ht = ht.filter(~ht.alleles[1] == "*").checkpoint(
+    ht = ht.filter(ht.alleles[1] != "*").checkpoint(
         new_temp_file("denovo_no_star", "ht")
     )
     logger.info(f"Getting {ht.count()} de novos after filtering out '*' alts...")

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -105,16 +105,9 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
 
     This step produces two sets of de novo calls:
 
-       - **Filtered de novos**: Variants that are not in low-confidence regions, do not have a `*` alt allele,
-       and are not excluded by variant QC. Includes all confidence levels.
+       - **Filtered de novos**: Variants that are not in low-confidence regions, do not have a `*` alt allele, and are not excluded by variant QC. Includes all confidence levels.
 
-       - **Filtered high-quality coding de novos**: A subset of filtered de novos, further restricted to:
-
-          - HIGH confidence, or MEDIUM confidence with a high P-value
-
-          - Coding consequence
-
-          - gnomAD v4.1 exomes allele frequency (AF) and callset allele count (AC) filters.
+       - **Filtered high-quality coding de novos**: A subset of filtered de novos, further restricted to HIGH confidence, or MEDIUM confidence with a high P-value, coding consequence, and gnomAD v4.1 exomes allele frequency (AF) and callset allele count (AC) filters.
 
     :param ht: De novo calls Table.
     :return: Aggregated and annotated Tables.

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -143,8 +143,10 @@ def get_releasable_de_novo_calls_ht(
         PL=hl.or_else(mt.PL, [0, mt.GQ, 2 * mt.GQ]),
     )
     mt = mt.annotate_rows(prior=priors_ht[mt.row_key].freq[0].AF)
+    mt = mt.select_entries("GT", "AD", "DP", "GQ", "PL", "adj")
 
     tm = hl.trio_matrix(mt, ped, complete_trios=True)
+    tm = tm.transmute_cols(is_xx=tm.is_female)
     tm = tm.checkpoint(new_temp_file("trio_matrix", "mt"))
 
     ht = tm.entries()
@@ -155,7 +157,7 @@ def get_releasable_de_novo_calls_ht(
             ht.proband_entry,
             ht.father_entry,
             ht.mother_entry,
-            is_xx_expr=ht.is_female,
+            is_xx_expr=ht.is_xx,
         )
     )
 
@@ -172,7 +174,7 @@ def get_releasable_de_novo_calls_ht(
             proband_expr=ht.proband_entry,
             father_expr=ht.father_entry,
             mother_expr=ht.mother_entry,
-            is_xx_expr=ht.is_female,
+            is_xx_expr=ht.is_xx,
             freq_prior_expr=ht.prior,
         )
     )

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -177,7 +177,7 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
             ),
             p_de_novo_stats=hl.agg.stats(ht.de_novo_call_info.p_de_novo),
             # The mixed_site info should stay the same for each variant.
-            mixed_site=hl.agg.collect(ht.mixed_site)[0],
+            mixed_site=hl.agg.take(ht.mixed_site, 1)[0],
         )
         .key_by("locus", "alleles")
     )
@@ -255,6 +255,7 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
         f"callset..."
     )
 
+    ht = ht.drop(ht.de_novo_AC.AC_medium_conf, ht.de_novo_AC.AC_low_conf)
     return ht_all_conf, ht
 
 
@@ -268,7 +269,6 @@ def restructure_for_tsv(ht: hl.Table) -> hl.Table:
     :param ht: De novo release HT.
     :return: Restructured HT.
     """
-    ht = ht.drop(ht.de_novo_AC.AC_medium_conf, ht.de_novo_AC.AC_low_conf)
     return ht.flatten().rename(
         {
             "de_novo_AC.AC_all": "de_novo_AC_all",

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import hail as hl
 from gnomad.resources.grch38.gnomad import all_sites_an, public_release
-from gnomad.sample_qc.relatedness import call_de_novo, get_de_novo_expr
+from gnomad.sample_qc.relatedness import default_get_de_novo_expr
 from gnomad.utils.annotations import annotate_adj
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.vep import process_consequences
@@ -153,7 +153,7 @@ def get_releasable_de_novo_calls_ht(
     ht = tm.entries()
 
     ht = ht.annotate(
-        de_novo_call_info=get_de_novo_expr(
+        de_novo_call_info=default_get_de_novo_expr(
             locus_expr=ht.locus,
             alleles_expr=ht.alleles,
             proband_expr=ht.proband_entry,

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -155,9 +155,6 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> hl.Table:
                 AC_high_conf=hl.agg.count_where(
                     (ht.de_novo_call_info.confidence == "HIGH") & ht.adj_trio
                 ),
-                AC_medium_conf=hl.agg.count_where(
-                    (ht.de_novo_call_info.confidence == "MEDIUM") & ht.adj_trio
-                ),
                 # We're adding some MEDIUM confidence calls to high-quality because
                 # we found the rate of some coding consequences didn't meet the
                 # expectations, based on the distribution of p_de_novo values at
@@ -166,9 +163,6 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> hl.Table:
                     (ht.de_novo_call_info.confidence == "MEDIUM")
                     & (ht.de_novo_call_info.p_de_novo >= 0.9)
                     & ht.adj_trio
-                ),
-                AC_low_conf=hl.agg.count_where(
-                    (ht.de_novo_call_info.confidence == "LOW") & ht.adj_trio
                 ),
             ),
             p_de_novo_stats=hl.agg.stats(ht.de_novo_call_info.p_de_novo),
@@ -248,7 +242,6 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> hl.Table:
         f"callset..."
     )
 
-    ht = ht.drop(ht.de_novo_AC.AC_medium_conf, ht.de_novo_AC.AC_low_conf)
     return ht
 
 
@@ -302,7 +295,7 @@ def main(args):
             overwrite=overwrite,
         )
 
-    if args.generate_final_hts:
+    if args.generate_final_ht:
         ht = hl.read_table(trio_denovo_ht(test=test).path)
         ht = aggregate_and_annotate_de_novos(ht)
         ht.naive_coalesce(20).write(
@@ -344,7 +337,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     parser.add_argument(
-        "--generate-final-hts",
+        "--generate-final-ht",
         help="Generate the final HT for de novo release.",
         action="store_true",
     )

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -218,7 +218,6 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
             "splice_region_variant",
             "splice_donor_region_variant",
             "incomplete_terminal_codon_variant",
-            "coding_sequence_variant",
             "coding_transcript_variant",
         }
     )

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -2,11 +2,10 @@
 
 import argparse
 import logging
-from datetime import datetime
-from typing import Dict, Tuple
+from typing import Tuple
 
 import hail as hl
-from gnomad.resources.grch38.gnomad import all_sites_an, public_release
+from gnomad.resources.grch38.gnomad import public_release
 from gnomad.sample_qc.relatedness import default_get_de_novo_expr
 from gnomad.utils.annotations import annotate_adj, get_copy_state_by_sex
 from gnomad.utils.filtering import filter_low_conf_regions
@@ -20,22 +19,7 @@ from gnomad.utils.vep import (
 from hail.utils import new_temp_file
 
 from gnomad_qc.slack_creds import slack_token
-from gnomad_qc.v4.create_release.create_release_sites_ht import (
-    custom_region_flags_select,
-    get_config,
-    get_final_ht_fields,
-    get_freq_array_readme,
-    join_hts,
-)
-from gnomad_qc.v4.create_release.create_release_utils import (
-    DBSNP_VERSION,
-    GENCODE_VERSION,
-    MANE_SELECT_VERSION,
-    POLYPHEN_VERSION,
-    SIFT_VERSION,
-)
-from gnomad_qc.v4.resources.annotations import get_info, get_trio_stats, get_vep
-from gnomad_qc.v4.resources.constants import CURRENT_RELEASE
+from gnomad_qc.v4.resources.annotations import get_vep
 from gnomad_qc.v4.resources.release import release_de_novo
 from gnomad_qc.v4.resources.sample_qc import dense_trio_mt, pedigree, trio_denovo_ht
 from gnomad_qc.v4.resources.variant_qc import final_filter
@@ -46,67 +30,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger("create_de_novo_release_ht")
 logger.setLevel(logging.INFO)
-
-FINALIZED_SCHEMA = {
-    "globals": [
-        "exomes_freq_globals",
-        "genomes_freq_globals",
-        "joint_freq_globals",
-        "exomes_an_globals",
-        "filtering_model",
-        "inbreeding_coeff_cutoff",
-        "tool_versions",
-        "vep_globals",
-        "frequency_README",
-        "date",
-        "version",
-    ],
-    "rows": [
-        "de_novo_stats",
-        "de_novo_stats_raw",
-        "exomes_freq",
-        "genomes_freq",
-        "joint_freq",
-        "exomes_an",
-        "a_index",
-        "was_split",
-        "rsid",
-        "filters",
-        "vep",
-        "region_flags",
-        "allele_info",
-        "exomes_qual_hists",
-        "in_silico_predictors",
-    ],
-}
-
-TABLES_FOR_RELEASE = [
-    "de_novos",
-    "dbsnp",
-    "filters",
-    "info",
-    "in_silico",
-    "vep",
-    "joint_freq",
-    "exomes_an",
-]
-
-
-def filter_de_novos(ht: hl.Table) -> hl.Table:
-    """
-    Filter the trio stats Table to de novo variants.
-
-    Removes variants that are not de novo, AS_lowqual, and '*' alleles.
-
-    :param ht: Trio stats Table.
-    :return: Filtered Table.
-    """
-    ht = ht.filter(
-        (ht.n_de_novos_raw > 0)
-        & ~get_info().ht()[ht.key].AS_lowqual
-        & (ht.alleles[1] != "*")
-    )
-    return ht
 
 
 def get_releasable_de_novo_calls_ht(
@@ -243,6 +166,9 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
     )
     logger.info(f"Getting {ht.count()} unique de novo variants after computing AC...")
 
+    ht = ht.annotate(vep=vep_ht[ht.key].vep)
+    ht = process_consequences(ht, has_polyphen=False)
+
     ht = ht.annotate(
         alt_is_star=ht.alleles[1] == "*",
         pass_filters=filters_ht[ht.key]
@@ -250,9 +176,14 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
         .length()
         == 0,  # AC0 is not used as a criteria in de novos because AC0 was used for
         # release sites and some of the probands weren't included in the release.
-    )
+        worst_csq_for_variant=ht.vep.worst_csq_for_variant.most_severe_consequence,
+        gene_id=ht.vep.worst_csq_for_variant.gene_id,
+        transcript_id=ht.vep.worst_csq_for_variant.transcript_id,
+        gnomAD_v4_exomes_AF=freq_ht[ht.key].freq[0].AF,
+    ).drop("vep")
 
     # Store the de novo calls with all confidence levels.
+    # TODO: Should this be after non-star filtering or even after pass_filters?
     ht_all_conf = ht
 
     ht = ht.filter(~ht.alt_is_star).checkpoint(new_temp_file("denovo_no_star", "ht"))
@@ -266,17 +197,7 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
         f"filters..."
     )
 
-    ht = ht.annotate(vep=vep_ht[ht.key].vep)
-    ht = process_consequences(ht, has_polyphen=False)
-
-    ht = ht.annotate(
-        worst_csq_for_variant=ht.vep.worst_csq_for_variant.most_severe_consequence,
-        gene_id=ht.vep.worst_csq_for_variant.gene_id,
-        transcript_id=ht.vep.worst_csq_for_variant.transcript_id,
-        gnomAD_v4_exomes_AF=freq_ht[ht.key].freq[0].AF,
-    ).drop("vep")
-
-    ht = ht.filter(ht.de_novo_AC.AC_high_conf_adj > 0).checkpoint(
+    ht = ht.filter(ht.de_novo_AC.AC_high_conf > 0).checkpoint(
         new_temp_file("denovo_high_conf", "ht")
     )
     logger.info(f"Getting {ht.count()} high confidence de novos...")
@@ -297,7 +218,7 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
     )
     logger.info(f"Getting {ht.count()} high confidence coding de novos...")
 
-    ht = ht.filter(ht.de_novo_AC.AC_high_conf_adj <= 15).checkpoint(
+    ht = ht.filter(ht.de_novo_AC.AC_high_conf <= 15).checkpoint(
         new_temp_file("denovo_high_coding_ac15", "ht")
     )
     logger.info(
@@ -316,196 +237,6 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> Tuple[hl.Table, hl.Table]:
     return ht_all_conf, ht
 
 
-# TODO: Change when we decide on the final de novo data to release.
-def custom_de_novo_select(ht, **_):
-    """Select fields from de novo stats Table."""
-    return {
-        f"de_novo_stats{'' if g == 'adj' else '_raw'}": hl.struct(
-            n_de_novo=ht[f"n_de_novos_{g}"],
-            parents=hl.struct(
-                AC=ht[f"ac_parents_{g}"],
-                AN=ht[f"an_parents_{g}"],
-            ),
-            children=hl.struct(
-                AC=ht[f"ac_children_{g}"],
-                AN=ht[f"an_children_{g}"],
-            ),
-        )
-        for g in ["adj", "raw"]
-    }
-
-
-def custom_joint_freq_select(ht: hl.Table, **_) -> Dict[str, hl.expr.Expression]:
-    """
-    Select joint freq fields for release.
-
-    :param ht: Joint freq Hail Table.
-    :return: Select expression dict.
-    """
-    selects = {
-        f"{data_type}_freq": ht[data_type].freq
-        for data_type in ["exomes", "genomes", "joint"]
-    }
-    selects["exomes_qual_hists"] = ht.exomes.histograms.qual_hists
-
-    return selects
-
-
-def custom_joint_freq_select_globals(ht: hl.Table) -> Dict[str, hl.expr.Expression]:
-    """
-    Select joint freq globals for release.
-
-    :param ht: Joint freq Hail Table.
-    :return: Select expression dict
-    """
-    return {
-        f"{data_type}_freq_globals": ht[f"{data_type}_globals"].select(
-            "freq_meta", "freq_index_dict", "freq_meta_sample_count"
-        )
-        for data_type in ["exomes", "genomes", "joint"]
-    }
-
-
-def custom_info_select(ht: hl.Table, **_) -> Dict[str, hl.expr.Expression]:
-    """
-    Select fields for info Hail Table annotation in de novo release.
-
-    :param ht: Info Hail Table.
-    :return: Select expression dict.
-    """
-    return {"allele_info": ht.allele_info.drop("nonsplit_alleles")}
-
-
-def custom_an_select(ht: hl.Table, **_) -> Dict[str, hl.expr.Expression]:
-    """
-    Select AN for release.
-
-    :param ht: Hail Table with AN.
-    :return: Select expression dict.
-    """
-    selects = {"exomes_an": ht.AN, **custom_region_flags_select(ht, data_type="")}
-    selects["region_flags"] = selects["region_flags"].annotate(
-        **{r: ht[r] for r in ht.row_value if r.endswith("_region")}
-    )
-
-    return selects
-
-
-def custom_an_select_globals(ht: hl.Table) -> Dict[str, hl.expr.Expression]:
-    """
-    Select AN Table globals for release.
-
-    :param ht: Hail Table with AN.
-    :return: Select expression dict.
-    """
-    return {
-        "exomes_an_globals": hl.struct(
-            meta=ht.strata_meta,
-            sample_count=ht.strata_sample_count,
-        )
-    }
-
-
-def get_de_novo_config() -> Dict[str, dict]:
-    """
-    Get de novo release config.
-
-    :return: Config dict.
-    """
-    config = get_config(data_type="exomes")
-    config["info"].update(
-        {
-            "select": ["was_split", "a_index"],
-            "custom_select": custom_info_select,
-        }
-    )
-    config.update(
-        {
-            "filters": {
-                "ht": final_filter(all_variants=True, only_filters=True).ht(),
-                "path": final_filter(all_variants=True, only_filters=True).path,
-                "select": ["filters"],
-            },
-            # TODO: Change when we decide on the final de novo data to release.
-            "de_novos": {
-                "ht": get_trio_stats(releasable_only=True).ht(),
-                "path": get_trio_stats(releasable_only=True).path,
-                "custom_select": custom_de_novo_select,
-            },
-            "joint_freq": {
-                "ht": public_release("joint").ht(),
-                "path": public_release("joint").path,
-                "custom_select": custom_joint_freq_select,
-                "custom_globals_select": custom_joint_freq_select_globals,
-            },
-            "exomes_an": {
-                "ht": all_sites_an("exomes").ht(),
-                "path": all_sites_an("exomes").path,
-                "custom_select": custom_an_select,
-                "custom_globals_select": custom_an_select_globals,
-            },
-        }
-    )
-
-    return config
-
-
-def get_de_novo_release_ht(
-    tables_for_join: list[str], version: str, test: bool = False
-) -> hl.Table:
-    """
-    Get de novo release HT.
-
-    :param tables_for_join: Tables to join for release.
-    :param version: Version of gnomAD.
-    :param test: Run test on chr20. Default is False.
-    """
-    config = get_de_novo_config()
-    ht = join_hts(
-        "de_novos",
-        tables_for_join,
-        "exomes",
-        config,
-        version=version,
-        new_n_partitions=5 if test else 1000,
-        checkpoint_tables=True,
-        track_included_datasets=False,
-        use_annotate=True,
-        test=test,
-    )
-
-    # Filter out chrM, AS_lowqual, alt is '*' sites (these sites are dropped in the
-    # final_filters HT so will not have information in `filters`).
-    logger.info("Filtering out chrM, AS_lowqual and alt is '*'...")
-    ht = hl.filter_intervals(ht, [hl.parse_locus_interval("chrM")], keep=False)
-    ht = ht.filter(hl.is_defined(ht.filters))
-
-    # TODO: Change when we decide on the final de novo data to release.
-    ht = ht.filter(ht.de_novo_stats_raw.n_de_novo > 0)
-
-    logger.info("Finalizing the release HT global and row fields...")
-    # Add additional globals that were not present on the joined HTs.
-    ht = ht.annotate_globals(
-        vep_globals=ht.vep_globals.annotate(
-            gencode_version=GENCODE_VERSION,
-            mane_select_version=MANE_SELECT_VERSION,
-        ),
-        tool_versions=ht.tool_versions.annotate(
-            dbsnp_version=DBSNP_VERSION,
-            sift_version=SIFT_VERSION,
-            polyphen_version=POLYPHEN_VERSION,
-        ),
-        date=datetime.now().isoformat(),
-        version=CURRENT_RELEASE,
-        frequency_README=get_freq_array_readme(data_type="exomes"),
-    )
-
-    # Organize the fields in the release HT to match the order of FINALIZED_SCHEMA when
-    # the fields are present in the HT.
-    final_fields = get_final_ht_fields(ht, schema=FINALIZED_SCHEMA)
-    return ht.select(*final_fields["rows"]).select_globals(*final_fields["globals"])
-
-
 def restructure_for_tsv(ht: hl.Table) -> hl.Table:
     """
     Restructure the de novo release HT for TSV export.
@@ -513,36 +244,18 @@ def restructure_for_tsv(ht: hl.Table) -> hl.Table:
     :param ht: De novo release HT.
     :return: Restructured HT.
     """
-    # TODO: Change when we decide on the final de novo data to release.
-    ht = ht.filter((ht.filters.length() == 0) & (ht.de_novo_stats.n_de_novo > 0))
-    ht = process_consequences(ht, penalize_flags=False, has_polyphen=False)
-    return (
-        ht.select(
-            "de_novo_stats",
-            exomes=ht.exomes_freq[0],
-            genomes=ht.genomes_freq[0],
-            joint=ht.joint_freq[0],
-            worst_csq_for_variant_canonical=ht.vep.worst_csq_for_variant_canonical.select(
-                "most_severe_consequence",
-                "transcript_id",
-                "gene_id",
-                "gene_symbol",
-                "mane_select",
-                "lof",
-                "hgnc_id",
-            ),
-            **ht.in_silico_predictors,
-        )
-        .flatten()
-        .rename(
-            {
-                "de_novo_stats.n_de_novo": "n_de_novo",
-                "de_novo_stats.parents.AC": "trio_parents.AC",
-                "de_novo_stats.parents.AN": "trio_parents.AN",
-                "de_novo_stats.children.AC": "trio_children.AC",
-                "de_novo_stats.children.AN": "trio_children.AN",
-            }
-        )
+    return ht.flatten().rename(
+        {
+            "de_novo_AC.AC_all": "de_novo_AC_all",
+            "de_novo_AC.AC_all_raw": "de_novo_AC_all_raw",
+            "de_novo_AC.AC_high_conf": "de_novo_AC_high_conf",
+            "de_novo_AC.AC_medium_conf": "de_novo_AC_medium_conf",
+            "de_novo_AC.AC_low_conf": "de_novo_AC_low_conf",
+            "p_de_novo_stats.mean": "p_de_novo_mean",
+            "p_de_novo_stats.stdev": "p_de_novo_stdev",
+            "p_de_novo_stats.min": "p_de_novo_min",
+            "p_de_novo_stats.max": "p_de_novo_max",
+        }
     )
 
 
@@ -551,9 +264,8 @@ def main(args):
     hl.init(
         log=f"/create_de_novo_release_ht.log",
         tmp_dir="gs://gnomad-tmp-4day",
-        # TODO: Change to be set outside init, used this to run with hail 0.2.122.
-        default_reference="GRCh38",
     )
+    hl.default_reference("GRCh38")
 
     test = args.test
     overwrite = args.overwrite
@@ -566,40 +278,27 @@ def main(args):
         ht = get_releasable_de_novo_calls_ht(mt, priors_ht, ped, test)
         ht.write(trio_denovo_ht(releasable=True, test=test).path, overwrite=overwrite)
 
-    if args.aggregate_and_annotate_de_novos:
+    if args.generate_final_hts:
         ht = hl.read_table(trio_denovo_ht(releasable=True, test=test).path)
         ht, ht_high = aggregate_and_annotate_de_novos(ht)
         ht.naive_coalesce(500).write(
-            trio_denovo_ht(
-                releasable=True, test=test, filtered_by_confidence="all"
-            ).path,
+            release_de_novo(test=test, by_confidence="all").path,
             overwrite=overwrite,
         )
         ht_high.naive_coalesce(20).write(
-            trio_denovo_ht(
-                releasable=True, test=test, filtered_by_confidence="high"
-            ).path,
+            release_de_novo(test=test, by_confidence="high").path,
             overwrite=overwrite,
         )
-
-    if args.generate_final_ht:
-        ht = get_de_novo_release_ht(args.tables_for_join, args.version, test=test)
-
         logger.info("Final de novo release HT schema:")
         ht.describe()
 
-        ht = ht.checkpoint(new_temp_file("de_novo_release", "ht"))
-        output_path = release_de_novo(test=test).path
-        logger.info(f"Writing out de novo release HT to %s", output_path)
-        ht = ht.naive_coalesce(args.n_partitions).checkpoint(output_path, overwrite)
-
-        logger.info("Final de novo count: %d", ht.count())
-
     if args.generate_final_tsv:
-        ht = release_de_novo(test=test).ht()
+        ht = release_de_novo(test=test, by_confidence="high").ht()
         ht = restructure_for_tsv(ht)
         ht.export(
-            release_de_novo(test=test).path.replace(".ht", ".tsv.bgz"),
+            release_de_novo(test=test, by_confidence="high").path.replace(
+                ".ht", ".tsv.bgz"
+            ),
             header=True,
             delimiter="\t",
         )
@@ -609,12 +308,6 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     """Get script argument parser."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--overwrite", help="Overwrite data", action="store_true")
-    parser.add_argument(
-        "-v",
-        "--version",
-        help="The version of gnomAD.",
-        default=CURRENT_RELEASE,
-    )
     parser.add_argument(
         "-t",
         "--test",
@@ -627,34 +320,9 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     parser.add_argument(
-        "--aggregate-and-annotate-de-novos",
-        help="Aggregate and annotate de novo calls.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--de-novo-n-partitions",
-        help="Number of partitions to naive coalesce the de novo dense MT to.",
-        type=int,
-        default=100,
-    )
-    parser.add_argument(
-        "--generate-final-ht",
+        "--generate-final-hts",
         help="Generate the final HT for de novo release.",
         action="store_true",
-    )
-    parser.add_argument(
-        "-j",
-        "--tables-for-join",
-        help="Tables to join for release",
-        default=TABLES_FOR_RELEASE,
-        type=str,
-        nargs="+",
-    )
-    parser.add_argument(
-        "--n-partitions",
-        help="Number of partitions to naive coalesce the release Table to.",
-        type=int,
-        default=100,
     )
     parser.add_argument(
         "--generate-final-tsv",

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -103,11 +103,13 @@ def aggregate_and_annotate_de_novos(ht: hl.Table) -> hl.Table:
     """
     Aggregate and annotate de novo calls.
 
-    This step produces high-quality coding de novos for the release, including variants
-    that are not in low-confidence regions, do not have a `*` alt allele, and are not
-    excluded by variant QC A subset of filtered de novos, further restricted to HIGH
-    confidence or MEDIUM confidence with a P-value >= 0.9, coding consequence,
-    and gnomAD v4.1 exomes allele frequency (AF) and callset allele count (AC) filters.
+    This step produces high quality coding de novos for release. High quality is defined as variants that:
+        - Are not in low-confidence regions
+        - Do not have a `*` alt allele
+        - Passed variant QC
+        - Have either HIGH (all probabilities) or MEDIUM (P-value >=0.9) confidence of being a *de novo*
+        - Have a coding consequence
+        - Pass gnomAD v4.1 exomes allele frequency (AF) and callset allele count (AC) filters
 
     :param ht: De novo calls Table.
     :return: Aggregated and annotated Table.

--- a/gnomad_qc/v4/create_release/create_de_novo_release.py
+++ b/gnomad_qc/v4/create_release/create_de_novo_release.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import hail as hl
 from gnomad.resources.grch38.gnomad import all_sites_an, public_release
-from gnomad.sample_qc.relatedness import get_de_novo_expr
+from gnomad.sample_qc.relatedness import call_de_novo, get_de_novo_expr
 from gnomad.utils.annotations import annotate_adj
 from gnomad.utils.slack import slack_notifications
 from gnomad.utils.vep import process_consequences

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -398,30 +398,16 @@ def release_all_sites_an(
 
 def release_de_novo(
     test: bool = False,
-    by_confidence: str = "all",
 ) -> VersionedTableResource:
     """
     Retrieve versioned resource for exomes de novo release Table.
 
     :param test: Whether to use a tmp path for testing. Default is False.
-    :param by_confidence: Whether to get the table filtered by confidence level.
-       Either 'all' or 'high'. Default is 'all'.
     :return: De novo release Table.
     """
     data_type = "exomes"
 
-    valid_options = {"all", "high"}
-    if by_confidence not in valid_options:
-        raise ValueError(
-            f"Invalid value for by_confidence: '{by_confidence}'. "
-            f"Allowed values are {valid_options}."
-        )
-
-    confidence_suffix = (
-        ".all_confidences.filtered"
-        if by_confidence == "all"
-        else ".high_confidence.filtered"
-    )
+    confidence_suffix = ".high_quality_coding"
     return VersionedTableResource(
         default_version=CURRENT_DE_NOVO_RELEASE[data_type],
         versions={

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -405,9 +405,7 @@ def release_de_novo(
 
     :param test: Whether to use a tmp path for testing. Default is False.
     :param by_confidence: Whether to get the table filtered by confidence level.
-       Options:
-        - "all": Retrieves the table with all confidence levels filtered.
-        - "high": Retrieves the table with only high-confidence variants.
+       Either 'all' or 'high'. Default is 'all'.
     :return: De novo release Table.
     """
     data_type = "exomes"

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -396,14 +396,34 @@ def release_all_sites_an(
     )
 
 
-def release_de_novo(test: bool = False) -> VersionedTableResource:
+def release_de_novo(
+    test: bool = False,
+    by_confidence: str = "all",
+) -> VersionedTableResource:
     """
     Retrieve versioned resource for exomes de novo release Table.
 
     :param test: Whether to use a tmp path for testing. Default is False.
+    :param by_confidence: Whether to get the table filtered by confidence level.
+       Options:
+        - "all": Retrieves the table with all confidence levels filtered.
+        - "high": Retrieves the table with only high-confidence variants.
     :return: De novo release Table.
     """
     data_type = "exomes"
+
+    valid_options = {"all", "high"}
+    if by_confidence not in valid_options:
+        raise ValueError(
+            f"Invalid value for by_confidence: '{by_confidence}'. "
+            f"Allowed values are {valid_options}."
+        )
+
+    confidence_suffix = (
+        ".all_confidences.filtered"
+        if by_confidence == "all"
+        else ".high_confidence.filtered"
+    )
     postfix = f".{datetime.today().strftime('%Y-%m-%d')}" if test else ""
     return VersionedTableResource(
         default_version=CURRENT_DE_NOVO_RELEASE[data_type],
@@ -411,7 +431,7 @@ def release_de_novo(test: bool = False) -> VersionedTableResource:
             release: TableResource(
                 path=(
                     f"{_release_root(version=release, test=test, data_type=data_type)}"
-                    f"/gnomad.{data_type}.v{release}.de_novo{postfix}.ht"
+                    f"/gnomad.{data_type}.v{release}.de_novo{confidence_suffix}{postfix}.ht"
                 )
             )
             for release in DE_NOVO_RELEASES[data_type]

--- a/gnomad_qc/v4/resources/release.py
+++ b/gnomad_qc/v4/resources/release.py
@@ -422,14 +422,13 @@ def release_de_novo(
         if by_confidence == "all"
         else ".high_confidence.filtered"
     )
-    postfix = f".{datetime.today().strftime('%Y-%m-%d')}" if test else ""
     return VersionedTableResource(
         default_version=CURRENT_DE_NOVO_RELEASE[data_type],
         versions={
             release: TableResource(
                 path=(
                     f"{_release_root(version=release, test=test, data_type=data_type)}"
-                    f"/gnomad.{data_type}.v{release}.de_novo{confidence_suffix}{postfix}.ht"
+                    f"/gnomad.{data_type}.v{release}.de_novo{confidence_suffix}.ht"
                 )
             )
             for release in DE_NOVO_RELEASES[data_type]

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -999,12 +999,14 @@ def ped_filter_param_json_path(
 
 def dense_trio_mt(
     releasable: bool = True,
+    split: bool = False,
     test: bool = False,
 ) -> VersionedMatrixTableResource:
     """
     Get the VersionedMatrixTableResource for the dense trio MatrixTable.
 
     :param releasable: Whether to get the resource for the releasable trios only.
+    :param split: Whether to get the resource for the split trio MatrixTable.
     :param test: Whether to use a tmp path for a test resource.
     :return: VersionedMatrixTableResource of dense trio MatrixTable.
     """
@@ -1015,7 +1017,33 @@ def dense_trio_mt(
             version: MatrixTableResource(
                 f"{get_sample_qc_root(version, test, data_type='exomes')}"
                 f"/relatedness/trios/gnomad.{data_type}.v{version}.trios"
-                f"{'.releasable' if releasable else ''}.dense.mt"
+                f"{'.releasable' if releasable else ''}.dense"
+                f"{'.split' if split else ''}.mt"
+            )
+            for version in SAMPLE_QC_VERSIONS
+        },
+    )
+
+
+def trio_denovo_ht(
+    releasable: bool = True,
+    test: bool = False,
+) -> VersionedTableResource:
+    """
+    Get the VersionedTableResource for the trio de novo Table.
+
+    :param releasable: Whether to get the resource for the releasable trios only.
+    :param test: Whether to use a tmp path for a test resource.
+    :return: VersionedTableResource of trio de novo Table.
+    """
+    data_type = "exomes"
+    return VersionedTableResource(
+        CURRENT_SAMPLE_QC_VERSION,
+        {
+            version: TableResource(
+                f"{get_sample_qc_root(version, test, data_type='exomes')}"
+                f"/relatedness/trios/gnomad.{data_type}.v{version}.trios"
+                f"{'.releasable' if releasable else ''}.denovo.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },
@@ -1094,56 +1122,3 @@ hgdp_tgp_duplicated_to_exomes = TableResource(
 hgdp_tgp_relatedness = TableResource(
     path="gs://gnomad/v4.0/sample_qc/additional_resources/gnomad.genomes.v4.0.hgdp_tgp_relatedness.ht",
 )
-
-
-def de_novo_mt(
-    releasable: bool = True,
-    split: bool = False,
-    test: bool = False,
-) -> VersionedMatrixTableResource:
-    """
-    Get the VersionedMatrixTableResource for the dense de novo variants MatrixTable.
-
-    :param releasable: Whether to get the resource for the releasable trios only.
-    :param split: Whether to get the resource for multiallelic split
-    :param test: Whether to use a tmp path for a test resource.
-    :return: VersionedMatrixTableResource of dense de novo variants MatrixTable.
-    """
-    data_type = "exomes"
-    return VersionedMatrixTableResource(
-        CURRENT_SAMPLE_QC_VERSION,
-        {
-            version: MatrixTableResource(
-                f"{get_sample_qc_root(version, test, data_type='exomes')}"
-                f"/relatedness/trios/gnomad.{data_type}.v{version}.de_novo"
-                f"{'.releasable' if releasable else ''}.dense"
-                f"{'.split' if split else ''}.mt"
-            )
-            for version in SAMPLE_QC_VERSIONS
-        },
-    )
-
-
-def de_novo_calls_ht(
-    releasable: bool = True,
-    test: bool = False,
-) -> VersionedTableResource:
-    """
-    Get the VersionedTableResource for the de novo calls Table.
-
-    :param releasable: Whether to get the resource for the releasable trios only.
-    :param test: Whether to use a tmp path for a test resource.
-    :return: VersionedTableResource of de novo calls Table.
-    """
-    data_type = "exomes"
-    return VersionedTableResource(
-        CURRENT_SAMPLE_QC_VERSION,
-        {
-            version: TableResource(
-                f"{get_sample_qc_root(version, test, data_type='exomes')}"
-                f"/relatedness/trios/gnomad.{data_type}.v{version}.de_novo"
-                f"{'.releasable' if releasable else ''}.calls.ht"
-            )
-            for version in SAMPLE_QC_VERSIONS
-        },
-    )

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1098,12 +1098,14 @@ hgdp_tgp_relatedness = TableResource(
 
 def de_novo_mt(
     releasable: bool = True,
+    split: bool = False,
     test: bool = False,
 ) -> VersionedMatrixTableResource:
     """
     Get the VersionedMatrixTableResource for the dense de novo variants MatrixTable.
 
     :param releasable: Whether to get the resource for the releasable trios only.
+    :param split: Whether to get the resource for multiallelic split
     :param test: Whether to use a tmp path for a test resource.
     :return: VersionedMatrixTableResource of dense de novo variants MatrixTable.
     """
@@ -1114,7 +1116,33 @@ def de_novo_mt(
             version: MatrixTableResource(
                 f"{get_sample_qc_root(version, test, data_type='exomes')}"
                 f"/relatedness/trios/gnomad.{data_type}.v{version}.de_novo"
-                f"{'.releasable' if releasable else ''}.dense.mt"
+                f"{'.releasable' if releasable else ''}.dense"
+                f"{'.split' if split else ''}.mt"
+            )
+            for version in SAMPLE_QC_VERSIONS
+        },
+    )
+
+
+def de_novo_calls_ht(
+    releasable: bool = True,
+    test: bool = False,
+) -> VersionedTableResource:
+    """
+    Get the VersionedTableResource for the de novo calls Table.
+
+    :param releasable: Whether to get the resource for the releasable trios only.
+    :param test: Whether to use a tmp path for a test resource.
+    :return: VersionedTableResource of de novo calls Table.
+    """
+    data_type = "exomes"
+    return VersionedTableResource(
+        CURRENT_SAMPLE_QC_VERSION,
+        {
+            version: TableResource(
+                f"{get_sample_qc_root(version, test, data_type='exomes')}"
+                f"/relatedness/trios/gnomad.{data_type}.v{version}.de_novo"
+                f"{'.releasable' if releasable else ''}.calls.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1026,13 +1026,11 @@ def dense_trio_mt(
 
 
 def trio_denovo_ht(
-    releasable: bool = True,
     test: bool = False,
 ) -> VersionedTableResource:
     """
     Get the VersionedTableResource for the trio de novo Table.
 
-    :param releasable: Whether to get the resource for the releasable trios only.
     :param test: Whether to use a tmp path for a test resource.
     :return: VersionedTableResource of trio de novo Table.
     """
@@ -1042,8 +1040,8 @@ def trio_denovo_ht(
         {
             version: TableResource(
                 f"{get_sample_qc_root(version, test, data_type='exomes')}"
-                f"/relatedness/trios/gnomad.{data_type}.v{version}.trios"
-                f"{'.releasable' if releasable else ''}.denovo.ht"
+                f"/relatedness/trios/gnomad.{data_type}.v{version}.trios."
+                f"releasable.denovo.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1028,22 +1028,35 @@ def dense_trio_mt(
 def trio_denovo_ht(
     releasable: bool = True,
     test: bool = False,
+    filtered_by_confidence: Optional[str] = None,
 ) -> VersionedTableResource:
     """
     Get the VersionedTableResource for the trio de novo Table.
 
     :param releasable: Whether to get the resource for the releasable trios only.
     :param test: Whether to use a tmp path for a test resource.
+    :param filtered_by_confidence: Whether to get the table filtered by confidence level.
+        Options:
+        - None: Default, retrieves the standard table.
+        - "all": Retrieves the table with all confidence levels filtered.
+        - "high": Retrieves the table with only high-confidence variants.
     :return: VersionedTableResource of trio de novo Table.
     """
     data_type = "exomes"
+
+    confidence_suffix = ""
+    if filtered_by_confidence == "all":
+        confidence_suffix = ".all_confidence.filtered"
+    elif filtered_by_confidence == "high":
+        confidence_suffix = ".high_confidence.filtered"
+
     return VersionedTableResource(
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: TableResource(
                 f"{get_sample_qc_root(version, test, data_type='exomes')}"
                 f"/relatedness/trios/gnomad.{data_type}.v{version}.trios"
-                f"{'.releasable' if releasable else ''}.denovo.ht"
+                f"{'.releasable' if releasable else ''}.denovo{confidence_suffix}.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },

--- a/gnomad_qc/v4/resources/sample_qc.py
+++ b/gnomad_qc/v4/resources/sample_qc.py
@@ -1028,35 +1028,22 @@ def dense_trio_mt(
 def trio_denovo_ht(
     releasable: bool = True,
     test: bool = False,
-    filtered_by_confidence: Optional[str] = None,
 ) -> VersionedTableResource:
     """
     Get the VersionedTableResource for the trio de novo Table.
 
     :param releasable: Whether to get the resource for the releasable trios only.
     :param test: Whether to use a tmp path for a test resource.
-    :param filtered_by_confidence: Whether to get the table filtered by confidence level.
-        Options:
-        - None: Default, retrieves the standard table.
-        - "all": Retrieves the table with all confidence levels filtered.
-        - "high": Retrieves the table with only high-confidence variants.
     :return: VersionedTableResource of trio de novo Table.
     """
     data_type = "exomes"
-
-    confidence_suffix = ""
-    if filtered_by_confidence == "all":
-        confidence_suffix = ".all_confidence.filtered"
-    elif filtered_by_confidence == "high":
-        confidence_suffix = ".high_confidence.filtered"
-
     return VersionedTableResource(
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: TableResource(
                 f"{get_sample_qc_root(version, test, data_type='exomes')}"
                 f"/relatedness/trios/gnomad.{data_type}.v{version}.trios"
-                f"{'.releasable' if releasable else ''}.denovo{confidence_suffix}.ht"
+                f"{'.releasable' if releasable else ''}.denovo.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },

--- a/gnomad_qc/v4/sample_qc/identify_trios.py
+++ b/gnomad_qc/v4/sample_qc/identify_trios.py
@@ -420,6 +420,8 @@ def create_dense_trio_mt(
     meta_ht = filter_to_trios(meta_ht, fam_ht)
 
     # Get the gnomAD VDS filtered to high quality releasable trios.
+    # Using 'entries_to_keep' to keep all entries that are not `gvcf_info` because it
+    # is likely not needed, and removal will reduce the size of the dense MatrixTable.
     vds = get_gnomad_v4_vds(
         high_quality_only=True,
         chrom="chr20" if test else None,

--- a/gnomad_qc/v4/sample_qc/identify_trios.py
+++ b/gnomad_qc/v4/sample_qc/identify_trios.py
@@ -420,8 +420,6 @@ def create_dense_trio_mt(
     meta_ht = filter_to_trios(meta_ht, fam_ht)
 
     # Get the gnomAD VDS filtered to high quality releasable trios.
-    # Using 'entries_to_keep' to keep all entries that are not `gvcf_info` because it
-    # is likely not needed, and removal will reduce the size of the dense MatrixTable.
     vds = get_gnomad_v4_vds(
         high_quality_only=True,
         chrom="chr20" if test else None,


### PR DESCRIPTION
This cleaned up some redundant dense mt functions and arguments since we had PR #651. Julia created the dense MT in job [0a3e98e75ba14b2f8341012515d11f8b](https://console.cloud.google.com/dataproc/jobs/0a3e98e75ba14b2f8341012515d11f8b?region=us-central1&inv=1&invt=AboKJg&project=broad-mpg-gnomad) before the PR was merged. 

This is waiting on [PR #760](https://github.com/broadinstitute/gnomad_methods/pull/760) in gnomad_methods. 

Test run on chr20: [b0729d42ea77466c8cc1fe9697e73af1](https://console.cloud.google.com/dataproc/jobs/b0729d42ea77466c8cc1fe9697e73af1?region=us-central1&project=broad-mpg-gnomad)