### PR TITLE
Add VEP 115 as an option for the VEP context script

### DIFF
--- a/gnomad_qc/v4/annotations/vep_context_ht.py
+++ b/gnomad_qc/v4/annotations/vep_context_ht.py
@@ -78,7 +78,6 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--vep-version",
         help="Version of VEP the context Table is being annotated with.",
-        action="store_true",
         default="105",
         choices=["105", "115"],
     )

--- a/gnomad_qc/v4/annotations/vep_context_ht.py
+++ b/gnomad_qc/v4/annotations/vep_context_ht.py
@@ -80,6 +80,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         help="Version of VEP the context Table is being annotated with.",
         action="store_true",
         default="105",
+        choices=["105", "115"],
     )
     parser.add_argument(
         "--test", help="Runs a test on two partitions of the MT.", action="store_true"


### PR DESCRIPTION
Test run:
```
hailctl dataproc submit vep-115-no-ancestral gnomad_qc/gnomad_qc/v4/annotations/vep_context_ht.py \
    --vep-version 115 \
    --test \
    --pyfiles gnomad_qc/gnomad_qc,gnomad_methods/gnomad \
    --project broad-mpg-gnomad
```

Job: [aa540a8ff2cc484ea98f5f8edf11a925](https://console.cloud.google.com/dataproc/jobs/aa540a8ff2cc484ea98f5f8edf11a925/monitoring?region=us-central1&project=broad-mpg-gnomad)