### PR TITLE
Lazy import v3 for v4s get vds function to prevent unwanted logger 

### DIFF
--- a/gnomad_qc/v4/resources/basics.py
+++ b/gnomad_qc/v4/resources/basics.py
@@ -12,7 +12,6 @@ from gnomad.resources.resource_utils import (
 )
 from hail.utils import new_temp_file
 
-import gnomad_qc.v3.resources.basics as v3_basics
 from gnomad_qc.v4.resources.constants import (
     CURRENT_RAW_VERSION,
     CURRENT_SAMPLE_QC_VERSION,
@@ -445,6 +444,8 @@ def get_gnomad_v4_genomes_vds(
     :param filter_samples_ht: Optional Table of samples to filter the VDS to.
     :return: gnomAD v4 genomes VariantDataset with chosen annotations and filters.
     """
+    import gnomad_qc.v3.resources.basics as v3_basics
+
     vds = v3_basics.get_gnomad_v3_vds(
         split=split,
         remove_hard_filtered_samples=remove_hard_filtered_samples,


### PR DESCRIPTION
The new warning regarding files moving into archive and a function updating to autoclass was surfacing through a series of imports between v5 basic resources -> v4 basic resources ->v3 basic resources.  This moves the call to v3 into the function that uses it as to not trigger the warning every time the module is accessed. 