### PR TITLE
Split trio stats per chromosome

### DIFF
--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -499,13 +499,9 @@ def main(args):
                 overwrite=overwrite,
             )
 
-            # Trio stats use autosomes only; union the per-chromosome dense trio MTs.
+            # `get_dense_trio_mt` defaults to the autosomes (and chr20 if test is specified).
             ht = run_generate_trio_stats(
-                get_dense_trio_mt(
-                    [f"chr{i}" for i in range(1, 23)],
-                    test=test,
-                    environment=environment,
-                ),
+                get_dense_trio_mt(test=test, environment=environment),
                 pedigree(test=test, environment=environment).pedigree(),
             )
             ht.write(trio_stats_ht_path, overwrite=overwrite)

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -42,7 +42,7 @@ from gnomad_qc.v5.resources.basics import (
     get_logging_path,
 )
 from gnomad_qc.v5.resources.sample_qc import (
-    DENSE_TRIO_TEST_CHROM,
+    DENSE_TRIO_TEST_CHROMS,
     dense_trios,
     get_dense_trio_chroms,
     pedigree,
@@ -504,9 +504,9 @@ def main(args):
                     "--chrom is required for --generate-trio-stats; trio stats are "
                     "computed one chromosome at a time (combine with --union-trio-stats)."
                 )
-            if test and chrom != DENSE_TRIO_TEST_CHROM:
+            if test and chrom not in DENSE_TRIO_TEST_CHROMS:
                 raise ValueError(
-                    f"--test computes trio stats only for {DENSE_TRIO_TEST_CHROM}; got "
+                    f"--test computes trio stats only for {DENSE_TRIO_TEST_CHROMS}; got "
                     f"--chrom {chrom}."
                 )
             logger.info("Generating trio stats for %s...", chrom)

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -526,14 +526,22 @@ def main(args):
 
         if args.union_trio_stats:
             logger.info("Unioning per-chromosome trio stats...")
+            chroms = get_dense_trio_chroms(test)
+            per_chrom_trio_stats_paths = [
+                get_trio_stats(test=test, environment=environment, chrom=c).path
+                for c in chroms
+            ]
             _check_resource_existence(
                 environment=environment,
+                input_step_resources={
+                    "trio_stats_per_chrom": per_chrom_trio_stats_paths
+                },
                 output_step_resources={"trio_stats_ht": [trio_stats_ht_path]},
                 overwrite=overwrite,
             )
             hts = [
                 get_trio_stats(test=test, environment=environment, chrom=c).ht()
-                for c in get_dense_trio_chroms(test)
+                for c in chroms
             ]
             ht = hts[0] if len(hts) == 1 else hts[0].union(*hts[1:])
             ht.write(trio_stats_ht_path, overwrite=overwrite)

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -41,7 +41,7 @@ from gnomad_qc.v5.resources.basics import (
     get_aou_vds,
     get_logging_path,
 )
-from gnomad_qc.v5.resources.sample_qc import dense_trios, pedigree, relatedness
+from gnomad_qc.v5.resources.sample_qc import get_dense_trio_mt, pedigree, relatedness
 
 logging.basicConfig(
     format="%(levelname)s (%(name)s %(lineno)s): %(message)s",
@@ -499,8 +499,13 @@ def main(args):
                 overwrite=overwrite,
             )
 
+            # Trio stats use autosomes only; union the per-chromosome dense trio MTs.
             ht = run_generate_trio_stats(
-                dense_trios(test=test, environment=environment).mt(),
+                get_dense_trio_mt(
+                    [f"chr{i}" for i in range(1, 23)],
+                    test=test,
+                    environment=environment,
+                ),
                 pedigree(test=test, environment=environment).pedigree(),
             )
             ht.write(trio_stats_ht_path, overwrite=overwrite)

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -41,7 +41,13 @@ from gnomad_qc.v5.resources.basics import (
     get_aou_vds,
     get_logging_path,
 )
-from gnomad_qc.v5.resources.sample_qc import get_dense_trio_mt, pedigree, relatedness
+from gnomad_qc.v5.resources.sample_qc import (
+    DENSE_TRIO_TEST_CHROM,
+    dense_trios,
+    get_dense_trio_chroms,
+    pedigree,
+    relatedness,
+)
 
 logging.basicConfig(
     format="%(levelname)s (%(name)s %(lineno)s): %(message)s",
@@ -492,18 +498,44 @@ def main(args):
             hl.export_vcf(info_ht, out_info_vcf_path, tabix=True)
 
         if args.generate_trio_stats:
-            logger.info("Generating trio stats...")
+            chrom = args.chrom
+            if chrom is None:
+                raise ValueError(
+                    "--chrom is required for --generate-trio-stats; trio stats are "
+                    "computed one chromosome at a time (combine with --union-trio-stats)."
+                )
+            if test and chrom != DENSE_TRIO_TEST_CHROM:
+                raise ValueError(
+                    f"--test computes trio stats only for {DENSE_TRIO_TEST_CHROM}; got "
+                    f"--chrom {chrom}."
+                )
+            logger.info("Generating trio stats for %s...", chrom)
+            per_chrom_trio_stats_path = get_trio_stats(
+                test=test, environment=environment, chrom=chrom
+            ).path
+            _check_resource_existence(
+                environment=environment,
+                output_step_resources={"trio_stats_ht": [per_chrom_trio_stats_path]},
+                overwrite=overwrite,
+            )
+            ht = run_generate_trio_stats(
+                dense_trios(test=test, chrom=chrom, environment=environment).mt(),
+                pedigree(test=test, environment=environment).pedigree(),
+            )
+            ht.write(per_chrom_trio_stats_path, overwrite=overwrite)
+
+        if args.union_trio_stats:
+            logger.info("Unioning per-chromosome trio stats...")
             _check_resource_existence(
                 environment=environment,
                 output_step_resources={"trio_stats_ht": [trio_stats_ht_path]},
                 overwrite=overwrite,
             )
-
-            # `get_dense_trio_mt` defaults to the autosomes (and chr20 if test is specified).
-            ht = run_generate_trio_stats(
-                get_dense_trio_mt(test=test, environment=environment),
-                pedigree(test=test, environment=environment).pedigree(),
-            )
+            hts = [
+                get_trio_stats(test=test, environment=environment, chrom=c).ht()
+                for c in get_dense_trio_chroms(test)
+            ]
+            ht = hts[0] if len(hts) == 1 else hts[0].union(*hts[1:])
             ht.write(trio_stats_ht_path, overwrite=overwrite)
 
         if args.generate_sibling_stats:
@@ -641,8 +673,25 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--generate-trio-stats",
-        help="Calculates trio stats.",
+        help=(
+            "Calculate trio stats for a single chromosome (--chrom). Run once per "
+            "chromosome, then combine with --union-trio-stats."
+        ),
         action="store_true",
+    )
+    parser.add_argument(
+        "--union-trio-stats",
+        help="Union the per-chromosome trio stats HTs into the combined trio stats HT.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--chrom",
+        help=(
+            "Single chromosome (e.g. 'chr20'). Required for --generate-trio-stats; trio "
+            "stats are computed one chromosome at a time."
+        ),
+        type=str,
+        default=None,
     )
     parser.add_argument(
         "--generate-sibling-stats",

--- a/gnomad_qc/v5/resources/annotations.py
+++ b/gnomad_qc/v5/resources/annotations.py
@@ -1,5 +1,7 @@
 """Script containing annotation related resources."""
 
+from typing import Optional
+
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 
 from gnomad_qc.v5.resources.basics import (
@@ -62,6 +64,7 @@ def _annotations_root(
 def get_trio_stats(
     test: bool = False,
     environment: str = "batch",
+    chrom: Optional[str] = None,
 ) -> VersionedTableResource:
     """
     Get gnomAD v5 (AoU genomes only) trio stats VersionedTableResource.
@@ -69,6 +72,8 @@ def get_trio_stats(
     :param test: Whether to use a temporary path for testing.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
+    :param chrom: Optional single chromosome for a per-chromosome trio stats HT (trio
+        stats are computed one chromosome at a time). Default is None (combined HT).
     :return: AoU trio stats VersionedTableResource.
     """
     _validate_environment(environment, _SAMPLE_DATA_ENVIRONMENTS)
@@ -77,7 +82,7 @@ def get_trio_stats(
         {
             version: TableResource(
                 f"{_annotations_root(version, test=test, environment=environment)}/aou.genomes.v{version}."
-                "trio_stats.ht"
+                f"trio_stats{f'.{chrom}' if chrom else ''}.ht"
             )
             for version in ANNOTATION_VERSIONS
         },

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -1,5 +1,8 @@
 """Script containing sample QC related resources."""
 
+from typing import List
+
+import hail as hl
 from gnomad.resources.resource_utils import (
     MatrixTableResource,
     PedigreeResource,
@@ -814,14 +817,17 @@ def trios(
 
 
 def dense_trios(
+    chrom: str,
     split: bool = False,
     test: bool = False,
     environment: str = "batch",
     read_only: bool = False,
 ) -> VersionedMatrixTableResource:
     """
-    Get the VersionedMatrixTableResource for the dense trio MatrixTable.
+    Get the VersionedMatrixTableResource for the per-chromosome dense trio MatrixTable.
 
+    :param chrom: Single chromosome (e.g. 'chr20') for the per-chromosome dense trio MT.
+        The dense trio MT is densified one chromosome at a time.
     :param split: Whether to get the resource for the split trio MatrixTable.
     :param test: Whether to use a tmp path for a test resource.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
@@ -835,8 +841,36 @@ def dense_trios(
             version: MatrixTableResource(
                 f"{get_sample_qc_root(version, test, environment=environment, read_only=read_only)}"
                 f"/relatedness/trios/aou.genomes.v{version}.trios.dense"
-                f"{'.split' if split else ''}.mt"
+                f"{'.split' if split else ''}"
+                f".{chrom}.mt"
             )
             for version in SAMPLE_QC_VERSIONS
         },
     )
+
+
+def get_dense_trio_mt(
+    chroms: List[str],
+    test: bool = False,
+    environment: str = "batch",
+) -> hl.MatrixTable:
+    """
+    Union the per-chromosome dense trio MatrixTables for `chroms` into one MatrixTable.
+
+    The dense trio MT is densified one chromosome at a time (see ``create_dense_trio_mt``
+    in ``identify_trios.py``); this lazily unions their rows. The per-chromosome MTs share
+    the same trio columns (built from the same pedigree and metadata), so ``union_rows``,
+    which requires matching column keys, aligns them.
+
+    :param chroms: Chromosomes whose per-chromosome dense trio MTs to union.
+    :param test: Whether to read the test-path MTs. Default is False.
+    :param environment: Environment to use. Default is "batch". Must be one of "rwb"
+        or "batch".
+    :return: Dense trio MatrixTable spanning `chroms`.
+    """
+    mts = [
+        dense_trios(test=test, chrom=c, environment=environment).mt() for c in chroms
+    ]
+    if len(mts) == 1:
+        return mts[0]
+    return mts[0].union_rows(*mts[1:])

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -1,6 +1,6 @@
 """Script containing sample QC related resources."""
 
-from typing import List
+from typing import List, Optional
 
 import hail as hl
 from gnomad.resources.resource_utils import (
@@ -850,7 +850,7 @@ def dense_trios(
 
 
 def get_dense_trio_mt(
-    chroms: List[str],
+    chroms: Optional[List[str]] = None,
     test: bool = False,
     environment: str = "batch",
 ) -> hl.MatrixTable:
@@ -862,12 +862,16 @@ def get_dense_trio_mt(
     the same trio columns (built from the same pedigree and metadata), so ``union_rows``,
     which requires matching column keys, aligns them.
 
-    :param chroms: Chromosomes whose per-chromosome dense trio MTs to union.
+    :param chroms: Chromosomes whose per-chromosome dense trio MTs to union. Default is
+        None, which uses the autosomes, or just 'chr20' when `test` (the test dense trio
+        MT is densified on chr20).
     :param test: Whether to read the test-path MTs. Default is False.
     :param environment: Environment to use. Default is "batch". Must be one of "rwb"
         or "batch".
     :return: Dense trio MatrixTable spanning `chroms`.
     """
+    if chroms is None:
+        chroms = ["chr20"] if test else [f"chr{i}" for i in range(1, 23)]
     mts = [
         dense_trios(test=test, chrom=c, environment=environment).mt() for c in chroms
     ]

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -1,8 +1,7 @@
 """Script containing sample QC related resources."""
 
-from typing import List, Optional
+from typing import List
 
-import hail as hl
 from gnomad.resources.resource_utils import (
     MatrixTableResource,
     PedigreeResource,
@@ -849,32 +848,22 @@ def dense_trios(
     )
 
 
-def get_dense_trio_mt(
-    chroms: Optional[List[str]] = None,
-    test: bool = False,
-    environment: str = "batch",
-) -> hl.MatrixTable:
+# Chromosome the dense trio MT is densified on for test runs. Single source of truth for
+# both the test chromosome consumers process (``get_dense_trio_chroms``) and the
+# ``--test`` densify in identify_trios.py.
+DENSE_TRIO_TEST_CHROM = "chr20"
+
+
+def get_dense_trio_chroms(test: bool = False) -> List[str]:
     """
-    Union the per-chromosome dense trio MatrixTables for `chroms` into one MatrixTable.
+    Get the chromosomes the dense trio MT spans.
 
     The dense trio MT is densified one chromosome at a time (see ``create_dense_trio_mt``
-    in ``identify_trios.py``); this lazily unions their rows. The per-chromosome MTs share
-    the same trio columns (built from the same pedigree and metadata), so ``union_rows``,
-    which requires matching column keys, aligns them.
+    in ``identify_trios.py``); consumers (trio stats, de novo calling) process those
+    chromosomes individually and union their per-chromosome outputs, rather than unioning
+    the large dense MTs.
 
-    :param chroms: Chromosomes whose per-chromosome dense trio MTs to union. Default is
-        None, which uses the autosomes, or just 'chr20' when `test` (the test dense trio
-        MT is densified on chr20).
-    :param test: Whether to read the test-path MTs. Default is False.
-    :param environment: Environment to use. Default is "batch". Must be one of "rwb"
-        or "batch".
-    :return: Dense trio MatrixTable spanning `chroms`.
+    :param test: Whether this is a test run. Default is False.
+    :return: ``[DENSE_TRIO_TEST_CHROM]`` when `test`, else the autosomes.
     """
-    if chroms is None:
-        chroms = ["chr20"] if test else [f"chr{i}" for i in range(1, 23)]
-    mts = [
-        dense_trios(test=test, chrom=c, environment=environment).mt() for c in chroms
-    ]
-    if len(mts) == 1:
-        return mts[0]
-    return mts[0].union_rows(*mts[1:])
+    return [DENSE_TRIO_TEST_CHROM] if test else [f"chr{i}" for i in range(1, 23)]

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -848,10 +848,11 @@ def dense_trios(
     )
 
 
-# Chromosome the dense trio MT is densified on for test runs. Single source of truth for
-# both the test chromosome consumers process (``get_dense_trio_chroms``) and the
-# ``--test`` densify in identify_trios.py.
-DENSE_TRIO_TEST_CHROM = "chr20"
+# Chromosomes the dense trio MT is densified on for test runs. Single source of truth for
+# both the test chromosomes consumers process (``get_dense_trio_chroms``) and the
+# ``--test`` densify in identify_trios.py. Two chromosomes so the per-chromosome union is
+# exercised in test.
+DENSE_TRIO_TEST_CHROMS = ["chr20", "chr21"]
 
 
 def get_dense_trio_chroms(test: bool = False) -> List[str]:
@@ -864,6 +865,6 @@ def get_dense_trio_chroms(test: bool = False) -> List[str]:
     the large dense MTs.
 
     :param test: Whether this is a test run. Default is False.
-    :return: ``[DENSE_TRIO_TEST_CHROM]`` when `test`, else the autosomes.
+    :return: ``DENSE_TRIO_TEST_CHROMS`` when `test`, else the autosomes.
     """
-    return [DENSE_TRIO_TEST_CHROM] if test else [f"chr{i}" for i in range(1, 23)]
+    return DENSE_TRIO_TEST_CHROMS if test else [f"chr{i}" for i in range(1, 23)]

--- a/gnomad_qc/v5/resources/sample_qc.py
+++ b/gnomad_qc/v5/resources/sample_qc.py
@@ -855,7 +855,9 @@ def dense_trios(
 DENSE_TRIO_TEST_CHROMS = ["chr20", "chr21"]
 
 
-def get_dense_trio_chroms(test: bool = False) -> List[str]:
+def get_dense_trio_chroms(
+    test: bool = False, include_sex_chr: bool = False
+) -> List[str]:
     """
     Get the chromosomes the dense trio MT spans.
 
@@ -865,6 +867,14 @@ def get_dense_trio_chroms(test: bool = False) -> List[str]:
     the large dense MTs.
 
     :param test: Whether this is a test run. Default is False.
-    :return: ``DENSE_TRIO_TEST_CHROMS`` when `test`, else the autosomes.
+    :param include_sex_chr: Whether to include chrX and chrY. Trio stats use autosomes
+        only; de novo calling sets this True. Ignored when `test` is set. Default is False.
+    :return: ``DENSE_TRIO_TEST_CHROMS`` when `test`, else the autosomes (plus chrX and
+        chrY when `include_sex_chr`).
     """
-    return DENSE_TRIO_TEST_CHROMS if test else [f"chr{i}" for i in range(1, 23)]
+    if test:
+        return DENSE_TRIO_TEST_CHROMS
+    chroms = [f"chr{i}" for i in range(1, 23)]
+    if include_sex_chr:
+        chroms += ["chrX", "chrY"]
+    return chroms

--- a/gnomad_qc/v5/sample_qc/identify_trios.py
+++ b/gnomad_qc/v5/sample_qc/identify_trios.py
@@ -285,9 +285,6 @@ def main(args):
             test=test, environment=environment
         )
         trios_path = trios(test=test, environment=environment).path
-        dense_trio_mt_path = dense_trios(
-            test=test, chrom=chrom, environment=environment
-        ).path
 
         logger.info(
             "Filtering relatedness HT to only include high quality AoU samples..."
@@ -408,6 +405,9 @@ def main(args):
                 )
             logger.info("Creating dense trio MT...")
             logger.info("Note that sample IDs in this MT will contain 'aou_' prefix.")
+            dense_trio_mt_path = dense_trios(
+                test=test, chrom=chrom, environment=environment
+            ).path
             _check_resource_existence(
                 environment=environment,
                 output_step_resources={"dense_trio_mt": [dense_trio_mt_path]},

--- a/gnomad_qc/v5/sample_qc/identify_trios.py
+++ b/gnomad_qc/v5/sample_qc/identify_trios.py
@@ -27,7 +27,7 @@ from gnomad_qc.v5.resources.basics import (
 )
 from gnomad_qc.v5.resources.meta import meta
 from gnomad_qc.v5.resources.sample_qc import (
-    DENSE_TRIO_TEST_CHROM,
+    DENSE_TRIO_TEST_CHROMS,
     dense_trios,
     duplicates,
     ped_filter_param_json_path,
@@ -404,10 +404,10 @@ def main(args):
                     "--chrom is required for --create-dense-trio-mt; the dense trio MT "
                     "is densified one chromosome at a time."
                 )
-            if test and chrom != DENSE_TRIO_TEST_CHROM:
+            if test and chrom not in DENSE_TRIO_TEST_CHROMS:
                 raise ValueError(
-                    f"--test densifies only the test chromosome "
-                    f"{DENSE_TRIO_TEST_CHROM}; got --chrom {chrom}."
+                    f"--test densifies only the test chromosomes "
+                    f"{DENSE_TRIO_TEST_CHROMS}; got --chrom {chrom}."
                 )
             logger.info("Creating dense trio MT...")
             logger.info("Note that sample IDs in this MT will contain 'aou_' prefix.")

--- a/gnomad_qc/v5/sample_qc/identify_trios.py
+++ b/gnomad_qc/v5/sample_qc/identify_trios.py
@@ -226,8 +226,7 @@ def filter_ped(
 def create_dense_trio_mt(
     fam_ht: hl.Table,
     meta_ht: hl.Table,
-    test: bool = False,
-    full_trios_chr20: bool = False,
+    chrom: str,
     naive_coalesce_partitions: Optional[int] = None,
     environment: str = "rwb",
 ) -> hl.MatrixTable:
@@ -236,10 +235,8 @@ def create_dense_trio_mt(
 
     :param fam_ht: Table with family information.
     :param meta_ht: Table with metadata information.
-    :param test: Whether to filter to two partitions of chr20 for testing. Default is False.
-    :param full_trios_chr20: Whether to densify *all* trios on whole chr20 (no sample
-        or partition subset) to get an overhead-independent per-genomic-unit cost that
-        can be scaled to whole-genome (~46x). Default is False.
+    :param chrom: Single chromosome to densify (e.g., 'chr20'). All trios on that
+        chromosome only. The dense trio MT is densified one chromosome at a time.
     :param naive_coalesce_partitions: Optional Number of partitions to coalesce the VDS
         to. Default is None.
     :param environment: Environment to use. Default is "rwb". Must be one of "rwb"
@@ -254,25 +251,9 @@ def create_dense_trio_mt(
     # Note: Checked IDs for samples in trios; none of them have sample ID collisions.
     meta_ht = filter_to_trios(meta_ht, fam_ht)
 
-    if test:
-        # Filter to the first 15 trios for testing.
-        fam_ht = fam_ht.head(15)
-        fam_ht_list = fam_ht.collect()
-        trio_samples = set()
-        for row in fam_ht_list:
-            trio_samples.add(row.id)
-            trio_samples.add(row.pat_id)
-            trio_samples.add(row.mat_id)
-
-        meta_ht = meta_ht.filter(hl.literal(trio_samples).contains(meta_ht.s))
-
-    # Keep all AoU VDS entries except FT (genotype-level filtering information
-    # from AoU).
     vds = get_aou_vds(
         filter_samples=meta_ht,
-        filter_partitions=range(2) if test else None,
-        chrom="chr20" if (test or full_trios_chr20) else None,
-        entries_to_keep=["GQ", "RGQ", "PS", "LGT", "LAD", "LA"],
+        chrom=chrom,
         naive_coalesce_partitions=naive_coalesce_partitions,
         add_project_prefix=True,
         environment=environment,
@@ -287,7 +268,7 @@ def main(args):
 
     overwrite = args.overwrite
     test = args.test
-    full_trios_chr20 = args.full_trios_chr20
+    chrom = args.chrom
 
     try:
 
@@ -305,7 +286,7 @@ def main(args):
         )
         trios_path = trios(test=test, environment=environment).path
         dense_trio_mt_path = dense_trios(
-            test=test or full_trios_chr20, environment=environment
+            test=test, chrom=chrom, environment=environment
         ).path
 
         logger.info(
@@ -420,6 +401,11 @@ def main(args):
                 d.write(json.dumps(filters))
 
         if args.create_dense_trio_mt:
+            if chrom is None:
+                raise ValueError(
+                    "--chrom is required for --create-dense-trio-mt; the dense trio MT "
+                    "is densified one chromosome at a time."
+                )
             logger.info("Creating dense trio MT...")
             logger.info("Note that sample IDs in this MT will contain 'aou_' prefix.")
             _check_resource_existence(
@@ -434,11 +420,12 @@ def main(args):
                     "Specifying naive coalesce partitions may make the densify significantly slower..."
                 )
 
+            # NOTE: Code always densifies all trios from the finalized pedigree for
+            # cost estimation reasons.
             dense_trio_mt = create_dense_trio_mt(
-                hl.import_fam(final_ped_path),
+                hl.import_fam(pedigree(test=False, environment=environment).path),
                 meta_ht,
-                test=test,
-                full_trios_chr20=full_trios_chr20,
+                chrom=chrom,
                 naive_coalesce_partitions=naive_coalesce_partitions,
                 environment=environment,
             )
@@ -460,7 +447,11 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--test",
-        help="Run script on subset of dataset. Applies to Mendel errors and dense trio MT creation.",
+        help=(
+            "Use test output paths. Subsets the data for Mendel error calculation. For "
+            "dense trio MT creation it only changes the output path (all trios are still "
+            "densified); pair with --chrom to limit to a single chromosome."
+        ),
         action="store_true",
     )
     parser.add_argument(
@@ -608,14 +599,15 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     dense_trio_mt_args.add_argument(
-        "--full-trios-chr20",
+        "--chrom",
         help=(
-            "Densify all trios on whole chr20 (no sample or partition subset) for cost "
-            "calibration. Writes to the test output path. Scale the resulting "
-            "overhead-subtracted cost by ~46x to estimate whole-genome cost. Do not "
-            "combine with --test."
+            "Single chromosome to densify (e.g., 'chr20'). Required for "
+            "--create-dense-trio-mt: the dense trio MT is densified one chromosome at a "
+            "time, run once per chromosome. Combine with --test to route output to a "
+            "test path."
         ),
-        action="store_true",
+        type=str,
+        default=None,
     )
     dense_trio_mt_args.add_argument(
         "--naive-coalesce-partitions",

--- a/gnomad_qc/v5/sample_qc/identify_trios.py
+++ b/gnomad_qc/v5/sample_qc/identify_trios.py
@@ -227,6 +227,7 @@ def create_dense_trio_mt(
     fam_ht: hl.Table,
     meta_ht: hl.Table,
     test: bool = False,
+    full_trios_chr20: bool = False,
     naive_coalesce_partitions: Optional[int] = None,
     environment: str = "rwb",
 ) -> hl.MatrixTable:
@@ -236,6 +237,9 @@ def create_dense_trio_mt(
     :param fam_ht: Table with family information.
     :param meta_ht: Table with metadata information.
     :param test: Whether to filter to two partitions of chr20 for testing. Default is False.
+    :param full_trios_chr20: Whether to densify *all* trios on whole chr20 (no sample
+        or partition subset) to get an overhead-independent per-genomic-unit cost that
+        can be scaled to whole-genome (~46x). Default is False.
     :param naive_coalesce_partitions: Optional Number of partitions to coalesce the VDS
         to. Default is None.
     :param environment: Environment to use. Default is "rwb". Must be one of "rwb"
@@ -267,7 +271,7 @@ def create_dense_trio_mt(
     vds = get_aou_vds(
         filter_samples=meta_ht,
         filter_partitions=range(2) if test else None,
-        chrom="chr20" if test else None,
+        chrom="chr20" if (test or full_trios_chr20) else None,
         naive_coalesce_partitions=naive_coalesce_partitions,
         add_project_prefix=True,
         environment=environment,
@@ -282,6 +286,7 @@ def main(args):
 
     overwrite = args.overwrite
     test = args.test
+    full_trios_chr20 = args.full_trios_chr20
 
     try:
 
@@ -298,7 +303,9 @@ def main(args):
             test=test, environment=environment
         )
         trios_path = trios(test=test, environment=environment).path
-        dense_trio_mt_path = dense_trios(test=test, environment=environment).path
+        dense_trio_mt_path = dense_trios(
+            test=test or full_trios_chr20, environment=environment
+        ).path
 
         logger.info(
             "Filtering relatedness HT to only include high quality AoU samples..."
@@ -430,6 +437,7 @@ def main(args):
                 hl.import_fam(final_ped_path),
                 meta_ht,
                 test=test,
+                full_trios_chr20=full_trios_chr20,
                 naive_coalesce_partitions=naive_coalesce_partitions,
                 environment=environment,
             )
@@ -596,6 +604,16 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     dense_trio_mt_args.add_argument(
         "--create-dense-trio-mt",
         help=("Create a dense MT for high quality trios."),
+        action="store_true",
+    )
+    dense_trio_mt_args.add_argument(
+        "--full-trios-chr20",
+        help=(
+            "Densify all trios on whole chr20 (no sample or partition subset) for cost "
+            "calibration. Writes to the test output path. Scale the resulting "
+            "overhead-subtracted cost by ~46x to estimate whole-genome cost. Do not "
+            "combine with --test."
+        ),
         action="store_true",
     )
     dense_trio_mt_args.add_argument(

--- a/gnomad_qc/v5/sample_qc/identify_trios.py
+++ b/gnomad_qc/v5/sample_qc/identify_trios.py
@@ -266,12 +266,13 @@ def create_dense_trio_mt(
 
         meta_ht = meta_ht.filter(hl.literal(trio_samples).contains(meta_ht.s))
 
-    # v4 used `entries_to_keep` to filter non `gvcf_info` entries, but
-    # AoU VDS only has GQ, RGQ, PS, LGT, LAD, LA, FT entries.
+    # Keep all AoU VDS entries except FT (genotype-level filtering information
+    # from AoU).
     vds = get_aou_vds(
         filter_samples=meta_ht,
         filter_partitions=range(2) if test else None,
         chrom="chr20" if (test or full_trios_chr20) else None,
+        entries_to_keep=["GQ", "RGQ", "PS", "LGT", "LAD", "LA"],
         naive_coalesce_partitions=naive_coalesce_partitions,
         add_project_prefix=True,
         environment=environment,

--- a/gnomad_qc/v5/sample_qc/identify_trios.py
+++ b/gnomad_qc/v5/sample_qc/identify_trios.py
@@ -27,6 +27,7 @@ from gnomad_qc.v5.resources.basics import (
 )
 from gnomad_qc.v5.resources.meta import meta
 from gnomad_qc.v5.resources.sample_qc import (
+    DENSE_TRIO_TEST_CHROM,
     dense_trios,
     duplicates,
     ped_filter_param_json_path,
@@ -402,6 +403,11 @@ def main(args):
                 raise ValueError(
                     "--chrom is required for --create-dense-trio-mt; the dense trio MT "
                     "is densified one chromosome at a time."
+                )
+            if test and chrom != DENSE_TRIO_TEST_CHROM:
+                raise ValueError(
+                    f"--test densifies only the test chromosome "
+                    f"{DENSE_TRIO_TEST_CHROM}; got --chrom {chrom}."
                 )
             logger.info("Creating dense trio MT...")
             logger.info("Note that sample IDs in this MT will contain 'aou_' prefix.")


### PR DESCRIPTION
PR adds code to create per-chromosome dense trio MTs, calculate trio stats per chromosome, and union the resulting trio stats HTs. I didn't add any code to help dispatch the jobs since I thought we'd run this one chromosome at a time.

Test runs (I forgot to add the chromosome to the dense trio MT app names):
chr20 dense trio MT( https://batch.hail.is/batches/8417771)
```
python v5/sample_qc/identify_trios.py --environment batch --app-name test-dense-trios --create-dense-trio-mt --test --chrom chr20 --overwrite --driver-memory highmem --driver-cores 8
```
59 minutes 58s / $26.1232 

chr21 dense trio MT (https://batch.hail.is/batches/8418114)
```
python v5/sample_qc/identify_trios.py --environment batch --app-name test-dense-trios --create-dense-trio-mt --test --chrom chr21 --driver-memory highmem --driver-cores 8
```
1 hour 11 minutes / $16.0151 

chr20 trio stats (https://batch.hail.is/batches/8418120)
```
python v5/annotations/generate_variant_qc_annotations.py --environment batch --app-name test-trio-stats-chr20 --test --chrom chr20 --generate-trio-stats --driver-memory highmem --driver-cores 2
```
4 minutes 52s / $0.4430 

chr21 trio stats (https://batch.hail.is/batches/8418121)
```
python v5/annotations/generate_variant_qc_annotations.py --environment batch --app-name test-trio-stats-chr21 --test --chrom chr21 --generate-trio-stats --driver-memory highmem --driver-cores 2
```
4 minutes 15s / $0.1034 

union (https://batch.hail.is/batches/8418125)
```
python v5/annotations/generate_variant_qc_annotations.py --environment batch --app-name test-trio-stats-union --test --union-trio-stats --driver-memory highmem --overwrite --driver-cores 2
```
10 minutes 51s / $0.2567 