### PR TITLE
Drops deprecated reviewers from dependabot config and adds CODEOWNERs for automatic review assignment 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   broadinstitute/gnomad-production

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   broadinstitute/gnomad-production
+*   @broadinstitute/gnomad-production

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,8 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 0
-    reviewers:
-      - 'broadinstitute/gnomad-production'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 0
-    reviewers:
-      - 'broadinstitute/gnomad-production'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 #  - Disables non-security update PRs (by setting pull requests limit to 0)
 #  - Schedules security update PRs weekly
-#  - Auto assigns PRs to the gnomAD production team
 
 version: 2
 updates:


### PR DESCRIPTION
Github now has a [CODEOWNERs file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) which we'll use to replace dependabot automatic assignment. 