### PR TITLE
Add markdown to direct dependency list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# We're using the master of gnomad_method on github rather than the pip version
+# We're using the main of gnomad_method on github rather than the pip version
 # since gnomad_qc and gnonmad_method are being developed in tandem.
 git+https://github.com/broadinstitute/gnomad_methods@main
 networkx
@@ -7,3 +7,4 @@ scipy
 hail
 papermill
 bs4
+markdown


### PR DESCRIPTION
We previously used an indirect dependency through the ga4gh package. The ga4gh removed the markdown dependency when moving from 0.8.4 to 2.0.1 so we need to install it ourselves.  This causes the git action in gnomad_methods to fail: https://github.com/broadinstitute/gnomad_methods/actions/runs/17776527117/job/50525507592?pr=797. 