### PR TITLE
Remove loci with >100 alt alleles from vds sample QC

### DIFF
--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -351,22 +351,19 @@ def add_project_prefix_to_sample_collisions(
 
     if is_matrix:
         t = t.key_cols_by()
-        sample_id_expr = hl.if_else(
-            collision_ids.contains(t[sample_id_field]),
-            hl.delimit([prefix_expr, t[sample_id_field]], "_"),
-            t[sample_id_field],
-        )
-
-        t = t.annotate_cols(**{sample_id_field: sample_id_expr})
-        # We don't rekey the MatrixTable here because it will slow down the run
     else:
         t = t.key_by()
-        sample_id_expr = hl.if_else(
-            collision_ids.contains(t[sample_id_field]),
-            hl.delimit([prefix_expr, t[sample_id_field]], "_"),
-            t[sample_id_field],
-        )
 
+    sample_id_expr = hl.if_else(
+        collision_ids.contains(t[sample_id_field]),
+        hl.delimit([prefix_expr, t[sample_id_field]], "_"),
+        t[sample_id_field],
+    )
+
+    if is_matrix:
+        t = t.annotate_cols(**{sample_id_field: sample_id_expr})
+        t = t.key_cols_by(sample_id_field)
+    else:
         t = t.annotate(**{sample_id_field: sample_id_expr})
         t = t.key_by(sample_id_field)
 

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -357,10 +357,12 @@ def add_project_prefix_to_sample_collisions(
     )
 
     if is_matrix:
+        t = t.key_cols_by()
         t = t.annotate_cols(**{sample_id_field: sample_id_expr})
-        t = t.key_cols_by(**{sample_id_field: t[sample_id_field]})
+        # We don't re-key the MatrixTable here because it will slow down the process
     else:
+        t = t.key_by()
         t = t.annotate(**{sample_id_field: sample_id_expr})
-        t = t.key_by(**{sample_id_field: t[sample_id_field]})
+        t = t.key_by(sample_id_field)
 
     return t

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -187,8 +187,8 @@ def get_aou_vds(
     n_samples_after = vds.variant_data.count_cols()
     logger.info("Removed %d samples from VDS.", n_samples_before - n_samples_after)
 
-    # Remove the chr4 site with excessive numbers of alleles (n=22233) which
-    # might cause memory issue later on
+    # Remove the chr4 site with excessive numbers of alleles (n=22233) to
+    # avoid memory issues with `split_multi`.
     logger.info("Dropping excessively multi-allelic site at chr4:12237652...")
     vds = hl.vds.filter_intervals(
         vds,

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -357,12 +357,10 @@ def add_project_prefix_to_sample_collisions(
     )
 
     if is_matrix:
-        t = t.key_cols_by()
         t = t.annotate_cols(**{sample_id_field: sample_id_expr})
-        t = t.key_cols_by(sample_id_field)
+        t = t.key_cols_by(**{sample_id_field: t[sample_id_field]})
     else:
-        t = t.key_by()
         t = t.annotate(**{sample_id_field: sample_id_expr})
-        t = t.key_by(sample_id_field)
+        t = t.key_by(**{sample_id_field: t[sample_id_field]})
 
     return t

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -187,6 +187,15 @@ def get_aou_vds(
     n_samples_after = vds.variant_data.count_cols()
     logger.info("Removed %d samples from VDS.", n_samples_before - n_samples_after)
 
+    # Remove the chr4 site with excessive numbers of alleles (n=22233) which
+    # might cause memory issue later on
+    logger.info("Dropping excessively multi-allelic site at chr4:12237652...")
+    vds = hl.vds.filter_intervals(
+        vds,
+        [hl.parse_locus_interval("chr4:12237652-12237653", reference_genome="GRCh38")],
+        keep=False,
+    )
+
     if filter_samples:
         logger.info(
             "Filtering to %s samples...",

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -317,7 +317,7 @@ def add_project_prefix_to_sample_collisions(
     sample_collisions: hl.Table,
     project: Optional[str] = None,
     sample_id_field: str = "s",
-) -> hl.Table:
+) -> Union[hl.Table, hl.MatrixTable]:
     """
     Add project prefix to sample IDs that exist in multiple projects.
 
@@ -325,7 +325,7 @@ def add_project_prefix_to_sample_collisions(
     :param sample_collisions: Table of sample IDs that exist in multiple projects.
     :param project: Optional project name to prepend to sample collisions. If not set, will use 'ht.project' annotation. Default is None.
     :param sample_id_field: Field name for sample IDs in the table.
-    :return: Table with project prefix added to sample IDs.
+    :return: Table or MatrixTable with project prefix added to sample IDs.
     """
     logger.info(
         "Adding project prefix to sample IDs that exists in multiple projects..."

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -349,19 +349,24 @@ def add_project_prefix_to_sample_collisions(
                 "No project provided and 'project' field not found in the input table or MatrixTable columns."
             )
 
-    # Build new sample ID expression
-    sample_id_expr = hl.if_else(
-        collision_ids.contains(t[sample_id_field]),
-        hl.delimit([prefix_expr, t[sample_id_field]], "_"),
-        t[sample_id_field],
-    )
-
     if is_matrix:
         t = t.key_cols_by()
+        sample_id_expr = hl.if_else(
+            collision_ids.contains(t[sample_id_field]),
+            hl.delimit([prefix_expr, t[sample_id_field]], "_"),
+            t[sample_id_field],
+        )
+
         t = t.annotate_cols(**{sample_id_field: sample_id_expr})
-        # We don't re-key the MatrixTable here because it will slow down the process
+        # We don't rekey the MatrixTable here because it will slow down the run
     else:
         t = t.key_by()
+        sample_id_expr = hl.if_else(
+            collision_ids.contains(t[sample_id_field]),
+            hl.delimit([prefix_expr, t[sample_id_field]], "_"),
+            t[sample_id_field],
+        )
+
         t = t.annotate(**{sample_id_field: sample_id_expr})
         t = t.key_by(sample_id_field)
 

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -56,6 +56,10 @@ def get_sample_qc(
         full VDS.
     :return: Sample QC table.
     """
+    # NOTE: The sample QC tables currently do not have the `aou` prefix added to sample IDs
+    # that collide with gnomAD samples. This renaming step must be applied before merging
+    # with the metadata, using the `add_project_prefix_to_sample_collisions` function from
+    # `gnomad_qc.v5.resources.basics`.
     return VersionedTableResource(
         CURRENT_AOU_VERSION,
         {

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -106,6 +106,8 @@ def main(args):
         ht = add_project_prefix_to_sample_collisions(
             ht, project="aou", sample_collisions=sample_id_collisions.ht()
         )
+        # Note: The prefix "aou" is only added to the 'all' Table, but not to the
+        # 'bi_allelic' or 'multi_allelic' Tables.
         ht.write(get_sample_qc(test=test).path, overwrite=overwrite)
 
 

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -66,14 +66,14 @@ def compute_aou_sample_qc(
 
     if test:
         logger.info(
-            "Rows before filtering loci with >100 alt alleles: %s", vmt.count_rows()
+            "Rows before filtering loci with >100 alt alleles: %s...", vmt.count_rows()
         )
 
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)
 
     if test:
         logger.info(
-            "Rows after filtering loci with >100 alt alleles: %s", vmt.count_rows()
+            "Rows after filtering loci with >100 alt alleles: %s...", vmt.count_rows()
         )
 
     logger.info("Computing sample QC metrics...")

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -40,7 +40,10 @@ def compute_aou_sample_qc(
     :return: Table containing sample QC metrics
     """
     if test:
-        logger.info("Filtering to first interval that contains n_alt_alleles > 100...")
+        logger.info(
+            "Loading test VDS using a small interval that includes loci with >100 alternate alleles..."
+        )
+        # This interval contains two loci with >100 alt alleles.
         vds = get_aou_vds(filter_intervals=["chr1:10440-10626"], split=True)
     else:
         logger.info("Loading AoU VDS...")
@@ -111,7 +114,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--overwrite",
-        help="Overwrite all Matrixtables/Tables. (default: False).",
+        help="Overwrite all Matrix Tables/Tables. (default: False).",
         action="store_true",
     )
     parser.add_argument(

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -62,10 +62,16 @@ def compute_aou_sample_qc(
     vmt = vds.variant_data
 
     if test:
-        logger.info("Number of rows before filtering: %s", vmt.count_rows())
+        logger.info(
+            "Rows before filtering loci with >100 alt alleles: %s", vmt.count_rows()
+        )
+
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)
+
     if test:
-        logger.info("Number of rows after filtering: %s", vmt.count_rows())
+        logger.info(
+            "Rows after filtering loci with >100 alt alleles: %s", vmt.count_rows()
+        )
 
     logger.info("Computing sample QC metrics...")
     sample_qc_ht = compute_stratified_sample_qc(

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -67,8 +67,8 @@ def compute_aou_sample_qc(
     sample_qc_ht = compute_stratified_sample_qc(
         vmt,  # It also takes MT as input
         strata={
-            "bi_allelic": bi_allelic_expr(vds.variant_data),
-            "multi_allelic": ~bi_allelic_expr(vds.variant_data),
+            "bi_allelic": bi_allelic_expr(vmt),
+            "multi_allelic": ~bi_allelic_expr(vmt),
         },
         tmp_ht_prefix=get_sample_qc(test=test).path[:-3],
         gt_col="GT",

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -72,17 +72,9 @@ def compute_aou_sample_qc(
 
     logger.info("Splitting multi-allelic variants...")
     vmt = hl.experimental.sparse_split_multi(vmt, filter_changed_loci=True)
-
-    vmt = add_project_prefix_to_sample_collisions(
-        vmt,
-        project="aou",
-        sample_collisions=sample_id_collisions.ht(),
-    )
-
     vds = hl.vds.VariantDataset(vds.reference_data, vmt)
 
     logger.info("Computing sample QC metrics...")
-    # This step will also checkpoint the stratified sample QC tables
     sample_qc_ht = compute_stratified_sample_qc(
         vds,
         strata={

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -63,8 +63,9 @@ def compute_aou_sample_qc(
     logger.info("Excluding loci with more than 100 alternative alleles...")
     # NOTE: Filtering loci with >100 alleles has no effect on the test dataset,
     # since it contains no such loci. However, this filtering is still necessary
-    # on the full dataset, as the number of alleles can change after removing
-    # samples from the raw VDS.
+    # on the full dataset because the number of alleles can change after removing
+    # samples from the raw VDS. As a result, it may not always match the 'EXCESS_ALLELES'
+    # flag in the 'filters' field of the raw VDS.
     vmt = vds.variant_data
     vmt = vmt.annotate_rows(n_unsplit_alleles=hl.len(vmt.alleles))
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -62,11 +62,10 @@ def compute_aou_sample_qc(
     logger.info("Excluding loci with more than 100 alternative alleles...")
     vmt = vds.variant_data
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)
-    vds = hl.vds.VariantDataset(vds.reference_data, vmt)
 
     logger.info("Computing sample QC metrics...")
     sample_qc_ht = compute_stratified_sample_qc(
-        vds,
+        vmt,  # It also takes MT as input
         strata={
             "bi_allelic": bi_allelic_expr(vds.variant_data),
             "multi_allelic": ~bi_allelic_expr(vds.variant_data),

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -61,6 +61,9 @@ def compute_aou_sample_qc(
     )
 
     logger.info("Excluding loci with more than 100 alternative alleles...")
+    # NOTE: Running on the test dataset, filtering or not wouldn't change the result because it won't have any loci
+    # with >100 alleles anyway, but this has been verified the number of alleles would change after some samples from
+    # the raw VDS.
     vmt = vds.variant_data
     vmt = vmt.annotate_rows(n_unsplit_alleles=hl.len(vmt.alleles))
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -93,7 +93,7 @@ def rename_sample_collisions_in_outputs(
     :param test: If True, use the AoU test dataset instead of the full dataset.
     :param project: Project name to use for renaming sample collisions.
     """
-    ht_prefix = get_sample_qc(test=test).path
+    ht_prefix = get_sample_qc(test=test).path[:-3]
 
     for strat in ["bi_allelic", "multi_allelic"]:
         path = f"{ht_prefix}_{strat}.ht"

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -39,16 +39,16 @@ def compute_aou_sample_qc(
     :param test: If true, test the function on a smaller subset of the data.
     :return: Table containing sample QC metrics
     """
-    logger.info("Loading test VDS..." if test else "Loading VDS...")
-
     if test:
         n_partitions = n_partitions // 100
-
-    vds = get_aou_vds(
-        test=test,
-        autosomes_only=True,
-        split=True,
-    )
+        logger.info("Filtering to first interval that contains n_alt_alleles > 100...")
+        vds = get_aou_vds(filter_intervals=["chr1:10440-10626"], split=True)
+    else:
+        logger.info("Loading AoU VDS...")
+        vds = get_aou_vds(
+            autosomes_only=True,
+            split=True,
+        )
 
     logger.info(
         "Excluding telomeres and centromeres from VDS (redundant but acts as a safety check)..."

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -8,12 +8,8 @@ from gnomad.resources.grch38.reference_data import telomeres_and_centromeres
 from gnomad.sample_qc.filtering import compute_stratified_sample_qc
 from gnomad.utils.annotations import bi_allelic_expr
 
-from gnomad_qc.v5.resources.basics import (
-    add_project_prefix_to_sample_collisions,
-    get_aou_vds,
-)
+from gnomad_qc.v5.resources.basics import get_aou_vds
 from gnomad_qc.v5.resources.constants import WORKSPACE_BUCKET
-from gnomad_qc.v5.resources.meta import sample_id_collisions
 from gnomad_qc.v5.resources.sample_qc import get_sample_qc
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
@@ -28,7 +24,7 @@ def compute_aou_sample_qc(
     """
     Perform sample QC on AoU VDS.
 
-    ..note::
+    .. note::
 
         We are not including the `n_alt_alleles_strata` parameter in this function—as we did for v4 exomes—
         because the distribution of alternate alleles in whole genome sequencing data is not as skewed as in exomes.
@@ -64,8 +60,10 @@ def compute_aou_sample_qc(
     # NOTE: Filtering loci with >100 alleles has no effect on the test dataset,
     # since it contains no such loci. However, this filtering is still necessary
     # on the full dataset because the number of alleles can change after removing
-    # samples from the raw VDS. As a result, it may not always match the 'EXCESS_ALLELES'
-    # flag in the 'filters' field of the raw VDS.
+    # samples from the raw VDS. As a result, it may not always match the ``EXCESS_ALLELES`` flag
+    # in the ``filters`` field of the raw VDS. (AoU v8 defined this as a site with >100 alternate alleles
+    # in their quality report: `All of Us Genomic Quality Report
+    # <https://support.researchallofus.org/hc/en-us/articles/29390274413716-All-of-Us-Genomic-Quality-Report>`_)
     vmt = vds.variant_data
     vmt = vmt.annotate_rows(n_unsplit_alleles=hl.len(vmt.alleles))
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -39,7 +39,6 @@ def compute_aou_sample_qc(
     :param test: If true, test the function on a smaller subset of the data.
     :return: Table containing sample QC metrics
     """
-    logger.info("Computing sample QC")
     logger.info("Loading test VDS..." if test else "Loading VDS...")
 
     if test:
@@ -65,6 +64,7 @@ def compute_aou_sample_qc(
     vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)
     vds = hl.vds.VariantDataset(vds.reference_data, vmt)
 
+    logger.info("Computing sample QC metrics...")
     sample_qc_ht = compute_stratified_sample_qc(
         vds,
         strata={

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -81,7 +81,7 @@ def compute_aou_sample_qc(
 
 def main(args):
     """Determine samples that fail hard filtering thresholds."""
-    hl.init(log="/hard_filters.log", tmp_dir=f"{WORKSPACE_BUCKET}/tmp/4_day")
+    hl.init(tmp_dir=f"{WORKSPACE_BUCKET}/tmp/4_day")
     hl.default_reference("GRCh38")
 
     test = args.test

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -62,8 +62,7 @@ def compute_aou_sample_qc(
 
     logger.info("Excluding loci with more than 100 alternative alleles...")
     vmt = vds.variant_data
-    vmt = vmt.annotate_rows(n_alleles=hl.len(vmt.alleles))
-    vmt = vmt.filter_rows(vmt.n_alleles < 101)
+    vmt = vmt.filter_rows(vmt.n_unsplit_alleles < 101)
     vds = hl.vds.VariantDataset(vds.reference_data, vmt)
 
     sample_qc_ht = compute_stratified_sample_qc(

--- a/gnomad_qc/v5/sample_qc/hard_filters.py
+++ b/gnomad_qc/v5/sample_qc/hard_filters.py
@@ -107,7 +107,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--overwrite",
-        help="Overwrite all Matrix Tables/Tables. (default: False).",
+        help="Overwrite all MatrixTables/Tables. (default: False).",
         action="store_true",
     )
     parser.add_argument(


### PR DESCRIPTION
This PR makes two main changes to improve test coverage and performance for `compute_sample_qc`:
1. Excludes a locus with extreme allele count from loading to avoid memory or runtime issues.
2. Updates test mode logic in `compute_sample_qc` to load a small genomic interval known to contain 2 loci with >100 alt alleles. This enables:
   - Verifying correct behavior using `count_rows()`.
   - Switching from loading all loci for 10 samples → to loading a small interval for all samples (excluding pre-filtered ones), which:
     - Preserves correct sample count filtering.
     - Reduces runtime in test mode (now it takes ~14 mins).
    
Test run in this [notebook](https://workbench.researchallofus.org/workspaces/aou-rw-4b0bd63f/gnomadproduction/analysis/preview/hard_filter_02_vds_sample_qc.ipynb). 
     
BTW, I tried to load first partitions or filter_partitions, they all seemed to be slow, I really prefer `hl.vds.filter_intervals()`