### PR TITLE
Fixes for trio stats

### DIFF
--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -232,8 +232,10 @@ def run_generate_trio_stats(
 
 
 # Per-chromosome trio stats inherit the dense trio MT's fine partitioning
-# (~2k-12k partitions each for a few tens of MB), so each is coalesced to this
-# both at generation and as it is read into the union (~22x this, ~550, combined).
+# (~2k-12k partitions each for a few tens of MB), so each is coalesced down to
+# this value -- both at generation and again as it's read into the union.
+# Across the 22 autosomes that's ~22 * 25 = ~550 partitions combined, versus
+# the ~138k we'd get from their native partitionings.
 TRIO_STATS_N_PARTITIONS_PER_CHROM = 25
 
 # adj/raw paired count fields produced by generate_trio_stats_expr.
@@ -683,8 +685,7 @@ def main(args):
             )
             # The per-chrom HTs inherit the dense trio MTs' fine partitioning
             # (~2k-12k partitions each), so naive_coalesce each one as it is read;
-            # union() then concatenates ~22x TRIO_STATS_N_PARTITIONS_PER_CHROM
-            # partitions rather than ~138k.
+            # union() then concatenate to get len(chroms) * TRIO_STATS_N_PARTITIONS_PER_CHROM partitions instead of the sum of every chrom's native count (~138k).
             hts = [
                 get_trio_stats(test=test, environment=environment, chrom=c)
                 .ht()

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -685,7 +685,9 @@ def main(args):
             )
             # The per-chrom HTs inherit the dense trio MTs' fine partitioning
             # (~2k-12k partitions each), so naive_coalesce each one as it is read;
-            # union() then concatenate to get len(chroms) * TRIO_STATS_N_PARTITIONS_PER_CHROM partitions instead of the sum of every chrom's native count (~138k).
+            # union() then concatenate to get len(chroms) *
+            # TRIO_STATS_N_PARTITIONS_PER_CHROM partitions instead of the sum of every
+            # chrom's native count (~138k).
             hts = [
                 get_trio_stats(test=test, environment=environment, chrom=c)
                 .ht()

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -231,6 +231,11 @@ def run_generate_trio_stats(
     return generate_trio_stats(mt)
 
 
+# Target partition count for the combined trio stats HT. union() concatenates the
+# per-chrom partitions (~138k total for ~650 MB of data), so the union is coalesced
+# down to this before writing the production HT.
+TRIO_STATS_N_PARTITIONS = 500
+
 # adj/raw paired count fields produced by generate_trio_stats_expr.
 TRIO_STATS_PAIRED_FIELDS = [
     "n_transmitted",
@@ -676,6 +681,11 @@ def main(args):
                 for c in chroms
             ]
             ht = hts[0] if len(hts) == 1 else hts[0].union(*hts[1:])
+            # union() concatenates the per-chrom partitions (~138k total), so
+            # materialize to a temp path first and naive_coalesce off the
+            # checkpointed partitioning before writing the production HT.
+            ht = ht.checkpoint(hl.utils.new_temp_file("union_trio_stats", "ht"))
+            ht = ht.naive_coalesce(TRIO_STATS_N_PARTITIONS)
             ht.write(trio_stats_ht_path, overwrite=overwrite)
 
         if args.validate_trio_stats:

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -233,13 +233,8 @@ def run_generate_trio_stats(
 
 # Per-chromosome trio stats inherit the dense trio MT's fine partitioning
 # (~2k-12k partitions each for a few tens of MB), so each is coalesced to this
-# before writing. The union is then ~22x this (~550 partitions).
+# both at generation and as it is read into the union (~22x this, ~550, combined).
 TRIO_STATS_N_PARTITIONS_PER_CHROM = 25
-
-# Target partition count for the combined trio stats HT. union() concatenates the
-# per-chrom partitions, so the union is coalesced down to this before writing the
-# production HT.
-TRIO_STATS_N_PARTITIONS = 500
 
 # adj/raw paired count fields produced by generate_trio_stats_expr.
 TRIO_STATS_PAIRED_FIELDS = [
@@ -686,16 +681,17 @@ def main(args):
                 output_step_resources={"trio_stats_ht": [trio_stats_ht_path]},
                 overwrite=overwrite,
             )
+            # The per-chrom HTs inherit the dense trio MTs' fine partitioning
+            # (~2k-12k partitions each), so naive_coalesce each one as it is read;
+            # union() then concatenates ~22x TRIO_STATS_N_PARTITIONS_PER_CHROM
+            # partitions rather than ~138k.
             hts = [
-                get_trio_stats(test=test, environment=environment, chrom=c).ht()
+                get_trio_stats(test=test, environment=environment, chrom=c)
+                .ht()
+                .naive_coalesce(TRIO_STATS_N_PARTITIONS_PER_CHROM)
                 for c in chroms
             ]
             ht = hts[0] if len(hts) == 1 else hts[0].union(*hts[1:])
-            # union() concatenates the per-chrom partitions (~138k total), so
-            # materialize to a temp path first and naive_coalesce off the
-            # checkpointed partitioning before writing the production HT.
-            ht = ht.checkpoint(hl.utils.new_temp_file("union_trio_stats", "ht"))
-            ht = ht.naive_coalesce(TRIO_STATS_N_PARTITIONS)
             ht.write(trio_stats_ht_path, overwrite=overwrite)
 
         if args.validate_trio_stats:

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -2,7 +2,7 @@
 
 import argparse
 import logging
-from typing import Dict
+from typing import Dict, List
 
 import hail as hl
 from gnomad.resources.grch38.gnomad import GROUPS
@@ -229,6 +229,138 @@ def run_generate_trio_stats(
     mt = mt.transmute_entries(GT=mt.LGT)
     mt = hl.trio_matrix(mt, pedigree=fam_ped, complete_trios=True)
     return generate_trio_stats(mt)
+
+
+# adj/raw paired count fields produced by generate_trio_stats_expr.
+TRIO_STATS_PAIRED_FIELDS = [
+    "n_transmitted",
+    "n_untransmitted",
+    "n_de_novos",
+    "ac_parents",
+    "an_parents",
+    "ac_children",
+    "an_children",
+]
+
+
+def validate_trio_stats(
+    ht: hl.Table,
+    per_chrom_hts: Dict[str, hl.Table],
+    expected_chroms: List[str],
+) -> None:
+    """
+    Validate the combined trio stats HT for union integrity and value sanity.
+
+    Raises on hard failures (row/contig loss, schema mismatch, invariant
+    violations); logs biological plausibility metrics for eyeballing.
+
+    :param ht: Combined (unioned) trio stats HT.
+    :param per_chrom_hts: Per-chromosome trio stats HTs keyed by contig.
+    :param expected_chroms: Contigs the union should cover (autosomes).
+    """
+    # Structural checks (cheap; catch a broken union first).
+    ref_ht = per_chrom_hts[expected_chroms[0]]
+    if ht.row.dtype != ref_ht.row.dtype or list(ht.key) != list(ref_ht.key):
+        raise ValueError("Combined trio stats schema/key differs from per-chrom HT.")
+
+    per_chrom_counts = {c: h.count() for c, h in per_chrom_hts.items()}
+
+    # Single pass over the combined HT for everything else.
+    agg = ht.aggregate(
+        hl.struct(
+            n_rows=hl.agg.count(),
+            contigs=hl.agg.counter(ht.locus.contig),
+            n_multiallelic=hl.agg.count_where(hl.len(ht.alleles) != 2),
+            n_non_autosome=hl.agg.count_where(~ht.locus.in_autosome()),
+            n_missing=hl.agg.count_where(
+                hl.any(
+                    [
+                        hl.is_missing(ht[f"{f}_{s}"])
+                        for f in TRIO_STATS_PAIRED_FIELDS
+                        for s in ["raw", "adj"]
+                    ]
+                )
+            ),
+            n_negative=hl.agg.count_where(
+                hl.any(
+                    [
+                        ht[f"{f}_{s}"] < 0
+                        for f in TRIO_STATS_PAIRED_FIELDS
+                        for s in ["raw", "adj"]
+                    ]
+                )
+            ),
+            # adj must be a subset of raw for every paired field.
+            n_adj_gt_raw=hl.agg.count_where(
+                hl.any(
+                    [ht[f"{f}_adj"] > ht[f"{f}_raw"] for f in TRIO_STATS_PAIRED_FIELDS]
+                )
+            ),
+            # AC <= AN for parents and children, both strata.
+            n_ac_gt_an=hl.agg.count_where(
+                hl.any(
+                    [
+                        ht[f"ac_{grp}_{s}"] > ht[f"an_{grp}_{s}"]
+                        for grp in ["parents", "children"]
+                        for s in ["raw", "adj"]
+                    ]
+                )
+            ),
+            sum_t_adj=hl.agg.sum(ht.n_transmitted_adj),
+            sum_u_adj=hl.agg.sum(ht.n_untransmitted_adj),
+            sum_dnm_raw=hl.agg.sum(ht.n_de_novos_raw),
+            sum_dnm_adj=hl.agg.sum(ht.n_de_novos_adj),
+        )
+    )
+
+    observed_contigs = set(agg.contigs)
+    problems = []
+
+    # Row-count conservation (union concatenates, so exact).
+    total_per_chrom = sum(per_chrom_counts.values())
+    if agg.n_rows != total_per_chrom:
+        problems.append(
+            f"row count {agg.n_rows} != sum of per-chrom counts {total_per_chrom}"
+        )
+    # Per-contig conservation + contig set.
+    if observed_contigs != set(expected_chroms):
+        problems.append(
+            f"contigs {sorted(observed_contigs)} != expected {sorted(expected_chroms)}"
+        )
+    for c in expected_chroms:
+        if agg.contigs.get(c, 0) != per_chrom_counts.get(c):
+            problems.append(
+                f"{c}: combined {agg.contigs.get(c, 0)} != per-chrom "
+                f"{per_chrom_counts.get(c)}"
+            )
+    # Content invariants (all must be zero).
+    for label, n in [
+        ("multiallelic rows", agg.n_multiallelic),
+        ("non-autosomal rows", agg.n_non_autosome),
+        ("rows with missing counts", agg.n_missing),
+        ("rows with negative counts", agg.n_negative),
+        ("rows where adj > raw", agg.n_adj_gt_raw),
+        ("rows where AC > AN", agg.n_ac_gt_an),
+    ]:
+        if n != 0:
+            problems.append(f"{n} {label}")
+
+    # Biological plausibility (logged, not fatal).
+    denom = agg.sum_t_adj + agg.sum_u_adj
+    ratio = agg.sum_t_adj / denom if denom > 0 else float("nan")
+    logger.info(
+        "Combined trio stats: %d rows across %d contigs.",
+        agg.n_rows,
+        len(observed_contigs),
+    )
+    logger.info("Transmission ratio (adj) = %.4f (expect ~0.5).", ratio)
+    logger.info("De novos: raw=%d, adj=%d.", agg.sum_dnm_raw, agg.sum_dnm_adj)
+
+    if problems:
+        raise ValueError(
+            "Trio stats validation FAILED:\n  - " + "\n  - ".join(problems)
+        )
+    logger.info("Trio stats validation PASSED.")
 
 
 def run_generate_sib_stats(
@@ -546,6 +678,26 @@ def main(args):
             ht = hts[0] if len(hts) == 1 else hts[0].union(*hts[1:])
             ht.write(trio_stats_ht_path, overwrite=overwrite)
 
+        if args.validate_trio_stats:
+            logger.info("Validating combined trio stats...")
+            chroms = get_dense_trio_chroms(test)
+            per_chrom = {
+                c: get_trio_stats(test=test, environment=environment, chrom=c)
+                for c in chroms
+            }
+            _check_resource_existence(
+                environment=environment,
+                input_step_resources={
+                    "trio_stats_ht": [trio_stats_ht_path],
+                    "trio_stats_per_chrom": [r.path for r in per_chrom.values()],
+                },
+            )
+            validate_trio_stats(
+                get_trio_stats(test=test, environment=environment).ht(),
+                {c: r.ht() for c, r in per_chrom.items()},
+                chroms,
+            )
+
         if args.generate_sibling_stats:
             logger.info("Generating sibling stats...")
             _check_resource_existence(
@@ -690,6 +842,11 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--union-trio-stats",
         help="Union the per-chromosome trio stats HTs into the combined trio stats HT.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--validate-trio-stats",
+        help="Validate the combined trio stats HT (union integrity + value sanity).",
         action="store_true",
     )
     parser.add_argument(

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -231,9 +231,14 @@ def run_generate_trio_stats(
     return generate_trio_stats(mt)
 
 
+# Per-chromosome trio stats inherit the dense trio MT's fine partitioning
+# (~2k-12k partitions each for a few tens of MB), so each is coalesced to this
+# before writing. The union is then ~22x this (~550 partitions).
+TRIO_STATS_N_PARTITIONS_PER_CHROM = 25
+
 # Target partition count for the combined trio stats HT. union() concatenates the
-# per-chrom partitions (~138k total for ~650 MB of data), so the union is coalesced
-# down to this before writing the production HT.
+# per-chrom partitions, so the union is coalesced down to this before writing the
+# production HT.
 TRIO_STATS_N_PARTITIONS = 500
 
 # adj/raw paired count fields produced by generate_trio_stats_expr.
@@ -659,6 +664,11 @@ def main(args):
                 dense_trios(test=test, chrom=chrom, environment=environment).mt(),
                 pedigree(test=test, environment=environment).pedigree(),
             )
+            # The dense trio MT is finely partitioned, so the per-chrom trio stats
+            # inherit ~thousands of tiny partitions. Checkpoint the full result,
+            # then naive_coalesce off the materialized partitioning before writing.
+            ht = ht.checkpoint(hl.utils.new_temp_file(f"trio_stats_{chrom}", "ht"))
+            ht = ht.naive_coalesce(TRIO_STATS_N_PARTITIONS_PER_CHROM)
             ht.write(per_chrom_trio_stats_path, overwrite=overwrite)
 
         if args.union_trio_stats:


### PR DESCRIPTION
PR adds two `naive_coalece` for trio stats HT creation. One coalesce is added per chromosome, and one is added for the full table; ideally, we'd run the coalesce per-chromosome, but I've already generated trio stats per chromosome, so the best path for v5 is to run a coalesce on the union.

PR also adds some checks on the unioned trio stats HT