### PR TITLE
Drop ukb and subset callstat support from subset requests

### DIFF
--- a/gnomad_qc/v4/subset.py
+++ b/gnomad_qc/v4/subset.py
@@ -237,7 +237,6 @@ def main(args):
     if args.export_meta:
         logger.info("Exporting metadata")
         meta_ht = meta_ht.semi_join(vds.variant_data.cols())
-        # TODO: Dropping the whole ukb_meta struct, but should we keep pop and sex inference if allowed? # noqa
         if args.keep_data_paths:
             data_to_drop = {"ukb_meta"}
         else:


### PR DESCRIPTION
We no longer offer these as ukb inclusion can be incredibly costly and subset callstats are easy enough for requesters to do themselves. This cleans this script up. 