### PR TITLE
Update sample_qc_root for Batch

### DIFF
--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -38,7 +38,8 @@ def get_sample_qc_root(
     :param data_set: Dataset identifier (e.g., "aou", "hgdp_tgp").
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
-    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is True.
+    :param read_only: Whether to use the read-only AoU batch bucket. Ignored unless
+        environment is "batch". Default is True.
     :return: GCS path to the sample QC directory.
     """
     _validate_environment(environment, _SAMPLE_DATA_ENVIRONMENTS)
@@ -49,7 +50,10 @@ def get_sample_qc_root(
             f"{qc_temp_prefix(version=version, environment=environment)}{path_suffix}"
         )
 
-    return f"gs://{_get_base_bucket(environment, read_only=read_only)}/v{version}/{path_suffix}"
+    ro = read_only if environment == "batch" else False
+    return (
+        f"gs://{_get_base_bucket(environment, read_only=ro)}/v{version}/{path_suffix}"
+    )
 
 
 ######################################################################

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -27,6 +27,7 @@ def get_sample_qc_root(
     data_type: str = "genomes",
     data_set: str = "aou",
     environment: str = "batch",
+    read_only: bool = True,
 ) -> str:
     """
     Return the root GCS path to sample QC results.
@@ -37,6 +38,7 @@ def get_sample_qc_root(
     :param data_set: Dataset identifier (e.g., "aou", "hgdp_tgp").
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is True.
     :return: GCS path to the sample QC directory.
     """
     _validate_environment(environment, _SAMPLE_DATA_ENVIRONMENTS)
@@ -47,7 +49,7 @@ def get_sample_qc_root(
             f"{qc_temp_prefix(version=version, environment=environment)}{path_suffix}"
         )
 
-    return f"gs://{_get_base_bucket(environment, read_only=True if environment == 'batch' else False)}/v{version}/{path_suffix}"
+    return f"gs://{_get_base_bucket(environment, read_only=read_only)}/v{version}/{path_suffix}"
 
 
 ######################################################################

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -674,12 +674,15 @@ def finalized_outlier_filtering(
 ######################################################################
 
 
-def duplicates(environment: str = "batch") -> VersionedTableResource:
+def duplicates(
+    environment: str = "batch", read_only: bool = False
+) -> VersionedTableResource:
     """
     Get the VersionedTableResource for duplicated (or twin) samples.
 
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is False.
     :return: VersionedTableResource of duplicate samples.
     """
     _validate_environment(environment, _SAMPLE_DATA_ENVIRONMENTS)
@@ -687,7 +690,7 @@ def duplicates(environment: str = "batch") -> VersionedTableResource:
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: TableResource(
-                f"{get_sample_qc_root(version, environment=environment)}/relatedness/trios/aou.genomes.v{version}.duplicates.ht"
+                f"{get_sample_qc_root(version, environment=environment, read_only=read_only)}/relatedness/trios/aou.genomes.v{version}.duplicates.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },
@@ -699,6 +702,7 @@ def pedigree(
     fake: bool = False,
     test: bool = False,
     environment: str = "batch",
+    read_only: bool = False,
 ) -> VersionedPedigreeResource:
     """
     Get the VersionedPedigreeResource for the trio pedigree including multiple trios per family.
@@ -709,6 +713,7 @@ def pedigree(
         for the finalized pedigree, which depends on `ped_mendel_errors`.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is False.
     :return: VersionedPedigreeResource of trio pedigree including multiple trios per
         family.
     """
@@ -724,7 +729,7 @@ def pedigree(
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: PedigreeResource(
-                f"{get_sample_qc_root(version, test, environment=environment)}/relatedness/trios/aou.genomes.v{version}.families{'' if finalized else '.raw'}{'.fake' if fake else ''}.fam",
+                f"{get_sample_qc_root(version, test, environment=environment, read_only=read_only)}/relatedness/trios/aou.genomes.v{version}.families{'' if finalized else '.raw'}{'.fake' if fake else ''}.fam",
                 delimiter="\t",
             )
             for version in SAMPLE_QC_VERSIONS
@@ -733,7 +738,9 @@ def pedigree(
 
 
 def ped_mendel_errors(
-    test: bool = False, environment: str = "batch"
+    test: bool = False,
+    environment: str = "batch",
+    read_only: bool = False,
 ) -> VersionedTableResource:
     """
     Get the VersionedTableResource for the number of mendel errors per trio.
@@ -741,13 +748,14 @@ def ped_mendel_errors(
     :param test: Whether to use a tmp path for a test resource.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is False.
     :return: VersionedTableResource of number of mendel errors per trio.
     """
     return VersionedTableResource(
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: TableResource(
-                f"{get_sample_qc_root(version, test, environment=environment)}/relatedness/trios/aou.genomes.v{version}.mendel_errors.samples.ht"
+                f"{get_sample_qc_root(version, test, environment=environment, read_only=read_only)}/relatedness/trios/aou.genomes.v{version}.mendel_errors.samples.ht"
             )
             for version in SAMPLE_QC_VERSIONS
         },
@@ -758,6 +766,7 @@ def ped_filter_param_json_path(
     version: str = CURRENT_SAMPLE_QC_VERSION,
     test: bool = False,
     environment: str = "batch",
+    read_only: bool = False,
 ):
     """
     Get path to JSON file containing filters used to create the finalized Pedigree and trios resources.
@@ -766,13 +775,17 @@ def ped_filter_param_json_path(
     :param test: Whether to use a tmp path for a test resource.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is False.
     :return: Path to Pedigree filter JSON.
     """
-    return f"{get_sample_qc_root(version, test, environment=environment)}/relatedness/trios/aou.genomes.v{version}.ped_filters.json"
+    return f"{get_sample_qc_root(version, test, environment=environment, read_only=read_only)}/relatedness/trios/aou.genomes.v{version}.ped_filters.json"
 
 
 def trios(
-    fake: bool = False, test: bool = False, environment: str = "batch"
+    fake: bool = False,
+    test: bool = False,
+    environment: str = "batch",
+    read_only: bool = False,
 ) -> VersionedPedigreeResource:
     """
     Get the VersionedPedigreeResource for finalized trio samples.
@@ -782,13 +795,14 @@ def trios(
         for the finalized Pedigree, which depends on `ped_mendel_errors`.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is False.
     :return: VersionedPedigreeResource of trio samples.
     """
     return VersionedPedigreeResource(
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: PedigreeResource(
-                f"{get_sample_qc_root(version, test, environment=environment)}/relatedness/trios/aou.genomes.v{version}.trios{'.fake' if fake else ''}.fam"
+                f"{get_sample_qc_root(version, test, environment=environment, read_only=read_only)}/relatedness/trios/aou.genomes.v{version}.trios{'.fake' if fake else ''}.fam"
             )
             for version in SAMPLE_QC_VERSIONS
         },
@@ -799,6 +813,7 @@ def dense_trios(
     split: bool = False,
     test: bool = False,
     environment: str = "batch",
+    read_only: bool = False,
 ) -> VersionedMatrixTableResource:
     """
     Get the VersionedMatrixTableResource for the dense trio MatrixTable.
@@ -807,13 +822,14 @@ def dense_trios(
     :param test: Whether to use a tmp path for a test resource.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param read_only: Whether to use the read-only bucket. Only applies if environment is "batch". Default is False.
     :return: VersionedMatrixTableResource of dense trio MatrixTable.
     """
     return VersionedMatrixTableResource(
         CURRENT_SAMPLE_QC_VERSION,
         {
             version: MatrixTableResource(
-                f"{get_sample_qc_root(version, test, environment=environment)}"
+                f"{get_sample_qc_root(version, test, environment=environment, read_only=read_only)}"
                 f"/relatedness/trios/aou.genomes.v{version}.trios.dense"
                 f"{'.split' if split else ''}.mt"
             )

--- a/gnomad_qc/v5/sample_qc/assign_ancestry.py
+++ b/gnomad_qc/v5/sample_qc/assign_ancestry.py
@@ -7,12 +7,7 @@ import pickle
 from typing import Any, Dict, List, Optional, Tuple
 
 import hail as hl
-import onnx
-from gnomad.sample_qc.ancestry import (
-    apply_onnx_classification_model,
-    assign_genetic_ancestry_pcs,
-    run_pca_with_relateds,
-)
+from gnomad.sample_qc.ancestry import assign_genetic_ancestry_pcs, run_pca_with_relateds
 from hail.utils.misc import new_temp_file
 
 from gnomad_qc.resource_utils import check_resource_existence
@@ -546,6 +541,17 @@ def project_aou_onto_v4(
     :return: Table of PCA scores of projected AoU samples onto v4 loadings and table of genetic ancestry assignments for projected AoU samples.
     """
     # Load ONNX RF model.
+    try:
+        import onnx  # pylint: disable=import-error
+    except ImportError as e:
+        raise ImportError(
+            "This function requires 'onnx', which is not included in the default gnomad_methods dependencies because"
+            " it conflicts with hailctl's protobuf pin. Install it with:"
+            " pip install onnx"
+        ) from e
+
+    from gnomad.sample_qc.ancestry import apply_onnx_classification_model
+
     with hl.hadoop_open(gnomad_v4_onnx_rf_path, "rb") as f:
         v4_onx_fit = onnx.load(f)
 


### PR DESCRIPTION
We previously set `read_only` to `True` for `get_sample_qc_root` if the environment was batch. However, this means that functions creating the trio resources, which haven't been written yet, were attempting to write to a read-only bucket