### PR TITLE
Mw/final relatedness ht

### DIFF
--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -191,3 +191,39 @@ def relatedness(test: bool = False, raw: bool = False) -> VersionedTableResource
             for version in SAMPLE_QC_VERSIONS
         },
     )
+
+
+def related_samples_to_drop(test: bool = False) -> VersionedTableResource:
+    """
+    Get the VersionedTableResource for samples to drop for ancestry PCA.
+
+    :param test: Whether to use a tmp path for a test resource.
+    :return: VersionedTableResource.
+    """
+    return VersionedTableResource(
+        CURRENT_SAMPLE_QC_VERSION,
+        {
+            version: TableResource(
+                f"{get_sample_qc_root(version, test, data_type='joint')}/relatedness/gnomad.joint.v{version}.related_samples_to_drop.pca.ht"
+            )
+            for version in SAMPLE_QC_VERSIONS
+        },
+    )
+
+
+def sample_rankings(test: bool = False) -> VersionedTableResource:
+    """
+    Get the VersionedTableResource for sample rankings for ancestry PCA.
+
+    :param test: Whether to use a tmp path for a test resource.
+    :return: VersionedTableResource.
+    """
+    return VersionedTableResource(
+        CURRENT_SAMPLE_QC_VERSION,
+        {
+            version: TableResource(
+                f"{get_sample_qc_root(version, test, data_type='joint')}/relatedness/gnomad.joint.v{version}.samples_ranking.pca.ht"
+            )
+            for version in SAMPLE_QC_VERSIONS
+        },
+    )

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -346,7 +346,7 @@ def main(args):
                 "second_degree_min_kin": second_degree_min_kin,
             }
             finalize_relatedness_ht(
-                relatedness(test=test, raw=True).ht(), joint_meta, relatedness_args
+                relatedness(test=test).ht(), joint_meta, relatedness_args
             ).write(relatedness(test=test).path, overwrite=overwrite)
 
         if args.compute_related_samples_to_drop:

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -13,7 +13,7 @@ from gnomad.sample_qc.relatedness import (
 )
 from hail.utils.misc import new_temp_file
 
-from gnomad_qc.resource_utils import check_resource_existence
+# from gnomad_qc.resource_utils import check_resource_existence
 from gnomad_qc.v5.resources.basics import get_logging_path
 from gnomad_qc.v5.resources.constants import WORKSPACE_BUCKET
 from gnomad_qc.v5.resources.meta import project_meta

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -283,7 +283,7 @@ def main(args):
     hl.default_reference("GRCh38")
 
     joint_meta = project_meta.ht()
-    joint_qc_mt = get_joint_qc(test=test).mt()
+    joint_qc_mt = get_joint_qc().mt()
 
     if test:
         logger.info("Filtering MT to the first 2 partitions for testing...")

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -13,7 +13,7 @@ from gnomad.sample_qc.relatedness import (
 )
 from hail.utils.misc import new_temp_file
 
-# from gnomad_qc.resource_utils import check_resource_existence
+from gnomad_qc.resource_utils import check_resource_existence
 from gnomad_qc.v5.resources.basics import get_logging_path
 from gnomad_qc.v5.resources.constants import WORKSPACE_BUCKET
 from gnomad_qc.v5.resources.meta import project_meta
@@ -265,7 +265,6 @@ def main(args):
     overwrite = args.overwrite
     min_emission_kinship = args.min_emission_kinship
     second_degree_min_kin = args.second_degree_min_kin
-    joint_meta = project_meta.ht()
 
     if args.print_cuking_command:
         print_cuking_command(
@@ -281,6 +280,7 @@ def main(args):
         tmp_dir=f"gs://{WORKSPACE_BUCKET}/tmp/4_day",
     )
     hl.default_reference("GRCh38")
+    joint_meta = project_meta.ht()
 
     try:
         if args.prepare_cuking_inputs:
@@ -322,6 +322,7 @@ def main(args):
             ht.write(relatedness(test=test, raw=True).path, overwrite=overwrite)
 
         if args.finalize_relatedness_ht:
+            logger.info("Finalizing relatedness HT...")
             check_resource_existence(
                 output_step_resources={
                     "final_relatedness_ht": relatedness(test=test).path
@@ -349,6 +350,7 @@ def main(args):
             ).write(relatedness(test=test).path, overwrite=overwrite)
 
         if args.compute_related_samples_to_drop:
+            logger.info("Computing the sample rankings andrelated samples to drop...")
             check_resource_existence(
                 output_resources={
                     "sample_rankings_ht": sample_rankings(test=test),

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -346,7 +346,7 @@ def main(args):
                 "second_degree_min_kin": second_degree_min_kin,
             }
             finalize_relatedness_ht(
-                relatedness(test=test).ht(), joint_meta, relatedness_args
+                relatedness(test=test, raw=True).ht(), joint_meta, relatedness_args
             ).write(relatedness(test=test).path, overwrite=overwrite)
 
         if args.compute_related_samples_to_drop:

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -354,8 +354,10 @@ def main(args):
             logger.info("Computing the sample rankings and related samples to drop...")
             check_resource_existence(
                 output_step_resources={
-                    "sample_rankings_ht": sample_rankings(test=test),
-                    "related_samples_to_drop_ht": related_samples_to_drop(test=test),
+                    "sample_rankings_ht": sample_rankings(test=test).path,
+                    "related_samples_to_drop_ht": related_samples_to_drop(
+                        test=test
+                    ).path,
                 }
             )
             rank_ht, drop_ht = run_compute_related_samples_to_drop(

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -204,8 +204,8 @@ def compute_rank_ht(ht: hl.Table) -> hl.Table:
     """
     ht = ht.select(
         "mean_depth",
-        is_genome=hl.is_defined(ht.data_type) & ht.data_type == "genomes",
-        in_aou=hl.is_defined(ht.project) & ht.project == "aou",
+        is_genome=hl.is_defined(ht.data_type) & (ht.data_type == "genomes"),
+        in_aou=hl.is_defined(ht.project) & (ht.project == "aou"),
         in_v4_release=hl.is_defined(ht.release) & ht.release,
     )
     rank_order = []

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -263,7 +263,6 @@ def main(args):
     """Compute relatedness estimates among pairs of samples in the callset."""
     test = args.test
     overwrite = args.overwrite
-    release = args.release
     min_emission_kinship = args.min_emission_kinship
     second_degree_min_kin = args.second_degree_min_kin
     joint_meta = project_meta.ht()

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -451,6 +451,11 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         "Arguments for finalizing the relatedness table with relationship annotation.",
     )
     finalize_args.add_argument(
+        "--finalize-relatedness-ht",
+        help="Finalize the relatedness HT by adding relationship annotations.",
+        action="store_true",
+    )
+    finalize_args.add_argument(
         "--parent-child-max-ibs0-over-ibs2",
         help="Maximum value of IBS0/IBS2 for a parent-child pair.",
         default=5.2e-5,
@@ -491,6 +496,19 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         help="Minimum kinship threshold for filtering a pair of samples with a second degree relationship when filtering related individuals.",
         default=0.08838835,
         type=float,
+    )
+    drop_related_samples = parser.add_argument_group(
+        "Compute related samples to drop",
+        "Arguments used to determine related samples that should be dropped from "
+        "the ancestry PCA or release.",
+    )
+    drop_related_samples.add_argument(
+        "--compute-related-samples-to-drop",
+        help=(
+            "Determine the minimal set of related samples to prune for ancestry PCA or "
+            "release if '--release' is used."
+        ),
+        action="store_true",
     )
     return parser
 

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -281,8 +281,13 @@ def main(args):
         tmp_dir=f"gs://{WORKSPACE_BUCKET}/tmp/4_day",
     )
     hl.default_reference("GRCh38")
+
     joint_meta = project_meta.ht()
     joint_qc_mt = get_joint_qc(test=test).mt()
+
+    if test:
+        logger.info("Filtering MT to the first 2 partitions for testing...")
+        joint_qc_mt = joint_qc_mt._filter_partitions(range(2))
 
     try:
         if args.prepare_cuking_inputs:
@@ -302,10 +307,6 @@ def main(args):
                 "Converting joint dense QC MatrixTable to a Parquet format suitable "
                 "for cuKING..."
             )
-            if test:
-                logger.info("Filtering MT to the first 2 partitions for testing...")
-                joint_qc_mt = joint_qc_mt._filter_partitions(range(2))
-
             mt_to_cuking_inputs(
                 mt=joint_qc_mt,
                 parquet_uri=get_cuking_input_path(test=test),

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -282,6 +282,7 @@ def main(args):
     )
     hl.default_reference("GRCh38")
     joint_meta = project_meta.ht()
+    joint_qc_mt = get_joint_qc(test=test).mt()
 
     try:
         if args.prepare_cuking_inputs:
@@ -294,7 +295,6 @@ def main(args):
             # We also cannot run `mt_to_cuking_inputs.py` directly because
             # Hail needs to be initialized with a temporary directory
             # to avoid memory errors.
-            joint_qc_mt = get_joint_qc(test=test).mt()
             check_resource_existence(
                 output_step_resources={"cuking_input_parquet": get_cuking_input_path()}
             )

--- a/gnomad_qc/v5/sample_qc/relatedness.py
+++ b/gnomad_qc/v5/sample_qc/relatedness.py
@@ -160,12 +160,13 @@ def finalize_relatedness_ht(
     parent_child_max_ann = "parent_child_max_ibs0_over_ibs2"
 
     ht = ht.annotate(
+        ibs0_2=ht.ibs0 / ht.ibs2,
         relationship=get_slope_int_relationship_expr(
             kin_expr=ht.kin,
             y_expr=y_expr,
             **relatedness_args,
             ibd1_expr=ibd1_expr,
-        )
+        ),
     )
     relatedness_args[parent_child_max_ann] = relatedness_args.pop("parent_child_max_y")
     ht = ht.annotate_globals(
@@ -350,9 +351,9 @@ def main(args):
             ).write(relatedness(test=test).path, overwrite=overwrite)
 
         if args.compute_related_samples_to_drop:
-            logger.info("Computing the sample rankings andrelated samples to drop...")
+            logger.info("Computing the sample rankings and related samples to drop...")
             check_resource_existence(
-                output_resources={
+                output_step_resources={
                     "sample_rankings_ht": sample_rankings(test=test),
                     "related_samples_to_drop_ht": related_samples_to_drop(test=test),
                 }
@@ -505,10 +506,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     )
     drop_related_samples.add_argument(
         "--compute-related-samples-to-drop",
-        help=(
-            "Determine the minimal set of related samples to prune for ancestry PCA or "
-            "release if '--release' is used."
-        ),
+        help="Determine the minimal set of related samples to prune for ancestry PCA.",
         action="store_true",
     )
     return parser


### PR DESCRIPTION
Here is the code for the final relatednes sHT, the rank HT, and the sample to drop HT. The associated notebooks are https://workbench.researchallofus.org/workspaces/aou-rw-4b0bd63f/gnomadproduction/analysis/relatedness_06_create_v5_annotated_relatedness_ht.ipynb and https://workbench.researchallofus.org/workspaces/aou-rw-4b0bd63f/gnomadproduction/analysis/relatedness_07_create_v5_rank_and_samples_to_drop_hts.ipynb.

 The samples to drop number is lower than I expected, v5 has 56kish vs v4 which had 126kish. v4 forced the max independent set to keep v3 samples --- but I havent yet thought through what the implications are here or if something else is going on. We also dropped releasable from the rank order since we figured we wouldnt need it after "in_aou" and "in_v4_release" but I'm not sure about this now. Im submitting this for review now as I have to step out the rest of the day and tomorrow. Happy to revisit Wednesday if you want to wait on review but I figured the code itself runs and  most seems reasonable -- especially the final relatedness HT. If you want to wait on rank and samples to drop, thats fine but figured I'd give you the option. 