### PR TITLE
Add isolation forest code for v5

### DIFF
--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -559,7 +559,8 @@ def main(args):
 
     overwrite = args.overwrite
     test_n_partitions = args.test_n_partitions
-    test = args.test or test_n_partitions is not None
+    test_chrom = args.test_chrom
+    test = args.test or test_n_partitions is not None or test_chrom is not None
 
     info_ht_path = get_info_ht(test=test, environment=environment).path
     trio_stats_ht_path = get_trio_stats(test=test, environment=environment).path
@@ -610,17 +611,32 @@ def main(args):
         if args.export_info_vcf:
             logger.info("Exporting info ht as VCF...")
             out_info_vcf_path = info_vcf_path(test=test, environment=environment)
+            # --test-chrom cuts the full info HT to the requested contigs. The test info
+            # HT is partition-filtered, so its contigs won't match a test run's -L args.
+            in_info_ht_path = (
+                get_info_ht(test=False, environment=environment).path
+                if test_chrom
+                else info_ht_path
+            )
             _check_resource_existence(
                 environment=environment,
                 input_step_resources={
-                    "info_ht": [info_ht_path],
+                    "info_ht": [in_info_ht_path],
                 },
                 output_step_resources={
                     "info_vcf_path": [out_info_vcf_path],
                 },
                 overwrite=overwrite,
             )
-            info_ht = hl.read_table(info_ht_path)
+            info_ht = hl.read_table(in_info_ht_path)
+            if test_chrom:
+                info_ht = hl.filter_intervals(
+                    info_ht,
+                    [
+                        hl.parse_locus_interval(c, reference_genome="GRCh38")
+                        for c in test_chrom
+                    ],
+                )
             # TODO: Check if AS_QUALapprox and AS_VarDP are needed for v5 (not used for v4) and if so need preceeded pipe.
             # Reformat AS_SB_TABLE to be a nested array of arrays for proper use
             # within the 'adjust_vcf_incompatible_types' function.
@@ -886,6 +902,16 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
             "stats are computed one chromosome at a time."
         ),
         type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--test-chrom",
+        help=(
+            "Contig(s) (e.g. 'chr22') to cut the full info HT to for --export-info-vcf. "
+            "Use to match the contigs a downstream test run scores. Implies --test."
+        ),
+        type=str,
+        nargs="+",
         default=None,
     )
     parser.add_argument(

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -652,9 +652,10 @@ def main(args):
             )
             # GATK's isolation forest infers allele-specific mode from Number=A in the
             # header (the explicit --use-allele-specific-annotations flag was replaced
-            # by this header check in GATK 4.5.0.0); Hail exports arrays as Number=. so
-            # declare the AS features Number=A. VQSR (VariantRecalibrator) is flag-driven
-            # and works with either.
+            # by this header check in GATK 4.5.0.0); these features are scalars here, so
+            # Hail would write Number=1. AS mode also forces
+            # START_POSITION_AND_MINIMAL_REPRESENTATION resource matching, so the header
+            # matters even though the input is split.
             vcf_metadata = {
                 "info": {
                     f: {"Number": "A", "Type": "Float", "Description": ""}

--- a/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
+++ b/gnomad_qc/v5/annotations/generate_variant_qc_annotations.py
@@ -634,7 +634,18 @@ def main(args):
             info_ht = adjust_vcf_incompatible_types(
                 info_ht, pipe_delimited_annotations=[]
             )
-            hl.export_vcf(info_ht, out_info_vcf_path, tabix=True)
+            # GATK's isolation forest infers allele-specific mode from Number=A in the
+            # header (the explicit --use-allele-specific-annotations flag was replaced
+            # by this header check in GATK 4.5.0.0); Hail exports arrays as Number=. so
+            # declare the AS features Number=A. VQSR (VariantRecalibrator) is flag-driven
+            # and works with either.
+            vcf_metadata = {
+                "info": {
+                    f: {"Number": "A", "Type": "Float", "Description": ""}
+                    for f in INFO_FEATURES
+                }
+            }
+            hl.export_vcf(info_ht, out_info_vcf_path, tabix=True, metadata=vcf_metadata)
 
         if args.generate_trio_stats:
             chrom = args.chrom

--- a/gnomad_qc/v5/resources/variant_qc.py
+++ b/gnomad_qc/v5/resources/variant_qc.py
@@ -1,6 +1,10 @@
 """Script containing variant QC related resources for v5."""
 
-from gnomad.resources.resource_utils import VariantDatasetResource
+from gnomad.resources.resource_utils import (
+    TableResource,
+    VariantDatasetResource,
+    VersionedTableResource,
+)
 
 from gnomad_qc.v5.resources.basics import (
     _ALL_ENVIRONMENTS,
@@ -8,7 +12,35 @@ from gnomad_qc.v5.resources.basics import (
     _validate_environment,
     qc_temp_prefix,
 )
-from gnomad_qc.v5.resources.constants import CURRENT_VARIANT_QC_VERSION
+from gnomad_qc.v5.resources.constants import (
+    CURRENT_VARIANT_QC_RESULT_VERSION,
+    CURRENT_VARIANT_QC_VERSION,
+    VARIANT_QC_RESULT_VERSIONS,
+)
+
+# Isolation forest features, keyed by variant type. GATK trains a separate model per
+# --mode, so SNPs/INDELs need their own lists. AS_MQ is dropped for indels (v4 genomes
+# VQSR convention); AS_pab_max is kept for both (tree-based, unlike Gaussian VQSR).
+IF_FEATURES = {
+    "snv": [
+        "AS_QD",
+        "AS_pab_max",
+        "AS_MQRankSum",
+        "AS_ReadPosRankSum",
+        "AS_FS",
+        "AS_SOR",
+        "AS_MQ",
+    ],
+    "indel": [
+        "AS_QD",
+        "AS_pab_max",
+        "AS_MQRankSum",
+        "AS_ReadPosRankSum",
+        "AS_FS",
+        "AS_SOR",
+    ],
+}
+"""Features used in the isolation forest model, keyed by variant type."""
 
 
 def _variant_qc_root(
@@ -79,3 +111,84 @@ def get_truth_samples_combiner_plan(test: bool = False) -> str:
         return f"{qc_temp_prefix(environment='batch', days=4)}truth_samples_combiner_plan.json"
 
     return f"{_variant_qc_root(version='5.0', environment='batch')}/aou/truth_samples/truth_samples_combiner_plan.json"
+
+
+######################################################################
+# Variant QC model / result resources
+######################################################################
+
+
+def _validate_model_id(model_id: str) -> str:
+    """
+    Validate a variant QC model ID and return its model type prefix.
+
+    :param model_id: Model ID. Must start with ``rf_``, ``vqsr_``, or ``if_``.
+    :return: Model type ('rf', 'vqsr', or 'if').
+    """
+    model_type = model_id.split("_")[0]
+    if model_type not in ["rf", "vqsr", "if"]:
+        raise ValueError(
+            f"Model ID must start with 'rf_', 'vqsr_', or 'if_', but got {model_id}"
+        )
+    return model_type
+
+
+def get_variant_qc_result(
+    model_id: str,
+    test: bool = False,
+    split: bool = True,
+    data_type: str = "genomes",
+    environment: str = "batch",
+) -> VersionedTableResource:
+    """
+    Get the results of variant QC filtering for a given run.
+
+    :param model_id: Model ID of variant QC run to load. Must start with ``rf_``,
+        ``vqsr_``, or ``if_``.
+    :param test: Whether to use a tmp path for variant QC tests.
+    :param split: Whether to return the split or unsplit variant QC result.
+    :param data_type: Whether to return 'exomes' or 'genomes' data. Default is genomes.
+    :param environment: Environment to use. Default is "batch". Must be one of "rwb",
+        "batch", or "dataproc".
+    :return: VersionedTableResource for variant QC results.
+    """
+    model_type = _validate_model_id(model_id)
+    return VersionedTableResource(
+        CURRENT_VARIANT_QC_RESULT_VERSION,
+        {
+            version: TableResource(
+                f"{_variant_qc_root(version, test=test, data_type=data_type, environment=environment)}/{model_type}/models/{model_id}/gnomad.{data_type}.v{version}.{model_type}_result{'' if split else '.unsplit'}.ht"
+            )
+            for version in VARIANT_QC_RESULT_VERSIONS
+        },
+    )
+
+
+def get_iforest_run_prefix(
+    model_id: str,
+    version: str = CURRENT_VARIANT_QC_RESULT_VERSION,
+    test: bool = False,
+    data_type: str = "genomes",
+    environment: str = "batch",
+) -> str:
+    """
+    Get the GCS prefix for an isolation forest run's GATK working/output files.
+
+    The isolation forest workflow writes its GATK intermediate outputs (extracted
+    annotations, trained model, scored VCFs) under this prefix, alongside the model's
+    result HT from :func:`get_variant_qc_result`.
+
+    :param model_id: Model ID of the isolation forest run. Must start with ``if_``.
+    :param version: Version of the variant QC result path to return.
+    :param test: Whether to use a tmp path for variant QC tests.
+    :param data_type: Whether to return 'exomes' or 'genomes' data. Default is genomes.
+    :param environment: Environment to use. Default is "batch". Must be one of "rwb",
+        "batch", or "dataproc".
+    :return: GCS prefix (no trailing slash) for the isolation forest run's files.
+    """
+    if _validate_model_id(model_id) != "if":
+        raise ValueError(f"model_id must start with 'if_', but got {model_id}")
+    root = _variant_qc_root(
+        version, test=test, data_type=data_type, environment=environment
+    )
+    return f"{root}/if/models/{model_id}"

--- a/gnomad_qc/v5/resources/variant_qc.py
+++ b/gnomad_qc/v5/resources/variant_qc.py
@@ -18,10 +18,10 @@ from gnomad_qc.v5.resources.constants import (
     VARIANT_QC_RESULT_VERSIONS,
 )
 
-# Isolation forest features, keyed by variant type. GATK trains a separate model per
+# Variant QC model features, keyed by variant type. GATK trains a separate model per
 # --mode, so SNPs/INDELs need their own lists. AS_MQ is dropped for indels (v4 genomes
 # VQSR convention); AS_pab_max is kept for both (tree-based, unlike Gaussian VQSR).
-IF_FEATURES = {
+VARIANT_QC_FEATURES = {
     "snv": [
         "AS_QD",
         "AS_pab_max",
@@ -40,7 +40,7 @@ IF_FEATURES = {
         "AS_SOR",
     ],
 }
-"""Features used in the isolation forest model, keyed by variant type."""
+"""Features used by the v5 variant QC models, keyed by variant type."""
 
 
 def _variant_qc_root(

--- a/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
+++ b/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
@@ -2,7 +2,7 @@
 
 import argparse
 import logging
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import hail as hl
 from gnomad.utils.sparse_mt import split_info_annotation
@@ -20,7 +20,7 @@ logger.setLevel(logging.INFO)
 
 
 def import_variant_qc_vcf(
-    vcf_path: str,
+    vcf_path: Union[str, List[str]],
     model_id: str,
     num_partitions: int = 5000,
     import_header_path: Optional[str] = None,
@@ -31,7 +31,8 @@ def import_variant_qc_vcf(
     """
     Import variant QC result sites VCF into a HT.
 
-    :param vcf_path: Path to variant QC result sites VCF. Can be Hadoop glob patterns.
+    :param vcf_path: Path(s) to variant QC result sites VCF(s). Can be a Hadoop glob
+        pattern or a list of paths.
     :param model_id: Model ID. Must start with ``rf_``, ``vqsr_``, or ``if_``.
     :param num_partitions: Number of partitions for the output HT.
     :param import_header_path: Optional header file to use for import.

--- a/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
+++ b/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
@@ -119,7 +119,9 @@ def import_variant_qc_vcf(
         unsplit_ht = None
         split_ht = ht
 
-    split_ht = split_ht.checkpoint(hl.utils.new_temp_file("split_vcq_result", "ht"))
+    # `ht` is already materialized at `tmp_path`; only checkpoint if it was changed.
+    if not is_split or deduplicate_check:
+        split_ht = split_ht.checkpoint(hl.utils.new_temp_file("split_vcq_result", "ht"))
     split_count = split_ht.count()
     if unsplit_count is None:
         logger.info("Found %s split variants in the VCF.", split_count)

--- a/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
+++ b/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
@@ -1,0 +1,243 @@
+"""Script to load variant QC result VCF into a Hail Table."""
+
+import argparse
+import logging
+from typing import Optional, Tuple, Union
+
+import hail as hl
+from gnomad.utils.sparse_mt import split_info_annotation
+
+from gnomad_qc.v5.resources.basics import (
+    _check_resource_existence,
+    _get_batch_resource_kwargs,
+    _init_hail,
+)
+from gnomad_qc.v5.resources.variant_qc import IF_FEATURES, get_variant_qc_result
+
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger = logging.getLogger("import_variant_qc_vcf")
+logger.setLevel(logging.INFO)
+
+
+def import_variant_qc_vcf(
+    vcf_path: str,
+    model_id: str,
+    num_partitions: int = 5000,
+    import_header_path: Optional[str] = None,
+    array_elements_required: bool = False,
+    is_split: bool = False,
+    deduplicate_check: bool = False,
+) -> Union[hl.Table, Tuple[hl.Table, hl.Table]]:
+    """
+    Import variant QC result sites VCF into a HT.
+
+    :param vcf_path: Path to variant QC result sites VCF. Can be Hadoop glob patterns.
+    :param model_id: Model ID. Must start with ``rf_``, ``vqsr_``, or ``if_``.
+    :param num_partitions: Number of partitions for the output HT.
+    :param import_header_path: Optional header file to use for import.
+    :param array_elements_required: Value passed to hl.import_vcf.
+    :param is_split: Whether the VCF is already split.
+    :param deduplicate_check: Whether to remove duplicate variants.
+    :return: HT (or split, unsplit HTs) containing variant QC results.
+    """
+    model_type = model_id.split("_")[0]
+    if model_type not in ["rf", "vqsr", "if"]:
+        raise ValueError(
+            f"Model ID must start with 'rf_', 'vqsr_', or 'if_', but got {model_id}"
+        )
+
+    logger.info(
+        "Importing variant QC annotations for model %s (array_elements_required=%s)...",
+        model_id,
+        array_elements_required,
+    )
+    ht = hl.import_vcf(
+        vcf_path,
+        force_bgz=True,
+        reference_genome="GRCh38",
+        array_elements_required=array_elements_required,
+        header_file=import_header_path,
+    ).rows()
+
+    # Read back with `_n_partitions` to repartition off the table index (no shuffle).
+    tmp_path = hl.utils.new_temp_file("imported_vcq_result", "ht")
+    ht.write(tmp_path)
+    ht = hl.read_table(tmp_path, _n_partitions=num_partitions)
+
+    if deduplicate_check:
+        dup_ht = ht.group_by(ht.locus, ht.alleles).aggregate(n=hl.agg.count())
+        dup_ht = dup_ht.filter(dup_ht.n > 1)
+        n_dup = dup_ht.count()
+        if n_dup > 0:
+            # NOTE: distinct() only drops fully-identical rows; duplicate keys with
+            # differing fields will survive and break split_multi_hts downstream.
+            logger.warning(
+                "Found %s variants with duplicate keys; keeping distinct rows. "
+                "Examples: %s",
+                n_dup,
+                [(e.locus, e.alleles) for e in dup_ht.take(5)],
+            )
+            ht = ht.distinct()
+        else:
+            logger.info("No duplicate variants found.")
+
+    unsplit_count = None
+    if not is_split:
+        if model_type == "vqsr":
+            as_vqslod_expr = {"AS_VQSLOD": ht.info.AS_VQSLOD.map(lambda x: hl.float(x))}
+        else:
+            as_vqslod_expr = {}
+        # TODO: Confirm AS_QUALapprox/AS_VarDP/AS_SB_TABLE are present and pipe-delimited
+        # in the v5 info VCF (this reformatting is carried over from v4).
+        ht = ht.annotate(
+            info=ht.info.annotate(
+                **as_vqslod_expr,
+                AS_QUALapprox=ht.info.AS_QUALapprox.split("\|")[1:].map(
+                    lambda x: hl.int(x)
+                ),
+                AS_VarDP=ht.info.AS_VarDP.split("\|")[1:].map(lambda x: hl.int(x)),
+                AS_SB_TABLE=ht.info.AS_SB_TABLE.split("\|").map(
+                    lambda x: hl.or_missing(
+                        x != "", x.split(",").map(lambda y: hl.int(y))
+                    )
+                ),
+            )
+        )
+
+        unsplit_ht = ht.checkpoint(hl.utils.new_temp_file("unsplit_vcq_result", "ht"))
+        unsplit_count = unsplit_ht.count()
+        split_ht = hl.split_multi_hts(unsplit_ht)
+        split_ht = split_ht.annotate(
+            info=split_ht.info.annotate(
+                **split_info_annotation(split_ht.info, split_ht.a_index)
+            ),
+        )
+    else:
+        unsplit_ht = None
+        split_ht = ht
+
+    split_ht = split_ht.checkpoint(hl.utils.new_temp_file("split_vcq_result", "ht"))
+    split_count = split_ht.count()
+    if unsplit_count is None:
+        logger.info("Found %s split variants in the VCF.", split_count)
+    else:
+        logger.info(
+            "Found %s unsplit and %s split variants in the VCF.",
+            unsplit_count,
+            split_count,
+        )
+
+    if unsplit_ht is None:
+        return split_ht
+    else:
+        return split_ht, unsplit_ht
+
+
+def main(args):
+    """Load a single variant QC result VCF into a Hail Table."""
+    environment = args.environment
+    _init_hail(
+        "import_variant_qc_vcf",
+        environment,
+        **_get_batch_resource_kwargs(args),
+    )
+
+    hts = import_variant_qc_vcf(
+        args.vcf_path,
+        args.model_id,
+        args.n_partitions,
+        args.header_path,
+        args.array_elements_required,
+        args.is_split,
+        args.deduplication_check,
+    )
+    if not isinstance(hts, tuple):
+        hts = (hts,)
+        splits = (True,)
+    else:
+        splits = (True, False)
+
+    for ht, split in zip(hts, splits):
+        res = get_variant_qc_result(
+            args.model_id, test=args.test, split=split, environment=environment
+        )
+        _check_resource_existence(
+            environment=environment,
+            output_step_resources={"variant_qc_result": [res]},
+            overwrite=args.overwrite,
+        )
+        ht = ht.annotate_globals(
+            model_id=args.model_id,
+            snp_features=args.snp_features,
+            indel_features=args.indel_features,
+        )
+        ht.write(res.path, overwrite=args.overwrite)
+
+
+def get_script_argument_parser() -> argparse.ArgumentParser:
+    """Get script argument parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o",
+        "--overwrite",
+        help="Whether to overwrite data already present in the output Table.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test", help="Whether to use a tmp path for output.", action="store_true"
+    )
+    parser.add_argument(
+        "--environment",
+        help="Compute environment.",
+        default="batch",
+        type=str,
+        choices=["rwb", "batch", "dataproc"],
+    )
+    parser.add_argument(
+        "--vcf-path",
+        help="Path to variant QC result VCF. Can be Hadoop glob patterns.",
+        required=True,
+    )
+    parser.add_argument(
+        "--model-id", help="Model ID for the result HT.", type=str, required=True
+    )
+    parser.add_argument(
+        "--n-partitions",
+        help="Number of partitions for the output Table.",
+        default=5000,
+        type=int,
+    )
+    parser.add_argument("--header-path", help="Optional header file to use for import.")
+    parser.add_argument(
+        "--array-elements-required",
+        action="store_true",
+        help="Set array_elements_required=True in import_vcf.",
+    )
+    parser.add_argument(
+        "--is-split", action="store_true", help="Whether the VCF is already split."
+    )
+    parser.add_argument(
+        "--deduplication-check",
+        action="store_true",
+        help="Remove duplicate variants (for overlapping shards).",
+    )
+    parser.add_argument(
+        "--snp-features",
+        help="SNP model features (stored as a global).",
+        default=IF_FEATURES["snv"],
+        type=str,
+        nargs="+",
+    )
+    parser.add_argument(
+        "--indel-features",
+        help="Indel model features (stored as a global).",
+        default=IF_FEATURES["indel"],
+        type=str,
+        nargs="+",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_script_argument_parser()
+    main(parser.parse_args())

--- a/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
+++ b/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
@@ -12,7 +12,7 @@ from gnomad_qc.v5.resources.basics import (
     _get_batch_resource_kwargs,
     _init_hail,
 )
-from gnomad_qc.v5.resources.variant_qc import IF_FEATURES, get_variant_qc_result
+from gnomad_qc.v5.resources.variant_qc import VARIANT_QC_FEATURES, get_variant_qc_result
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger("import_variant_qc_vcf")
@@ -88,10 +88,9 @@ def import_variant_qc_vcf(
             as_vqslod_expr = {"AS_VQSLOD": ht.info.AS_VQSLOD.map(lambda x: hl.float(x))}
         else:
             as_vqslod_expr = {}
-        # Reformat the pipe/comma-delimited AS fields when present. They may be absent
-        # (e.g. stripped by the isolation forest v4-test reheader, whose v4 encoding
-        # breaks import_vcf) and are not required for the variant QC result.
-        # TODO: Confirm these are present and pipe-delimited in the v5 info VCF.
+        # Reformat the pipe-delimited AS fields. This branch is v4-only: v4 exports them
+        # pipe-delimited (adjust_vcf_incompatible_types default) while v5 passes
+        # pipe_delimited_annotations=[]. Guards allow for fields absent from the input.
         reformat_expr = {}
         if "AS_QUALapprox" in ht.info:
             reformat_expr["AS_QUALapprox"] = ht.info.AS_QUALapprox.split("\|")[1:].map(
@@ -117,9 +116,20 @@ def import_variant_qc_vcf(
         )
     else:
         unsplit_ht = None
-        split_ht = ht
+        # Number=A fields import as length-1 arrays on split input; index to scalars
+        # (split_info_annotation does this via a_index on the unsplit path).
+        split_ht = ht.annotate(
+            info=ht.info.annotate(
+                **{
+                    f: ht.info[f][0]
+                    for f, t in ht.info.dtype.items()
+                    if f.startswith("AS_") and isinstance(t, hl.tarray)
+                }
+            )
+        )
 
-    # `ht` is already materialized at `tmp_path`; only checkpoint if it was changed.
+    # `ht` is already materialized at `tmp_path`; only checkpoint if it was changed
+    # (the split-path scalar indexing is cheap enough to recompute).
     if not is_split or deduplicate_check:
         split_ht = split_ht.checkpoint(hl.utils.new_temp_file("split_vcq_result", "ht"))
     split_count = split_ht.count()
@@ -264,14 +274,14 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--snp-features",
         help="SNP model features (stored as a global).",
-        default=IF_FEATURES["snv"],
+        default=VARIANT_QC_FEATURES["snv"],
         type=str,
         nargs="+",
     )
     parser.add_argument(
         "--indel-features",
         help="Indel model features (stored as a global).",
-        default=IF_FEATURES["indel"],
+        default=VARIANT_QC_FEATURES["indel"],
         type=str,
         nargs="+",
     )

--- a/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
+++ b/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
@@ -88,22 +88,24 @@ def import_variant_qc_vcf(
             as_vqslod_expr = {"AS_VQSLOD": ht.info.AS_VQSLOD.map(lambda x: hl.float(x))}
         else:
             as_vqslod_expr = {}
-        # TODO: Confirm AS_QUALapprox/AS_VarDP/AS_SB_TABLE are present and pipe-delimited
-        # in the v5 info VCF (this reformatting is carried over from v4).
-        ht = ht.annotate(
-            info=ht.info.annotate(
-                **as_vqslod_expr,
-                AS_QUALapprox=ht.info.AS_QUALapprox.split("\|")[1:].map(
-                    lambda x: hl.int(x)
-                ),
-                AS_VarDP=ht.info.AS_VarDP.split("\|")[1:].map(lambda x: hl.int(x)),
-                AS_SB_TABLE=ht.info.AS_SB_TABLE.split("\|").map(
-                    lambda x: hl.or_missing(
-                        x != "", x.split(",").map(lambda y: hl.int(y))
-                    )
-                ),
+        # Reformat the pipe/comma-delimited AS fields when present. They may be absent
+        # (e.g. stripped by the isolation forest v4-test reheader, whose v4 encoding
+        # breaks import_vcf) and are not required for the variant QC result.
+        # TODO: Confirm these are present and pipe-delimited in the v5 info VCF.
+        reformat_expr = {}
+        if "AS_QUALapprox" in ht.info:
+            reformat_expr["AS_QUALapprox"] = ht.info.AS_QUALapprox.split("\|")[1:].map(
+                lambda x: hl.int(x)
             )
-        )
+        if "AS_VarDP" in ht.info:
+            reformat_expr["AS_VarDP"] = ht.info.AS_VarDP.split("\|")[1:].map(
+                lambda x: hl.int(x)
+            )
+        if "AS_SB_TABLE" in ht.info:
+            reformat_expr["AS_SB_TABLE"] = ht.info.AS_SB_TABLE.split("\|").map(
+                lambda x: hl.or_missing(x != "", x.split(",").map(lambda y: hl.int(y)))
+            )
+        ht = ht.annotate(info=ht.info.annotate(**as_vqslod_expr, **reformat_expr))
 
         unsplit_ht = ht.checkpoint(hl.utils.new_temp_file("unsplit_vcq_result", "ht"))
         unsplit_count = unsplit_ht.count()

--- a/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
+++ b/gnomad_qc/v5/variant_qc/import_variant_qc_vcf.py
@@ -70,8 +70,8 @@ def import_variant_qc_vcf(
         dup_ht = dup_ht.filter(dup_ht.n > 1)
         n_dup = dup_ht.count()
         if n_dup > 0:
-            # NOTE: distinct() only drops fully-identical rows; duplicate keys with
-            # differing fields will survive and break split_multi_hts downstream.
+            # NOTE: distinct() keeps one arbitrary row per key, so if shards disagree
+            # on INFO values the surviving row is non-deterministic.
             logger.warning(
                 "Found %s variants with duplicate keys; keeping distinct rows. "
                 "Examples: %s",
@@ -145,6 +145,22 @@ def main(args):
         **_get_batch_resource_kwargs(args),
     )
 
+    # An already-split input yields only the split HT; otherwise split and unsplit.
+    splits = (True,) if args.is_split else (True, False)
+    resources = [
+        get_variant_qc_result(
+            args.model_id, test=args.test, split=split, environment=environment
+        )
+        for split in splits
+    ]
+    # Check up front so a rerun fails before the import instead of after it, and
+    # never after the split HT has already been written.
+    _check_resource_existence(
+        environment=environment,
+        output_step_resources={"variant_qc_result": resources},
+        overwrite=args.overwrite,
+    )
+
     hts = import_variant_qc_vcf(
         args.vcf_path,
         args.model_id,
@@ -156,19 +172,8 @@ def main(args):
     )
     if not isinstance(hts, tuple):
         hts = (hts,)
-        splits = (True,)
-    else:
-        splits = (True, False)
 
-    for ht, split in zip(hts, splits):
-        res = get_variant_qc_result(
-            args.model_id, test=args.test, split=split, environment=environment
-        )
-        _check_resource_existence(
-            environment=environment,
-            output_step_resources={"variant_qc_result": [res]},
-            overwrite=args.overwrite,
-        )
+    for ht, res in zip(hts, resources):
         ht = ht.annotate_globals(
             model_id=args.model_id,
             snp_features=args.snp_features,
@@ -195,6 +200,36 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         default="batch",
         type=str,
         choices=["rwb", "batch", "dataproc"],
+    )
+    parser.add_argument(
+        "--app-name",
+        help="Job name for the batch/QoB backend.",
+        default=None,
+        type=str,
+    )
+    parser.add_argument(
+        "--driver-cores",
+        help="Number of driver cores (Batch only).",
+        default=None,
+        type=int,
+    )
+    parser.add_argument(
+        "--driver-memory",
+        help="Driver memory (Batch only).",
+        default=None,
+        type=str,
+    )
+    parser.add_argument(
+        "--worker-cores",
+        help="Number of worker cores (Batch only).",
+        default=None,
+        type=int,
+    )
+    parser.add_argument(
+        "--worker-memory",
+        help="Worker memory (Batch only).",
+        default=None,
+        type=str,
     )
     parser.add_argument(
         "--vcf-path",

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -14,6 +14,7 @@ import hail as hl
 import hailtop.batch as hb
 from gnomad.resources.grch38.reference_data import telomeres_and_centromeres
 from gnomad.utils.file_utils import file_exists
+from gnomad.utils.vcf import adjust_vcf_incompatible_types
 from hailtop.batch.job import Job
 
 from gnomad_qc.v5.resources.annotations import get_true_positive_vcf_path, info_vcf_path
@@ -92,13 +93,15 @@ def _resource_args(mode: str, singletons_vcf: Optional[str]) -> str:
 
 def _annotation_args(features: List[str]) -> str:
     """
-    Build the GATK ``-A`` annotation args from a feature list.
+    Build the GATK ``-A`` (``--annotation``) args from a feature list.
 
     .. note::
 
-        AS annotations must have ``Number=A`` in the VCF header; GATK infers
-        allele-specific mode from that (the ``--use-allele-specific-annotations`` flag
-        was replaced by this header check in GATK 4.5.0.0).
+        GATK infers allele-specific mode from ``Number=A`` on any requested annotation's
+        header line (``LabeledVariantAnnotationsWalker.isAlleleSpecificAnnotationRequested``);
+        the ``--use-allele-specific-annotations`` flag was dropped in GATK 4.5.0.0. AS
+        mode also forces ``START_POSITION_AND_MINIMAL_REPRESENTATION`` resource matching,
+        so the header matters even on split input.
     """
     return " ".join(f"-A {f}" for f in features)
 
@@ -467,6 +470,46 @@ def export_exclusion_intervals(out_path: str) -> str:
     return out_path
 
 
+def export_v4_test_sites_vcf(contigs: List[str], out_path: str) -> None:
+    """
+    Export the v4 split info HT, filtered to ``contigs``, as a GATK-readable sites VCF.
+
+    v4's ``--export-split-info-vcf`` output is misnamed: it is exported from the unsplit
+    info HT, so it cannot stand in for the split v5 info VCF. Read the split info HT
+    directly instead.
+
+    :param contigs: Contigs to keep.
+    :param out_path: Destination VCF path.
+    :return: None.
+    """
+    from gnomad_qc.v4.annotations.generate_variant_qc_annotations import (
+        get_reformatted_info_fields,
+    )
+    from gnomad_qc.v4.resources.annotations import get_info as get_v4_info
+
+    ht = get_v4_info(split=True).ht()
+    ht = hl.filter_intervals(
+        ht, [hl.parse_locus_interval(c, reference_genome="GRCh38") for c in contigs]
+    )
+    ht = get_reformatted_info_fields(ht, info_method="quasi")
+    ht = ht.select(info=ht.site_info.annotate(**ht.quasi_info))
+    # split_info_annotation leaves the AS_ fields as scalars and AS_SB_TABLE as a flat
+    # array, both of which break adjust_vcf_incompatible_types' pipe-delimiting.
+    # AS_SB_TABLE is not an iforest feature, so drop it and skip pipe-delimiting.
+    if "AS_SB_TABLE" in ht.info:
+        ht = ht.annotate(info=ht.info.drop("AS_SB_TABLE"))
+    ht = adjust_vcf_incompatible_types(ht, pipe_delimited_annotations=[])
+    # Declare the features Number=A so GATK runs in allele-specific mode; Hail would
+    # write Number=1 for these split scalars. See `_annotation_args`.
+    metadata = {
+        "info": {
+            f: {"Number": "A", "Type": "Float", "Description": ""}
+            for f in VARIANT_QC_FEATURES["snv"]
+        }
+    }
+    hl.export_vcf(ht, out_path, tabix=True, metadata=metadata)
+
+
 def run_batch(b: hb.Batch, description: str) -> None:
     """
     Run a Batch to completion and raise if it did not succeed.
@@ -634,7 +677,6 @@ def main(args):
         from gnomad_qc.v4.resources.annotations import (
             get_true_positive_vcf_path as v4_get_true_positive_vcf_path,
         )
-        from gnomad_qc.v4.resources.annotations import info_vcf_path as v4_info_vcf_path
 
         run_prefix = f"gs://{BATCH_TMP_BUCKET}/if_v4_test/{model_id}"
         result_ht_path = f"{run_prefix}/gnomad.exomes.v4.0.{model_id}.result.ht"
@@ -645,8 +687,9 @@ def main(args):
             if true_positive_type
             else None
         )
-        # Use the split v4 info VCF for consistency with the v5 info VCF.
-        sites_only_vcf = v4_info_vcf_path(info_method="quasi", split=True)
+        # v4's info_vcf_path(split=True) is misnamed (exported from the unsplit info
+        # HT), so export our own split sites VCF via --export-v4-test-vcf.
+        sites_only_vcf = f"{run_prefix}/v4_test_sites.vcf.bgz"
     else:
         sites_only_vcf = info_vcf_path(test=test, environment=environment)
         singletons_vcf = (
@@ -668,6 +711,16 @@ def main(args):
 
     # Stable path so the same file used by GATK -XL is read back during reconciliation.
     exclude_intervals = f"{run_prefix}/exclude.intervals"
+
+    if args.export_v4_test_vcf:
+        if not args.test_on_v4:
+            raise ValueError("--export-v4-test-vcf requires --test-on-v4.")
+        _check_resource_existence(
+            environment=environment,
+            output_step_resources={"v4_test_sites_vcf": [sites_only_vcf]},
+            overwrite=args.overwrite,
+        )
+        export_v4_test_sites_vcf(contigs, sites_only_vcf)
 
     # Fail fast before the Batch if an input is missing. sites_only_vcf is checked
     # unconditionally because reconcile_scored_sites reads it on --load-only runs too.
@@ -757,6 +810,14 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--test-on-v4",
         help="Use gnomAD v4 sites/true-positive VCFs as inputs (v5 data unavailable).",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--export-v4-test-vcf",
+        help=(
+            "Export the v4 split info HT filtered to --test-chrom as the --test-on-v4 "
+            "sites VCF. Requires --test-on-v4."
+        ),
         action="store_true",
     )
     parser.add_argument(

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -14,6 +14,7 @@ import hail as hl
 import hailtop.batch as hb
 from gnomad.resources.grch38.reference_data import telomeres_and_centromeres
 from gnomad.utils.file_utils import file_exists
+from gnomad.variant_qc.pipeline import INFO_FEATURES
 from hailtop.batch.job import Job
 
 from gnomad_qc.v5.resources.annotations import get_true_positive_vcf_path, info_vcf_path
@@ -74,7 +75,15 @@ def _resource_args(mode: str, singletons_vcf: Optional[str]) -> str:
 
 
 def _annotation_args(features: List[str]) -> str:
-    """Build the GATK ``-A`` annotation args from a feature list."""
+    """
+    Build the GATK ``-A`` annotation args from a feature list.
+
+    .. note::
+
+        AS annotations must have ``Number=A`` in the VCF header; GATK infers
+        allele-specific mode from that (the ``--use-allele-specific-annotations`` flag
+        was replaced by this header check in GATK 4.5.0.0).
+    """
     return " ".join(f"-A {f}" for f in features)
 
 
@@ -84,6 +93,7 @@ def extract_variant_annotations_job(
     sites_only_vcf: str,
     features: List[str],
     resource_args: str,
+    calling_intervals_arg: str,
     out_root: str,
     gatk_image: str,
     gcp_billing_project: str,
@@ -96,6 +106,7 @@ def extract_variant_annotations_job(
     :param sites_only_vcf: AS-annotated sites-only input VCF.
     :param features: Features to extract for this mode.
     :param resource_args: GATK ``--resource`` args for the labeled sets.
+    :param calling_intervals_arg: GATK ``-L`` args restricting the extracted sites.
     :param out_root: Output prefix (files written as ``{out_root}.*``).
     :param gatk_image: GATK docker image.
     :param gcp_billing_project: GCP billing project for requester-pays buckets.
@@ -120,7 +131,7 @@ def extract_variant_annotations_job(
             -O {j.extract} \\
             --mode {mode} \\
             {_annotation_args(features)} \\
-            --use-allele-specific-annotations \\
+            {calling_intervals_arg} \\
             --gcs-project-for-requester-pays {gcp_billing_project} \\
             {resource_args}
         """
@@ -281,7 +292,6 @@ def score_variant_annotations_job(
             --resource:extracted,extracted=true {extracted_vcf} \\
             --model-prefix {model} \\
             --model-backend PYTHON_IFOREST \\
-            --use-allele-specific-annotations \\
             -L {interval} \\
             --gcs-project-for-requester-pays {gcp_billing_project} \\
             {resource_args}
@@ -358,6 +368,7 @@ def isolation_forest_workflow(
                 sites_only_vcf=sites_only_vcf,
                 features=features,
                 resource_args=resource_args,
+                calling_intervals_arg=calling_intervals_arg,
                 out_root=extract_root,
                 gatk_image=gatk_image,
                 gcp_billing_project=gcp_billing_project,
@@ -420,6 +431,38 @@ def export_exclusion_intervals() -> str:
     path = hl.utils.new_temp_file("telomeres_centromeres", "intervals")
     ht.export(path, header=False)
     return path
+
+
+def reheader_v4_sites_to_chr22(raw_vcf: str, out_path: str) -> str:
+    """
+    Write a chr22 copy of a v4 sites VCF with AS features declared ``Number=A``.
+
+    The published v4 info VCF declares AS annotations ``Number=.``; GATK's isolation
+    forest needs ``Number=A`` to enter allele-specific mode. The data is already one
+    value per ALT allele, so only the header changes. Filtering to chr22 keeps this
+    test-only re-export cheap.
+
+    :param raw_vcf: Path to the v4 sites VCF.
+    :param out_path: Output path for the reheadered chr22 VCF.
+    :return: ``out_path``.
+    """
+    ht = hl.import_vcf(
+        raw_vcf,
+        force_bgz=True,
+        reference_genome="GRCh38",
+        array_elements_required=False,
+    ).rows()
+    ht = hl.filter_intervals(
+        ht, [hl.parse_locus_interval("chr22", reference_genome="GRCh38")]
+    )
+    metadata = {
+        "info": {
+            f: {"Number": "A", "Type": "Float", "Description": ""}
+            for f in INFO_FEATURES
+        }
+    }
+    hl.export_vcf(ht, out_path, tabix=True, metadata=metadata)
+    return out_path
 
 
 def merge_iforest_result(
@@ -491,8 +534,9 @@ def main(args):
 
     test = args.test
     model_id = args.model_id
-    scatter_count = 10 if test else args.scatter_count
-    contigs = ["chr22"] if test else CALLING_CONTIGS
+    chr22_only = test or args.test_on_v4
+    scatter_count = 10 if chr22_only else args.scatter_count
+    contigs = ["chr22"] if chr22_only else CALLING_CONTIGS
     calling_intervals_arg = " ".join(f"-L {c}" for c in contigs)
 
     true_positive_type = None
@@ -510,7 +554,8 @@ def main(args):
         )
         from gnomad_qc.v4.resources.annotations import info_vcf_path as v4_info_vcf_path
 
-        sites_only_vcf = v4_info_vcf_path(info_method="quasi")
+        run_prefix = f"gs://{BATCH_TMP_BUCKET}/if_v4_test/{model_id}"
+        result_ht_path = f"{run_prefix}/gnomad.exomes.v4.0.{model_id}.result.ht"
         singletons_vcf = (
             v4_get_true_positive_vcf_path(
                 adj=args.adj, true_positive_type=true_positive_type
@@ -518,8 +563,16 @@ def main(args):
             if true_positive_type
             else None
         )
-        run_prefix = f"gs://{BATCH_TMP_BUCKET}/if_v4_test/{model_id}"
-        result_ht_path = f"{run_prefix}/gnomad.exomes.v4.0.{model_id}.result.ht"
+        # The published v4 info VCF declares AS fields Number=.; reheader a chr22 copy
+        # to Number=A so GATK enters allele-specific mode.
+        sites_only_vcf = (
+            reheader_v4_sites_to_chr22(
+                v4_info_vcf_path(info_method="quasi"),
+                f"{run_prefix}/reheader/{model_id}.chr22.sites.vcf.bgz",
+            )
+            if not args.load_only
+            else None
+        )
     else:
         sites_only_vcf = info_vcf_path(test=test, environment=environment)
         singletons_vcf = (

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -889,7 +889,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--model-id",
-        help="Model ID for the isolation forest run. Must start with 'if_'.",
+        help="Model ID for the isolation forest run. Must start with 'if' (e.g. if_test1).",
         type=str,
         required=True,
     )

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -200,6 +200,7 @@ def split_intervals_job(
     calling_intervals_arg: str,
     exclude_intervals: str,
     scatter_count: int,
+    out_root: str,
     gatk_image: str,
     gcp_billing_project: str,
 ) -> Job:
@@ -210,6 +211,7 @@ def split_intervals_job(
     :param calling_intervals_arg: GATK ``-L`` args covering the calling contigs.
     :param exclude_intervals: Path to an intervals file to exclude (``-XL``).
     :param scatter_count: Number of interval shards to produce.
+    :param out_root: Bucket prefix to persist the interval files to (for reconciliation).
     :param gatk_image: GATK docker image.
     :param gcp_billing_project: GCP billing project for requester-pays buckets.
     :return: Job with output ResourceGroup ``intervals``.
@@ -237,6 +239,7 @@ def split_intervals_job(
             --gcs-project-for-requester-pays {gcp_billing_project}
         """
     )
+    b.write_output(j.intervals, out_root)
     return j
 
 
@@ -274,12 +277,13 @@ def score_variant_annotations_job(
     j.cpu(4)
     j.memory("standard")
     j.storage("100G")
+    # Only the scored VCF is used downstream. GATK writes .annot.hdf5/.scores.hdf5 only
+    # when the interval has variants, so requiring them fails empty shards (e.g. chr22
+    # p-arm). Silent under-scoring is caught by reconcile_scored_sites in the load step.
     j.declare_resource_group(
         output_score={
             "vcf.gz": "{root}.vcf.gz",
             "vcf.gz.tbi": "{root}.vcf.gz.tbi",
-            "annot.hdf5": "{root}.annot.hdf5",
-            "scores.hdf5": "{root}.scores.hdf5",
         }
     )
     j.command(
@@ -339,6 +343,7 @@ def isolation_forest_workflow(
         calling_intervals_arg=calling_intervals_arg,
         exclude_intervals=exclude_intervals,
         scatter_count=scatter_count,
+        out_root=f"{run_prefix}/intervals",
         gatk_image=gatk_image,
         gcp_billing_project=gcp_billing_project,
     ).intervals
@@ -527,6 +532,53 @@ def merge_iforest_result(
     )
 
 
+def reconcile_scored_sites(
+    sites_only_vcf: str,
+    intervals_path: str,
+    scored_ht: hl.Table,
+    array_elements_required: bool = False,
+) -> None:
+    """
+    Raise if any input locus in the scored region is missing from the scored output.
+
+    GATK ScoreVariantAnnotations emits every input variant within its interval, so every
+    input locus inside the SplitIntervals regions must appear in the merged output. Any
+    that do not were silently dropped (e.g. a shard that under-emitted), which this
+    catches even for a small contiguous chunk. Reconciliation is at the locus level
+    since a dropped region removes whole loci.
+
+    :param sites_only_vcf: Input sites VCF that was scored.
+    :param intervals_path: Glob of the SplitIntervals ``.interval_list`` files defining
+        the scored region.
+    :param scored_ht: Merged scored result HT.
+    :param array_elements_required: Value passed to hl.import_vcf for the input.
+    :return: None.
+    """
+    intervals_ht = hl.import_locus_intervals(intervals_path, reference_genome="GRCh38")
+    input_ht = hl.import_vcf(
+        sites_only_vcf,
+        force_bgz=True,
+        reference_genome="GRCh38",
+        array_elements_required=array_elements_required,
+    ).rows()
+    input_loci = (
+        input_ht.filter(hl.is_defined(intervals_ht[input_ht.locus]))
+        .key_by("locus")
+        .select()
+        .distinct()
+    )
+    missing = input_loci.anti_join(scored_ht.key_by("locus").select().distinct())
+    n_missing = missing.count()
+    if n_missing > 0:
+        raise ValueError(
+            f"{n_missing} input loci in the scored region are missing from the scored "
+            f"output (silently dropped). Examples: {[m.locus for m in missing.take(5)]}"
+        )
+    logger.info(
+        "Reconciliation passed: all input loci in the scored region are present."
+    )
+
+
 def main(args):
     """Run the isolation forest variant QC workflow."""
     environment = args.environment
@@ -563,16 +615,13 @@ def main(args):
             if true_positive_type
             else None
         )
+        sites_only_vcf = f"{run_prefix}/reheader/{model_id}.chr22.sites.vcf.bgz"
         # The published v4 info VCF declares AS fields Number=.; reheader a chr22 copy
         # to Number=A so GATK enters allele-specific mode.
-        sites_only_vcf = (
+        if not args.load_only:
             reheader_v4_sites_to_chr22(
-                v4_info_vcf_path(info_method="quasi"),
-                f"{run_prefix}/reheader/{model_id}.chr22.sites.vcf.bgz",
+                v4_info_vcf_path(info_method="quasi"), sites_only_vcf
             )
-            if not args.load_only
-            else None
-        )
     else:
         sites_only_vcf = info_vcf_path(test=test, environment=environment)
         singletons_vcf = (
@@ -623,6 +672,12 @@ def main(args):
             scatter_count=scatter_count,
             n_partitions=args.n_partitions,
             header_path=args.header_path,
+            array_elements_required=args.array_elements_required,
+        )
+        reconcile_scored_sites(
+            sites_only_vcf=sites_only_vcf,
+            intervals_path=f"{run_prefix}/intervals/*.interval_list",
+            scored_ht=ht,
             array_elements_required=args.array_elements_required,
         )
         ht.write(result_ht_path, overwrite=args.overwrite)

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -14,7 +14,6 @@ import hail as hl
 import hailtop.batch as hb
 from gnomad.resources.grch38.reference_data import telomeres_and_centromeres
 from gnomad.utils.file_utils import file_exists
-from gnomad.variant_qc.pipeline import INFO_FEATURES
 from hailtop.batch.job import Job
 
 from gnomad_qc.v5.resources.annotations import get_true_positive_vcf_path, info_vcf_path
@@ -459,68 +458,12 @@ def export_exclusion_intervals(out_path: str) -> str:
     return out_path
 
 
-def reheader_v4_sites_job(
-    b: hb.Batch,
-    raw_vcf: str,
-    out_root: str,
-    contigs: List[str],
-    image: str,
-    gcp_billing_project: str,
-) -> Job:
-    """
-    Reheader a v4 sites VCF for the isolation forest and strip fields Hail can't import.
-
-    Streams the VCF: rewrites the AS-float ``##INFO`` header lines to ``Number=A`` (GATK
-    needs this to enter allele-specific mode), keeps records on ``contigs``, and passes
-    kept fields through untouched (no re-typing).
-
-    .. note::
-
-        AS_SB_TABLE / SB / AS_QUALapprox / AS_VarDP are stripped: these strand-bias /
-        count-table and pipe-delimited fields have a v4 encoding (comma values under a
-        scalar Number) that breaks Hail's ``import_vcf`` in the load step, and they are
-        not needed for the iforest result. Stopgap for the v4 test; revisit if a real
-        run needs them (see the reformatting TODO in ``import_variant_qc_vcf``).
-
-    :param b: Batch to add the job to.
-    :param raw_vcf: gs:// path to the v4 sites VCF (requester-pays).
-    :param out_root: Output prefix; writes ``{out_root}.vcf.gz`` and ``.vcf.gz.tbi``.
-    :param contigs: Contigs to keep.
-    :param image: Image providing gsutil, bcftools, and tabix.
-    :param gcp_billing_project: GCP project for requester-pays reads.
-    :return: Job with output ResourceGroup ``out``.
-    """
-    j = b.new_job("Reheader v4 sites (Number=A)")
-    j.image(image)
-    j.cpu(2)
-    j.memory("standard")
-    j.storage("50G")
-    j.declare_resource_group(
-        out={"vcf.gz": "{root}.vcf.gz", "vcf.gz.tbi": "{root}.vcf.gz.tbi"}
-    )
-    as_fields = "|".join(INFO_FEATURES)
-    keep_contig = " || ".join(f'$1=="{c}"' for c in contigs)
-    strip_fields = "INFO/AS_SB_TABLE,INFO/SB,INFO/AS_QUALapprox,INFO/AS_VarDP"
-    j.command(
-        f"""set -euo pipefail
-        gsutil -u {gcp_billing_project} cat {raw_vcf} | zcat \\
-          | sed -E 's/(##INFO=<ID=({as_fields}),Number=)\\./\\1A/' \\
-          | awk -F'\\t' '/^#/ || {keep_contig}' \\
-          | bcftools annotate -x {strip_fields} -Oz -o {j.out['vcf.gz']} -
-        tabix -p vcf {j.out['vcf.gz']}
-        """
-    )
-    b.write_output(j.out, out_root)
-    return j
-
-
 def run_batch(b: hb.Batch, description: str) -> None:
     """
     Run a Batch to completion and raise if it did not succeed.
 
     ``Batch.run`` waits but only prints the final state, so a failed batch would
-    otherwise fall through to the next step (e.g. submitting the GATK jobs against a
-    reheadered VCF that was never written).
+    otherwise fall through to the next step.
 
     :param b: Batch to run.
     :param description: Batch description used in the error message.
@@ -579,7 +522,8 @@ def merge_iforest_result(
             header_path,
             array_elements_required,
             is_split=is_split,
-            deduplicate_check=True,
+            # Disjoint shards make duplicate keys impossible; the check costs a shuffle.
+            deduplicate_check=False,
         )
         # Only the split HT is used; the unsplit HT is returned when is_split is False.
         ht = hts[0] if isinstance(hts, tuple) else hts
@@ -616,17 +560,15 @@ def reconcile_scored_sites(
     exclude_intervals_path: str,
     scored_ht: hl.Table,
     array_elements_required: bool = False,
-    max_consecutive_missing: int = 100,
 ) -> None:
     """
-    Warn on input loci in the scored region absent from the output; fail on a contiguous run.
+    Raise if any input variant in the scored region is missing from the output or unscored.
 
-    The scored region is reconstructed from the same ``-L`` contigs and ``-XL`` exclusion
-    file GATK used. GATK skips sites it cannot score (all-missing annotations, mixed/MNP/
-    spanning-deletion types), so scattered absences are expected and only warned about.
-    A run of ``max_consecutive_missing`` input loci that are all absent with no scored
-    locus between them indicates a silently dropped region (e.g. a shard that
-    under-emitted) and raises.
+    GATK writes every input record within its interval to the scored VCF, so any variant
+    absent from the merged output was dropped (e.g. a truncated shard). GATK classifies
+    every allele as either SNP or INDEL, so every variant should also carry a SCORE.
+
+    Input and output are both split, so variants are compared on the full key.
 
     :param sites_only_vcf: Input sites VCF that was scored.
     :param contigs: Calling contigs passed to GATK (``-L``).
@@ -634,7 +576,6 @@ def reconcile_scored_sites(
         (``-XL``).
     :param scored_ht: Merged scored result HT.
     :param array_elements_required: Value passed to hl.import_vcf for the input.
-    :param max_consecutive_missing: Fail if this many consecutive input loci are absent.
     :return: None.
     """
     exclude_ht = hl.import_locus_intervals(
@@ -646,56 +587,29 @@ def reconcile_scored_sites(
         reference_genome="GRCh38",
         array_elements_required=array_elements_required,
     ).rows()
-    scored_loci = scored_ht.key_by("locus").select().distinct()
     contig_set = hl.literal(set(contigs))
-    input_loci = (
-        input_ht.filter(
-            contig_set.contains(input_ht.locus.contig)
-            & hl.is_missing(exclude_ht[input_ht.locus])
-        )
-        .key_by("locus")
-        .select()
-        .distinct()
-    )
-    input_loci = input_loci.annotate(
-        scored=hl.is_defined(scored_loci[input_loci.locus])
-    )
-    input_loci = input_loci.checkpoint(hl.utils.new_temp_file("reconcile", "ht"))
+    input_ht = input_ht.filter(
+        contig_set.contains(input_ht.locus.contig)
+        & hl.is_missing(exclude_ht[input_ht.locus])
+    ).select()
 
-    n_missing = input_loci.aggregate(hl.agg.count_where(~input_loci.scored))
-    if n_missing == 0:
-        logger.info(
-            "Reconciliation passed: all input loci in the scored region are present."
-        )
-        return
-
-    examples = [r.locus for r in input_loci.filter(~input_loci.scored).take(5)]
-    logger.warning(
-        "%s input loci in the scored region are absent from the scored output; GATK "
-        "skips unscoreable sites, so scattered absences are expected. Examples: %s",
-        n_missing,
-        examples,
-    )
-
-    # Consecutive absent loci sharing a scored-prefix count form one dropped run; a long
-    # run (vs isolated scattered drops) signals a silently dropped region.
-    input_loci = input_loci.annotate(run_id=hl.scan.sum(hl.int(input_loci.scored)))
-    missing_ht = input_loci.filter(~input_loci.scored)
-    runs = missing_ht.group_by(
-        contig=missing_ht.locus.contig, run_id=missing_ht.run_id
-    ).aggregate(run_len=hl.agg.count())
-    longest = runs.aggregate(hl.agg.max(runs.run_len))
-    if longest is not None and longest >= max_consecutive_missing:
+    missing = input_ht.anti_join(scored_ht.select())
+    n_missing = missing.count()
+    if n_missing > 0:
         raise ValueError(
-            f"Longest run of consecutive missing loci is {longest} "
-            f"(>= {max_consecutive_missing}); a contiguous region was likely dropped."
+            f"{n_missing} input variants in the scored region are missing from the "
+            f"scored output. Examples: {[(m.locus, m.alleles) for m in missing.take(5)]}"
         )
-    logger.info(
-        "Missing loci are scattered (longest consecutive run %s < %s); treating as "
-        "expected GATK drops.",
-        longest,
-        max_consecutive_missing,
-    )
+
+    unscored = hl.is_missing(scored_ht.info.SCORE)
+    n_unscored = scored_ht.aggregate(hl.agg.count_where(unscored))
+    if n_unscored > 0:
+        examples = scored_ht.filter(unscored).take(5)
+        raise ValueError(
+            f"{n_unscored} variants have no SCORE. Examples: "
+            f"{[(e.locus, e.alleles) for e in examples]}"
+        )
+    logger.info("Reconciliation passed: all input variants are present and scored.")
 
 
 def main(args):
@@ -740,13 +654,9 @@ def main(args):
             if true_positive_type
             else None
         )
-        # The published v4 info VCF declares AS fields Number=.; a header-only reheader
-        # (run below) sets them to Number=A so GATK enters allele-specific mode.
-        raw_sites_vcf = v4_info_vcf_path(info_method="quasi")
-        reheader_root = f"{run_prefix}/reheader/{model_id}.sites"
-        sites_only_vcf = f"{reheader_root}.vcf.gz"
+        # Use the split v4 info VCF for consistency with the v5 info VCF.
+        sites_only_vcf = v4_info_vcf_path(info_method="quasi", split=True)
     else:
-        raw_sites_vcf = None
         sites_only_vcf = info_vcf_path(test=test, environment=environment)
         singletons_vcf = (
             get_true_positive_vcf_path(
@@ -781,21 +691,6 @@ def main(args):
             billing_project=args.batch_billing_project,
             remote_tmpdir=f"gs://{BATCH_TMP_BUCKET}/",
         )
-        # Reheader the v4 input to Number=A first, to completion, so the GATK jobs read
-        # the finished VCF from the bucket. Reuse an existing reheadered VCF unless
-        # overwriting, since re-streaming the full v4 sites VCF is expensive.
-        if args.test_on_v4 and (args.overwrite or not file_exists(sites_only_vcf)):
-            rb = hb.Batch(f"reheader {model_id}{args.batch_suffix}", backend=backend)
-            reheader_v4_sites_job(
-                b=rb,
-                raw_vcf=raw_sites_vcf,
-                out_root=reheader_root,
-                contigs=contigs,
-                image=args.reheader_image or args.gatk_image,
-                gcp_billing_project=args.gcp_billing_project,
-            )
-            run_batch(rb, "Reheader")
-
         export_exclusion_intervals(exclude_intervals)
         b = hb.Batch(f"isolation forest {model_id}{args.batch_suffix}", backend=backend)
         isolation_forest_workflow(
@@ -823,16 +718,16 @@ def main(args):
             n_partitions=args.n_partitions,
             header_path=args.header_path,
             array_elements_required=args.array_elements_required,
-            is_split=not args.test_on_v4,
         )
+        # Write first, then reconcile the materialized HT so the merge is computed once.
+        ht.write(result_ht_path, overwrite=args.overwrite)
         reconcile_scored_sites(
             sites_only_vcf=sites_only_vcf,
             contigs=contigs,
             exclude_intervals_path=exclude_intervals,
-            scored_ht=ht,
+            scored_ht=hl.read_table(result_ht_path),
             array_elements_required=args.array_elements_required,
         )
-        ht.write(result_ht_path, overwrite=args.overwrite)
 
 
 def get_script_argument_parser() -> argparse.ArgumentParser:
@@ -899,15 +794,6 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         "--gatk-image",
         help="GATK docker image.",
         default=DEFAULT_GATK_IMAGE,
-        type=str,
-    )
-    parser.add_argument(
-        "--reheader-image",
-        help=(
-            "Image for the --test-on-v4 reheader job; must provide gsutil, bcftools, "
-            "and tabix. Defaults to --gatk-image, which provides all three."
-        ),
-        default=None,
         type=str,
     )
     parser.add_argument(

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -712,32 +712,41 @@ def main(args):
     # Stable path so the same file used by GATK -XL is read back during reconciliation.
     exclude_intervals = f"{run_prefix}/exclude.intervals"
 
+    if args.export_v4_test_vcf and not args.test_on_v4:
+        raise ValueError("--export-v4-test-vcf requires --test-on-v4.")
+
+    # Fail fast before the Batch if an input is missing. sites_only_vcf is checked
+    # unconditionally because reconcile_scored_sites reads it on --load-only runs too,
+    # unless this run exports it.
+    input_step_resources = {}
+    if not args.export_v4_test_vcf:
+        input_step_resources["sites_only_vcf"] = [sites_only_vcf]
+    if singletons_vcf and not args.load_only:
+        input_step_resources["singletons_vcf"] = [singletons_vcf]
+    if input_step_resources:
+        _check_resource_existence(
+            environment=environment, input_step_resources=input_step_resources
+        )
+
+    # Fail fast before the Batch if an output we'd write already exists.
     if args.export_v4_test_vcf:
-        if not args.test_on_v4:
-            raise ValueError("--export-v4-test-vcf requires --test-on-v4.")
         _check_resource_existence(
             environment=environment,
             output_step_resources={"v4_test_sites_vcf": [sites_only_vcf]},
             overwrite=args.overwrite,
         )
-        export_v4_test_sites_vcf(contigs, sites_only_vcf)
-
-    # Fail fast before the Batch if an input is missing. sites_only_vcf is checked
-    # unconditionally because reconcile_scored_sites reads it on --load-only runs too.
-    input_step_resources = {"sites_only_vcf": [sites_only_vcf]}
-    if singletons_vcf and not args.load_only:
-        input_step_resources["singletons_vcf"] = [singletons_vcf]
-    _check_resource_existence(
-        environment=environment, input_step_resources=input_step_resources
-    )
-
-    # Fail fast before the Batch if the result HT already exists and we'd load it.
     if args.load_iforest or args.load_only:
         _check_resource_existence(
             environment=environment,
             output_step_resources={"variant_qc_result": [result_ht_path]},
             overwrite=args.overwrite,
         )
+
+    if args.export_v4_test_vcf:
+        export_v4_test_sites_vcf(contigs, sites_only_vcf)
+        if args.export_only:
+            logger.info("Exported %s; stopping.", sites_only_vcf)
+            return
 
     if not args.load_only:
         backend = hb.ServiceBackend(
@@ -818,6 +827,11 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
             "Export the v4 split info HT filtered to --test-chrom as the --test-on-v4 "
             "sites VCF. Requires --test-on-v4."
         ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--export-only",
+        help="Stop after --export-v4-test-vcf instead of continuing to the Batch.",
         action="store_true",
     )
     parser.add_argument(

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -426,6 +426,7 @@ def merge_iforest_result(
     run_prefix: str,
     out_vcf_name: str,
     model_id: str,
+    scatter_count: int,
     n_partitions: int,
     header_path: Optional[str],
     array_elements_required: bool,
@@ -436,16 +437,28 @@ def merge_iforest_result(
     The SNP-pass VCF contributes SNP alleles and the INDEL-pass VCF contributes all
     non-SNP alleles, so the union covers every scored allele exactly once.
 
+    Only the current run's ``scatter_count`` shards are read (by explicit index), so a
+    rerun with a smaller scatter count does not pick up stale shards from a prior run.
+
     :param run_prefix: GCS prefix for this run's GATK outputs.
     :param out_vcf_name: Base name used for scored VCF shards.
     :param model_id: Isolation forest model ID (starts with ``if_``).
+    :param scatter_count: Number of score shards per mode (must match the scoring run).
     :param n_partitions: Number of partitions for the imported HTs.
     :param header_path: Optional VCF header file for import.
     :param array_elements_required: Value passed to hl.import_vcf.
     :return: Merged variant QC result HT.
     """
+    snp_vcfs = [
+        f"{run_prefix}/score/snp/{out_vcf_name}{idx}.vcf.gz"
+        for idx in range(scatter_count)
+    ]
+    indel_vcfs = [
+        f"{run_prefix}/score/indel/{out_vcf_name}{idx}.vcf.gz"
+        for idx in range(scatter_count)
+    ]
     snp_ht = import_variant_qc_vcf(
-        f"{run_prefix}/score/snp/{out_vcf_name}*.vcf.gz",
+        snp_vcfs,
         model_id,
         n_partitions,
         header_path,
@@ -453,7 +466,7 @@ def merge_iforest_result(
         deduplicate_check=True,
     )[0]
     indel_ht = import_variant_qc_vcf(
-        f"{run_prefix}/score/indel/{out_vcf_name}*.vcf.gz",
+        indel_vcfs,
         model_id,
         n_partitions,
         header_path,
@@ -554,6 +567,7 @@ def main(args):
             run_prefix=run_prefix,
             out_vcf_name=args.out_vcf_name,
             model_id=model_id,
+            scatter_count=scatter_count,
             n_partitions=args.n_partitions,
             header_path=args.header_path,
             array_elements_required=args.array_elements_required,

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -625,9 +625,9 @@ def reconcile_scored_sites(
     # run (vs isolated scattered drops) signals a silently dropped region.
     input_loci = input_loci.annotate(run_id=hl.scan.sum(hl.int(input_loci.scored)))
     missing_ht = input_loci.filter(~input_loci.scored)
-    runs = missing_ht.group_by(missing_ht.locus.contig, missing_ht.run_id).aggregate(
-        run_len=hl.agg.count()
-    )
+    runs = missing_ht.group_by(
+        contig=missing_ht.locus.contig, run_id=missing_ht.run_id
+    ).aggregate(run_len=hl.agg.count())
     longest = runs.aggregate(hl.agg.max(runs.run_len))
     if longest is not None and longest >= max_consecutive_missing:
         raise ValueError(
@@ -822,8 +822,8 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--reheader-image",
         help=(
-            "Image for the --test-on-v4 reheader job; must provide gsutil, bgzip, and "
-            "tabix. Defaults to --gatk-image."
+            "Image for the --test-on-v4 reheader job; must provide gsutil, bcftools, "
+            "and tabix. Defaults to --gatk-image, which provides all three."
         ),
         default=None,
         type=str,

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -438,36 +438,53 @@ def export_exclusion_intervals() -> str:
     return path
 
 
-def reheader_v4_sites_to_chr22(raw_vcf: str, out_path: str) -> str:
+def reheader_v4_sites_job(
+    b: hb.Batch,
+    raw_vcf: str,
+    out_root: str,
+    contigs: List[str],
+    image: str,
+    gcp_billing_project: str,
+) -> Job:
     """
-    Write a chr22 copy of a v4 sites VCF with AS features declared ``Number=A``.
+    Header-only reheader of a v4 sites VCF, declaring the AS float features ``Number=A``.
 
-    The published v4 info VCF declares AS annotations ``Number=.``; GATK's isolation
-    forest needs ``Number=A`` to enter allele-specific mode. The data is already one
-    value per ALT allele, so only the header changes. Filtering to chr22 keeps this
-    test-only re-export cheap.
+    The published v4 info VCF declares the AS annotations ``Number=.``; GATK's isolation
+    forest needs ``Number=A`` to enter allele-specific mode. This streams the VCF and
+    rewrites only the matching ``##INFO`` header lines, keeping records on ``contigs``
+    and passing them through unchanged, so special fields (e.g. AS_SB_TABLE) keep their
+    original encoding (no Hail round-trip / field re-typing). The contig filter keeps the
+    test chr22-only (so the reheader output and the reconcile import stay small).
 
-    :param raw_vcf: Path to the v4 sites VCF.
-    :param out_path: Output path for the reheadered chr22 VCF.
-    :return: ``out_path``.
+    :param b: Batch to add the job to.
+    :param raw_vcf: gs:// path to the v4 sites VCF (requester-pays).
+    :param out_root: Output prefix; writes ``{out_root}.vcf.gz`` and ``.vcf.gz.tbi``.
+    :param contigs: Contigs to keep (records on other contigs are dropped).
+    :param image: Image providing gsutil, bgzip, and tabix.
+    :param gcp_billing_project: GCP project for requester-pays reads.
+    :return: Job with output ResourceGroup ``out``.
     """
-    ht = hl.import_vcf(
-        raw_vcf,
-        force_bgz=True,
-        reference_genome="GRCh38",
-        array_elements_required=False,
-    ).rows()
-    ht = hl.filter_intervals(
-        ht, [hl.parse_locus_interval("chr22", reference_genome="GRCh38")]
+    j = b.new_job("Reheader v4 sites (Number=A)")
+    j.image(image)
+    j.cpu(2)
+    j.memory("standard")
+    j.storage("50G")
+    j.declare_resource_group(
+        out={"vcf.gz": "{root}.vcf.gz", "vcf.gz.tbi": "{root}.vcf.gz.tbi"}
     )
-    metadata = {
-        "info": {
-            f: {"Number": "A", "Type": "Float", "Description": ""}
-            for f in INFO_FEATURES
-        }
-    }
-    hl.export_vcf(ht, out_path, tabix=True, metadata=metadata)
-    return out_path
+    as_fields = "|".join(INFO_FEATURES)
+    keep_contig = " || ".join(f'$1=="{c}"' for c in contigs)
+    j.command(
+        f"""set -euo pipefail
+        gsutil -u {gcp_billing_project} cat {raw_vcf} | zcat \\
+          | sed -E 's/(##INFO=<ID=({as_fields}),Number=)\\./\\1A/' \\
+          | awk -F'\\t' '/^#/ || {keep_contig}' \\
+          | bgzip > {j.out['vcf.gz']}
+        tabix -p vcf {j.out['vcf.gz']}
+        """
+    )
+    b.write_output(j.out, out_root)
+    return j
 
 
 def merge_iforest_result(
@@ -615,14 +632,13 @@ def main(args):
             if true_positive_type
             else None
         )
-        sites_only_vcf = f"{run_prefix}/reheader/{model_id}.chr22.sites.vcf.bgz"
-        # The published v4 info VCF declares AS fields Number=.; reheader a chr22 copy
-        # to Number=A so GATK enters allele-specific mode.
-        if not args.load_only:
-            reheader_v4_sites_to_chr22(
-                v4_info_vcf_path(info_method="quasi"), sites_only_vcf
-            )
+        # The published v4 info VCF declares AS fields Number=.; a header-only reheader
+        # (run below) sets them to Number=A so GATK enters allele-specific mode.
+        raw_sites_vcf = v4_info_vcf_path(info_method="quasi")
+        reheader_root = f"{run_prefix}/reheader/{model_id}.sites"
+        sites_only_vcf = f"{reheader_root}.vcf.gz"
     else:
+        raw_sites_vcf = None
         sites_only_vcf = info_vcf_path(test=test, environment=environment)
         singletons_vcf = (
             get_true_positive_vcf_path(
@@ -642,11 +658,25 @@ def main(args):
         ).path
 
     if not args.load_only:
-        exclude_intervals = export_exclusion_intervals()
         backend = hb.ServiceBackend(
             billing_project=args.batch_billing_project,
             remote_tmpdir=f"gs://{BATCH_TMP_BUCKET}/",
         )
+        # Reheader the v4 input to Number=A first, to completion, so the GATK jobs read
+        # the finished VCF from the bucket.
+        if args.test_on_v4:
+            rb = hb.Batch(f"reheader {model_id}{args.batch_suffix}", backend=backend)
+            reheader_v4_sites_job(
+                b=rb,
+                raw_vcf=raw_sites_vcf,
+                out_root=reheader_root,
+                contigs=contigs,
+                image=args.reheader_image or args.gatk_image,
+                gcp_billing_project=args.gcp_billing_project,
+            )
+            rb.run()
+
+        exclude_intervals = export_exclusion_intervals()
         b = hb.Batch(f"isolation forest {model_id}{args.batch_suffix}", backend=backend)
         isolation_forest_workflow(
             b=b,
@@ -737,6 +767,15 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         "--gatk-image",
         help="GATK docker image.",
         default=DEFAULT_GATK_IMAGE,
+        type=str,
+    )
+    parser.add_argument(
+        "--reheader-image",
+        help=(
+            "Image for the --test-on-v4 reheader job; must provide gsutil, bgzip, and "
+            "tabix. Defaults to --gatk-image."
+        ),
+        default=None,
         type=str,
     )
     parser.add_argument(

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -24,7 +24,7 @@ from gnomad_qc.v5.resources.basics import (
 )
 from gnomad_qc.v5.resources.constants import BATCH_TMP_BUCKET
 from gnomad_qc.v5.resources.variant_qc import (
-    IF_FEATURES,
+    VARIANT_QC_FEATURES,
     _validate_model_id,
     get_iforest_run_prefix,
     get_variant_qc_result,
@@ -364,10 +364,10 @@ def isolation_forest_workflow(
         gcp_billing_project=gcp_billing_project,
     ).intervals
 
-    # GATK requires an uppercase --mode; IF_FEATURES is keyed 'snv'/'indel'.
+    # GATK requires an uppercase --mode; VARIANT_QC_FEATURES is keyed 'snv'/'indel'.
     for mode, feature_key in [("SNP", "snv"), ("INDEL", "indel")]:
         m = mode.lower()
-        features = IF_FEATURES[feature_key]
+        features = VARIANT_QC_FEATURES[feature_key]
         resource_args = _resource_args(mode, singletons_vcf)
         extract_root = f"{run_prefix}/extract/{m}/extract"
         model_root = f"{run_prefix}/model/{m}/model"
@@ -419,7 +419,14 @@ def isolation_forest_workflow(
                 hyperparameters_json=hyperparameters_json,
             ).model
 
+        # Reuse existing score shards so a partial-failure rerun resumes instead of
+        # re-scoring and clobbering every shard.
+        n_skipped = 0
         for idx in range(scatter_count):
+            score_root = f"{run_prefix}/score/{m}/{out_vcf_name}{idx}"
+            if not overwrite and file_exists(f"{score_root}.vcf.gz"):
+                n_skipped += 1
+                continue
             score_variant_annotations_job(
                 b=b,
                 mode=mode,
@@ -429,10 +436,12 @@ def isolation_forest_workflow(
                 model=model,
                 resource_args=resource_args,
                 interval=intervals[f"interval_{idx}"],
-                out_root=f"{run_prefix}/score/{m}/{out_vcf_name}{idx}",
+                out_root=score_root,
                 gatk_image=gatk_image,
                 gcp_billing_project=gcp_billing_project,
             )
+        if n_skipped:
+            logger.info("Reusing %s existing %s score shards.", n_skipped, mode)
 
 
 def export_exclusion_intervals(out_path: str) -> str:
@@ -483,7 +492,6 @@ def merge_iforest_result(
     n_partitions: int,
     header_path: Optional[str],
     array_elements_required: bool,
-    is_split: bool = True,
 ) -> hl.Table:
     """
     Merge the per-mode scored VCFs into a single variant QC result HT.
@@ -501,8 +509,6 @@ def merge_iforest_result(
     :param n_partitions: Number of partitions for the imported HTs.
     :param header_path: Optional VCF header file for import.
     :param array_elements_required: Value passed to hl.import_vcf.
-    :param is_split: Whether the scored VCFs are already split. True for v5 (the info HT
-        is split by `annotate_allele_info`); False for the unsplit v4 test input.
     :return: Merged variant QC result HT.
     """
     snp_vcfs = [
@@ -515,31 +521,16 @@ def merge_iforest_result(
     ]
 
     def _import(vcfs: List[str]) -> hl.Table:
-        hts = import_variant_qc_vcf(
+        return import_variant_qc_vcf(
             vcfs,
             model_id,
             n_partitions,
             header_path,
             array_elements_required,
-            is_split=is_split,
+            is_split=True,
             # Disjoint shards make duplicate keys impossible; the check costs a shuffle.
             deduplicate_check=False,
         )
-        # Only the split HT is used; the unsplit HT is returned when is_split is False.
-        ht = hts[0] if isinstance(hts, tuple) else hts
-        if is_split:
-            # Number=A fields import as length-1 arrays on split input; index to scalars
-            # (split_info_annotation does this via a_index on the unsplit path).
-            ht = ht.annotate(
-                info=ht.info.annotate(
-                    **{
-                        f: ht.info[f][0]
-                        for f, t in ht.info.dtype.items()
-                        if f.startswith("AS_") and isinstance(t, hl.tarray)
-                    }
-                )
-            )
-        return ht
 
     snp_ht = _import(snp_vcfs)
     indel_ht = _import(indel_vcfs)
@@ -549,8 +540,8 @@ def merge_iforest_result(
     ht = snp_ht.union(indel_ht)
     return ht.annotate_globals(
         model_id=model_id,
-        snp_features=IF_FEATURES["snv"],
-        indel_features=IF_FEATURES["indel"],
+        snp_features=VARIANT_QC_FEATURES["snv"],
+        indel_features=VARIANT_QC_FEATURES["indel"],
     )
 
 
@@ -677,6 +668,15 @@ def main(args):
 
     # Stable path so the same file used by GATK -XL is read back during reconciliation.
     exclude_intervals = f"{run_prefix}/exclude.intervals"
+
+    # Fail fast before the Batch if an input is missing. sites_only_vcf is checked
+    # unconditionally because reconcile_scored_sites reads it on --load-only runs too.
+    input_step_resources = {"sites_only_vcf": [sites_only_vcf]}
+    if singletons_vcf and not args.load_only:
+        input_step_resources["singletons_vcf"] = [singletons_vcf]
+    _check_resource_existence(
+        environment=environment, input_step_resources=input_step_resources
+    )
 
     # Fail fast before the Batch if the result HT already exists and we'd load it.
     if args.load_iforest or args.load_only:

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -291,6 +291,15 @@ def score_variant_annotations_job(
     :param gatk_image: GATK docker image.
     :param gcp_billing_project: GCP billing project for requester-pays buckets.
     :return: Job with output ResourceGroup ``output_score``.
+
+    .. note::
+
+        GATK traversal returns every record *overlapping* the shard interval, and the
+        default output mode (ANYWHERE) writes all of them, so a deletion straddling a
+        shard boundary is emitted by both neighbors. ``--variant-output-filtering
+        STARTS_IN`` writes a record only if its start is in the interval, making
+        emission exactly-once across shards. It also makes ``-XL`` start-based, which
+        is the definition `reconcile_scored_sites` uses.
     """
     j = b.new_job(f"GATK: ScoreVariantAnnotations {mode}")
     j.image(gatk_image)
@@ -317,6 +326,7 @@ def score_variant_annotations_job(
             --model-prefix {model} \\
             --model-backend PYTHON_IFOREST \\
             -L {interval} \\
+            --variant-output-filtering STARTS_IN \\
             --gcs-project-for-requester-pays {gcp_billing_project} \\
             {resource_args}
         """
@@ -454,6 +464,10 @@ def export_exclusion_intervals(out_path: str) -> str:
     Written to a stable path (not a temp file) so the same file used by GATK ``-XL``
     can be read back during reconciliation to define the excluded region exactly.
 
+    `telomeres_and_centromeres` is a BED import, so its intervals are half-open
+    ``[start, end)``, while GATK reads ``chr:start-end`` as 1-based inclusive on both
+    ends. Emit ``end - 1`` so the file covers exactly the interval.
+
     :param out_path: Destination path for the intervals file.
     :return: ``out_path``.
     """
@@ -464,7 +478,7 @@ def export_exclusion_intervals(out_path: str) -> str:
         + ":"
         + hl.str(interval.start.position)
         + "-"
-        + hl.str(interval.end.position)
+        + hl.str(interval.end.position - 1)
     ).select()
     ht.export(out_path, header=False)
     return out_path
@@ -571,7 +585,8 @@ def merge_iforest_result(
             header_path,
             array_elements_required,
             is_split=True,
-            # Disjoint shards make duplicate keys impossible; the check costs a shuffle.
+            # Scoring runs with --variant-output-filtering STARTS_IN, so each record is
+            # emitted by exactly one shard; the check costs a shuffle.
             deduplicate_check=False,
         )
 
@@ -614,6 +629,18 @@ def reconcile_scored_sites(
     """
     exclude_ht = hl.import_locus_intervals(
         exclude_intervals_path, reference_genome="GRCh38"
+    )
+    # GATK reads chr:start-end as 1-based inclusive; hl.import_locus_intervals is
+    # end-exclusive. Re-key as inclusive so we exclude exactly what GATK excluded.
+    # `includes_start` must be carried over: Hail canonicalizes a single-base
+    # 'chr:p-p' to the open-open (p-1, p), which is only correct if it stays open.
+    exclude_ht = exclude_ht.key_by(
+        interval=hl.interval(
+            exclude_ht.interval.start,
+            exclude_ht.interval.end,
+            includes_start=exclude_ht.interval.includes_start,
+            includes_end=True,
+        )
     )
     input_ht = hl.import_vcf(
         sites_only_vcf,

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -455,10 +455,11 @@ def reheader_v4_sites_job(
 
     .. note::
 
-        AS_SB_TABLE / AS_QUALapprox / AS_VarDP are stripped: their v4 encoding breaks
-        Hail's ``import_vcf`` in the load step and they are not needed for the iforest
-        result. Stopgap for the v4 test; revisit if a real run needs them (see the
-        reformatting TODO in ``import_variant_qc_vcf``).
+        AS_SB_TABLE / SB / AS_QUALapprox / AS_VarDP are stripped: these strand-bias /
+        count-table and pipe-delimited fields have a v4 encoding (comma values under a
+        scalar Number) that breaks Hail's ``import_vcf`` in the load step, and they are
+        not needed for the iforest result. Stopgap for the v4 test; revisit if a real
+        run needs them (see the reformatting TODO in ``import_variant_qc_vcf``).
 
     :param b: Batch to add the job to.
     :param raw_vcf: gs:// path to the v4 sites VCF (requester-pays).
@@ -478,7 +479,7 @@ def reheader_v4_sites_job(
     )
     as_fields = "|".join(INFO_FEATURES)
     keep_contig = " || ".join(f'$1=="{c}"' for c in contigs)
-    strip_fields = "INFO/AS_SB_TABLE,INFO/AS_QUALapprox,INFO/AS_VarDP"
+    strip_fields = "INFO/AS_SB_TABLE,INFO/SB,INFO/AS_QUALapprox,INFO/AS_VarDP"
     j.command(
         f"""set -euo pipefail
         gsutil -u {gcp_billing_project} cat {raw_vcf} | zcat \\

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -200,7 +200,6 @@ def split_intervals_job(
     calling_intervals_arg: str,
     exclude_intervals: str,
     scatter_count: int,
-    out_root: str,
     gatk_image: str,
     gcp_billing_project: str,
 ) -> Job:
@@ -211,7 +210,6 @@ def split_intervals_job(
     :param calling_intervals_arg: GATK ``-L`` args covering the calling contigs.
     :param exclude_intervals: Path to an intervals file to exclude (``-XL``).
     :param scatter_count: Number of interval shards to produce.
-    :param out_root: Bucket prefix to persist the interval files to (for reconciliation).
     :param gatk_image: GATK docker image.
     :param gcp_billing_project: GCP billing project for requester-pays buckets.
     :return: Job with output ResourceGroup ``intervals``.
@@ -239,7 +237,6 @@ def split_intervals_job(
             --gcs-project-for-requester-pays {gcp_billing_project}
         """
     )
-    b.write_output(j.intervals, out_root)
     return j
 
 
@@ -343,7 +340,6 @@ def isolation_forest_workflow(
         calling_intervals_arg=calling_intervals_arg,
         exclude_intervals=exclude_intervals,
         scatter_count=scatter_count,
-        out_root=f"{run_prefix}/intervals",
         gatk_image=gatk_image,
         gcp_billing_project=gcp_billing_project,
     ).intervals
@@ -418,11 +414,15 @@ def isolation_forest_workflow(
             )
 
 
-def export_exclusion_intervals() -> str:
+def export_exclusion_intervals(out_path: str) -> str:
     """
-    Export telomere/centromere intervals to a GATK-readable intervals file.
+    Export telomere/centromere intervals to a GATK-readable ``chr:start-end`` file.
 
-    :return: Path to the exported ``chr:start-end`` intervals file.
+    Written to a stable path (not a temp file) so the same file used by GATK ``-XL``
+    can be read back during reconciliation to define the excluded region exactly.
+
+    :param out_path: Destination path for the intervals file.
+    :return: ``out_path``.
     """
     ht = telomeres_and_centromeres.ht()
     interval = ht.interval
@@ -433,9 +433,8 @@ def export_exclusion_intervals() -> str:
         + "-"
         + hl.str(interval.end.position)
     ).select()
-    path = hl.utils.new_temp_file("telomeres_centromeres", "intervals")
-    ht.export(path, header=False)
-    return path
+    ht.export(out_path, header=False)
+    return out_path
 
 
 def reheader_v4_sites_job(
@@ -557,48 +556,89 @@ def merge_iforest_result(
 
 def reconcile_scored_sites(
     sites_only_vcf: str,
-    intervals_path: str,
+    contigs: List[str],
+    exclude_intervals_path: str,
     scored_ht: hl.Table,
     array_elements_required: bool = False,
+    max_consecutive_missing: int = 100,
 ) -> None:
     """
-    Raise if any input locus in the scored region is missing from the scored output.
+    Warn on input loci in the scored region absent from the output; fail on a contiguous run.
 
-    GATK ScoreVariantAnnotations emits every input variant within its interval, so every
-    input locus inside the SplitIntervals regions must appear in the merged output. Any
-    that do not were silently dropped (e.g. a shard that under-emitted), which this
-    catches even for a small contiguous chunk. Reconciliation is at the locus level
-    since a dropped region removes whole loci.
+    The scored region is reconstructed from the same ``-L`` contigs and ``-XL`` exclusion
+    file GATK used. GATK skips sites it cannot score (all-missing annotations, mixed/MNP/
+    spanning-deletion types), so scattered absences are expected and only warned about.
+    A run of ``max_consecutive_missing`` input loci that are all absent with no scored
+    locus between them indicates a silently dropped region (e.g. a shard that
+    under-emitted) and raises.
 
     :param sites_only_vcf: Input sites VCF that was scored.
-    :param intervals_path: Glob of the SplitIntervals ``.interval_list`` files defining
-        the scored region.
+    :param contigs: Calling contigs passed to GATK (``-L``).
+    :param exclude_intervals_path: Telomere/centromere exclusion file passed to GATK
+        (``-XL``).
     :param scored_ht: Merged scored result HT.
     :param array_elements_required: Value passed to hl.import_vcf for the input.
+    :param max_consecutive_missing: Fail if this many consecutive input loci are absent.
     :return: None.
     """
-    intervals_ht = hl.import_locus_intervals(intervals_path, reference_genome="GRCh38")
+    exclude_ht = hl.import_locus_intervals(
+        exclude_intervals_path, reference_genome="GRCh38"
+    )
     input_ht = hl.import_vcf(
         sites_only_vcf,
         force_bgz=True,
         reference_genome="GRCh38",
         array_elements_required=array_elements_required,
     ).rows()
+    scored_loci = scored_ht.key_by("locus").select().distinct()
+    contig_set = hl.literal(set(contigs))
     input_loci = (
-        input_ht.filter(hl.is_defined(intervals_ht[input_ht.locus]))
+        input_ht.filter(
+            contig_set.contains(input_ht.locus.contig)
+            & hl.is_missing(exclude_ht[input_ht.locus])
+        )
         .key_by("locus")
         .select()
         .distinct()
     )
-    missing = input_loci.anti_join(scored_ht.key_by("locus").select().distinct())
-    n_missing = missing.count()
-    if n_missing > 0:
+    input_loci = input_loci.annotate(
+        scored=hl.is_defined(scored_loci[input_loci.locus])
+    )
+    input_loci = input_loci.checkpoint(hl.utils.new_temp_file("reconcile", "ht"))
+
+    n_missing = input_loci.aggregate(hl.agg.count_where(~input_loci.scored))
+    if n_missing == 0:
+        logger.info(
+            "Reconciliation passed: all input loci in the scored region are present."
+        )
+        return
+
+    examples = [r.locus for r in input_loci.filter(~input_loci.scored).take(5)]
+    logger.warning(
+        "%s input loci in the scored region are absent from the scored output; GATK "
+        "skips unscoreable sites, so scattered absences are expected. Examples: %s",
+        n_missing,
+        examples,
+    )
+
+    # Consecutive absent loci sharing a scored-prefix count form one dropped run; a long
+    # run (vs isolated scattered drops) signals a silently dropped region.
+    input_loci = input_loci.annotate(run_id=hl.scan.sum(hl.int(input_loci.scored)))
+    missing_ht = input_loci.filter(~input_loci.scored)
+    runs = missing_ht.group_by(missing_ht.locus.contig, missing_ht.run_id).aggregate(
+        run_len=hl.agg.count()
+    )
+    longest = runs.aggregate(hl.agg.max(runs.run_len))
+    if longest is not None and longest >= max_consecutive_missing:
         raise ValueError(
-            f"{n_missing} input loci in the scored region are missing from the scored "
-            f"output (silently dropped). Examples: {[m.locus for m in missing.take(5)]}"
+            f"Longest run of consecutive missing loci is {longest} "
+            f"(>= {max_consecutive_missing}); a contiguous region was likely dropped."
         )
     logger.info(
-        "Reconciliation passed: all input loci in the scored region are present."
+        "Missing loci are scattered (longest consecutive run %s < %s); treating as "
+        "expected GATK drops.",
+        longest,
+        max_consecutive_missing,
     )
 
 
@@ -663,6 +703,9 @@ def main(args):
             model_id, test=test, split=True, environment=environment
         ).path
 
+    # Stable path so the same file used by GATK -XL is read back during reconciliation.
+    exclude_intervals = f"{run_prefix}/exclude.intervals"
+
     if not args.load_only:
         backend = hb.ServiceBackend(
             billing_project=args.batch_billing_project,
@@ -682,7 +725,7 @@ def main(args):
             )
             rb.run()
 
-        exclude_intervals = export_exclusion_intervals()
+        export_exclusion_intervals(exclude_intervals)
         b = hb.Batch(f"isolation forest {model_id}{args.batch_suffix}", backend=backend)
         isolation_forest_workflow(
             b=b,
@@ -712,7 +755,8 @@ def main(args):
         )
         reconcile_scored_sites(
             sites_only_vcf=sites_only_vcf,
-            intervals_path=f"{run_prefix}/intervals/*.interval_list",
+            contigs=contigs,
+            exclude_intervals_path=exclude_intervals,
             scored_ht=ht,
             array_elements_required=args.array_elements_required,
         )

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -18,7 +18,7 @@ from gnomad.variant_qc.pipeline import INFO_FEATURES
 from hailtop.batch.job import Job
 
 from gnomad_qc.v5.resources.annotations import get_true_positive_vcf_path, info_vcf_path
-from gnomad_qc.v5.resources.basics import _init_hail
+from gnomad_qc.v5.resources.basics import _get_batch_resource_kwargs, _init_hail
 from gnomad_qc.v5.resources.constants import BATCH_TMP_BUCKET
 from gnomad_qc.v5.resources.variant_qc import (
     IF_FEATURES,
@@ -530,7 +530,7 @@ def merge_iforest_result(
 def main(args):
     """Run the isolation forest variant QC workflow."""
     environment = args.environment
-    _init_hail("isolation_forest", environment)
+    _init_hail("isolation_forest", environment, **_get_batch_resource_kwargs(args))
 
     test = args.test
     model_id = args.model_id
@@ -714,6 +714,36 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         "--batch-suffix",
         help="String to append to the Batch name.",
         default="",
+        type=str,
+    )
+    parser.add_argument(
+        "--app-name",
+        help="Job name for the batch/QoB backend.",
+        default=None,
+        type=str,
+    )
+    parser.add_argument(
+        "--driver-cores",
+        help="Number of driver cores (Batch only).",
+        default=None,
+        type=int,
+    )
+    parser.add_argument(
+        "--driver-memory",
+        help="Driver memory (Batch only).",
+        default=None,
+        type=str,
+    )
+    parser.add_argument(
+        "--worker-cores",
+        help="Number of worker cores (Batch only).",
+        default=None,
+        type=int,
+    )
+    parser.add_argument(
+        "--worker-memory",
+        help="Worker memory (Batch only).",
+        default=None,
         type=str,
     )
     parser.add_argument(

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -18,10 +18,15 @@ from gnomad.variant_qc.pipeline import INFO_FEATURES
 from hailtop.batch.job import Job
 
 from gnomad_qc.v5.resources.annotations import get_true_positive_vcf_path, info_vcf_path
-from gnomad_qc.v5.resources.basics import _get_batch_resource_kwargs, _init_hail
+from gnomad_qc.v5.resources.basics import (
+    _check_resource_existence,
+    _get_batch_resource_kwargs,
+    _init_hail,
+)
 from gnomad_qc.v5.resources.constants import BATCH_TMP_BUCKET
 from gnomad_qc.v5.resources.variant_qc import (
     IF_FEATURES,
+    _validate_model_id,
     get_iforest_run_prefix,
     get_variant_qc_result,
 )
@@ -58,15 +63,27 @@ def _resource_args(mode: str, singletons_vcf: Optional[str]) -> str:
     :param singletons_vcf: Optional true-positive (transmitted/sibling singletons) VCF.
     :return: Space-joined GATK resource argument string.
     """
+    # Labels mirror v4 VQSR, not the v4 iforest.
     if mode == "SNP":
-        resources = ["hapmap", "omni", "one_thousand_genomes", "dbsnp"]
+        training_calibration = ["hapmap", "omni"]
+        training_only = ["one_thousand_genomes"]
     else:
-        resources = ["mills", "axiom_poly", "dbsnp"]
+        training_calibration = ["mills"]
+        training_only = ["axiom_poly"]
 
     args = [
         f"--resource:{r},training=true,calibration=true {REFERENCE_RESOURCES[r]}"
-        for r in resources
+        for r in training_calibration
     ]
+    args += [
+        f"--resource:{r},training=true,calibration=false {REFERENCE_RESOURCES[r]}"
+        for r in training_only
+    ]
+    # VETS ignores `known`; it only flags known vs novel in the scored VCF INFO.
+    args.append(
+        "--resource:dbsnp,known=true,training=false,calibration=false"
+        f" {REFERENCE_RESOURCES['dbsnp']}"
+    )
     if singletons_vcf:
         args.append(
             f"--resource:singletons,training=true,calibration=true {singletons_vcf}"
@@ -94,6 +111,7 @@ def extract_variant_annotations_job(
     features: List[str],
     resource_args: str,
     calling_intervals_arg: str,
+    exclude_intervals: str,
     out_root: str,
     gatk_image: str,
     gcp_billing_project: str,
@@ -107,6 +125,8 @@ def extract_variant_annotations_job(
     :param features: Features to extract for this mode.
     :param resource_args: GATK ``--resource`` args for the labeled sets.
     :param calling_intervals_arg: GATK ``-L`` args restricting the extracted sites.
+    :param exclude_intervals: Telomere/centromere intervals excluded from the
+        training/calibration set (``-XL``); these sites are not scored either.
     :param out_root: Output prefix (files written as ``{out_root}.*``).
     :param gatk_image: GATK docker image.
     :param gcp_billing_project: GCP billing project for requester-pays buckets.
@@ -132,6 +152,7 @@ def extract_variant_annotations_job(
             --mode {mode} \\
             {_annotation_args(features)} \\
             {calling_intervals_arg} \\
+            -XL {exclude_intervals} \\
             --gcs-project-for-requester-pays {gcp_billing_project} \\
             {resource_args}
         """
@@ -370,6 +391,7 @@ def isolation_forest_workflow(
                 features=features,
                 resource_args=resource_args,
                 calling_intervals_arg=calling_intervals_arg,
+                exclude_intervals=exclude_intervals,
                 out_root=extract_root,
                 gatk_image=gatk_image,
                 gcp_billing_project=gcp_billing_project,
@@ -649,6 +671,10 @@ def main(args):
 
     test = args.test
     model_id = args.model_id
+    # Validate up front so a bad model_id fails before Batch runs. The non-test-on-v4
+    # branch gets this via get_iforest_run_prefix; test-on-v4 builds its own prefix.
+    if _validate_model_id(model_id) != "if":
+        raise ValueError(f"model_id must start with 'if_', but got {model_id}")
     chr22_only = test or args.test_on_v4
     scatter_count = 10 if chr22_only else args.scatter_count
     contigs = ["chr22"] if chr22_only else CALLING_CONTIGS
@@ -706,14 +732,23 @@ def main(args):
     # Stable path so the same file used by GATK -XL is read back during reconciliation.
     exclude_intervals = f"{run_prefix}/exclude.intervals"
 
+    # Fail fast before the Batch if the result HT already exists and we'd load it.
+    if args.load_iforest or args.load_only:
+        _check_resource_existence(
+            environment=environment,
+            output_step_resources={"variant_qc_result": [result_ht_path]},
+            overwrite=args.overwrite,
+        )
+
     if not args.load_only:
         backend = hb.ServiceBackend(
             billing_project=args.batch_billing_project,
             remote_tmpdir=f"gs://{BATCH_TMP_BUCKET}/",
         )
         # Reheader the v4 input to Number=A first, to completion, so the GATK jobs read
-        # the finished VCF from the bucket.
-        if args.test_on_v4:
+        # the finished VCF from the bucket. Reuse an existing reheadered VCF unless
+        # overwriting, since re-streaming the full v4 sites VCF is expensive.
+        if args.test_on_v4 and (args.overwrite or not file_exists(sites_only_vcf)):
             rb = hb.Batch(f"reheader {model_id}{args.batch_suffix}", backend=backend)
             reheader_v4_sites_job(
                 b=rb,
@@ -743,7 +778,7 @@ def main(args):
         )
         b.run()
 
-    if args.load_iforest:
+    if args.load_iforest or args.load_only:
         ht = merge_iforest_result(
             run_prefix=run_prefix,
             out_vcf_name=args.out_vcf_name,
@@ -787,7 +822,7 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         help="Compute environment.",
         default="batch",
         type=str,
-        choices=["rwb", "batch", "dataproc"],
+        choices=["rwb", "batch"],
     )
     parser.add_argument(
         "--model-id",

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -549,6 +549,9 @@ def merge_iforest_result(
     n_partitions: int,
     header_path: Optional[str],
     array_elements_required: bool,
+    transmitted_singletons: bool,
+    sibling_singletons: bool,
+    adj: bool,
 ) -> hl.Table:
     """
     Merge the per-mode scored VCFs into a single variant QC result HT.
@@ -566,6 +569,9 @@ def merge_iforest_result(
     :param n_partitions: Number of partitions for the imported HTs.
     :param header_path: Optional VCF header file for import.
     :param array_elements_required: Value passed to hl.import_vcf.
+    :param transmitted_singletons: Whether transmitted singletons were a training set.
+    :param sibling_singletons: Whether sibling singletons were a training set.
+    :param adj: Whether the singletons VCF used adj genotypes.
     :return: Merged variant QC result HT.
     """
     snp_vcfs = [
@@ -600,6 +606,11 @@ def merge_iforest_result(
         model_id=model_id,
         snp_features=VARIANT_QC_FEATURES["snv"],
         indel_features=VARIANT_QC_FEATURES["indel"],
+        filtering_model_specific_info=hl.struct(
+            transmitted_singletons=transmitted_singletons,
+            sibling_singletons=sibling_singletons,
+            adj=adj,
+        ),
     )
 
 
@@ -675,15 +686,18 @@ def reconcile_scored_sites(
 
 def main(args):
     """Run the isolation forest variant QC workflow."""
+    model_id = args.model_id
+    if _validate_model_id(model_id) != "if":
+        raise ValueError(f"model_id must start with 'if_', but got {model_id}")
+    if args.export_v4_test_vcf and not args.test_on_v4:
+        raise ValueError("--export-v4-test-vcf requires --test-on-v4.")
+    if args.export_only and not args.export_v4_test_vcf:
+        raise ValueError("--export-only requires --export-v4-test-vcf.")
+
     environment = args.environment
     _init_hail("isolation_forest", environment, **_get_batch_resource_kwargs(args))
 
     test = args.test
-    model_id = args.model_id
-    # Validate up front so a bad model_id fails before Batch runs. The non-test-on-v4
-    # branch gets this via get_iforest_run_prefix; test-on-v4 builds its own prefix.
-    if _validate_model_id(model_id) != "if":
-        raise ValueError(f"model_id must start with 'if_', but got {model_id}")
     # Tests score only --test-chrom; must match the contigs in the test info VCF (see
     # --test-chrom in generate_variant_qc_annotations).
     test_mode = test or args.test_on_v4
@@ -738,9 +752,6 @@ def main(args):
 
     # Stable path so the same file used by GATK -XL is read back during reconciliation.
     exclude_intervals = f"{run_prefix}/exclude.intervals"
-
-    if args.export_v4_test_vcf and not args.test_on_v4:
-        raise ValueError("--export-v4-test-vcf requires --test-on-v4.")
 
     # Fail fast before the Batch if an input is missing. sites_only_vcf is checked
     # unconditionally because reconcile_scored_sites reads it on --load-only runs too,
@@ -807,6 +818,9 @@ def main(args):
             n_partitions=args.n_partitions,
             header_path=args.header_path,
             array_elements_required=args.array_elements_required,
+            transmitted_singletons=args.transmitted_singletons,
+            sibling_singletons=args.sibling_singletons,
+            adj=args.adj,
         )
         # Write first, then reconcile the materialized HT so the merge is computed once.
         ht.write(result_ht_path, overwrite=args.overwrite)

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -514,6 +514,24 @@ def reheader_v4_sites_job(
     return j
 
 
+def run_batch(b: hb.Batch, description: str) -> None:
+    """
+    Run a Batch to completion and raise if it did not succeed.
+
+    ``Batch.run`` waits but only prints the final state, so a failed batch would
+    otherwise fall through to the next step (e.g. submitting the GATK jobs against a
+    reheadered VCF that was never written).
+
+    :param b: Batch to run.
+    :param description: Batch description used in the error message.
+    :return: None.
+    """
+    batch = b.run()
+    state = None if batch is None else batch.status()["state"]
+    if state != "success":
+        raise RuntimeError(f"{description} batch did not succeed (state: {state}).")
+
+
 def merge_iforest_result(
     run_prefix: str,
     out_vcf_name: str,
@@ -522,6 +540,7 @@ def merge_iforest_result(
     n_partitions: int,
     header_path: Optional[str],
     array_elements_required: bool,
+    is_split: bool = True,
 ) -> hl.Table:
     """
     Merge the per-mode scored VCFs into a single variant QC result HT.
@@ -539,6 +558,8 @@ def merge_iforest_result(
     :param n_partitions: Number of partitions for the imported HTs.
     :param header_path: Optional VCF header file for import.
     :param array_elements_required: Value passed to hl.import_vcf.
+    :param is_split: Whether the scored VCFs are already split. True for v5 (the info HT
+        is split by `annotate_allele_info`); False for the unsplit v4 test input.
     :return: Merged variant QC result HT.
     """
     snp_vcfs = [
@@ -549,22 +570,35 @@ def merge_iforest_result(
         f"{run_prefix}/score/indel/{out_vcf_name}{idx}.vcf.gz"
         for idx in range(scatter_count)
     ]
-    snp_ht = import_variant_qc_vcf(
-        snp_vcfs,
-        model_id,
-        n_partitions,
-        header_path,
-        array_elements_required,
-        deduplicate_check=True,
-    )[0]
-    indel_ht = import_variant_qc_vcf(
-        indel_vcfs,
-        model_id,
-        n_partitions,
-        header_path,
-        array_elements_required,
-        deduplicate_check=True,
-    )[0]
+
+    def _import(vcfs: List[str]) -> hl.Table:
+        hts = import_variant_qc_vcf(
+            vcfs,
+            model_id,
+            n_partitions,
+            header_path,
+            array_elements_required,
+            is_split=is_split,
+            deduplicate_check=True,
+        )
+        # Only the split HT is used; the unsplit HT is returned when is_split is False.
+        ht = hts[0] if isinstance(hts, tuple) else hts
+        if is_split:
+            # Number=A fields import as length-1 arrays on split input; index to scalars
+            # (split_info_annotation does this via a_index on the unsplit path).
+            ht = ht.annotate(
+                info=ht.info.annotate(
+                    **{
+                        f: ht.info[f][0]
+                        for f, t in ht.info.dtype.items()
+                        if f.startswith("AS_") and isinstance(t, hl.tarray)
+                    }
+                )
+            )
+        return ht
+
+    snp_ht = _import(snp_vcfs)
+    indel_ht = _import(indel_vcfs)
 
     snp_ht = snp_ht.filter(hl.is_snp(snp_ht.alleles[0], snp_ht.alleles[1]))
     indel_ht = indel_ht.filter(~hl.is_snp(indel_ht.alleles[0], indel_ht.alleles[1]))
@@ -675,9 +709,11 @@ def main(args):
     # branch gets this via get_iforest_run_prefix; test-on-v4 builds its own prefix.
     if _validate_model_id(model_id) != "if":
         raise ValueError(f"model_id must start with 'if_', but got {model_id}")
-    chr22_only = test or args.test_on_v4
-    scatter_count = 10 if chr22_only else args.scatter_count
-    contigs = ["chr22"] if chr22_only else CALLING_CONTIGS
+    # Tests score only --test-chrom; must match the contigs in the test info VCF (see
+    # --test-chrom in generate_variant_qc_annotations).
+    test_mode = test or args.test_on_v4
+    scatter_count = 10 if test_mode else args.scatter_count
+    contigs = args.test_chrom if test_mode else CALLING_CONTIGS
     calling_intervals_arg = " ".join(f"-L {c}" for c in contigs)
 
     true_positive_type = None
@@ -758,7 +794,7 @@ def main(args):
                 image=args.reheader_image or args.gatk_image,
                 gcp_billing_project=args.gcp_billing_project,
             )
-            rb.run()
+            run_batch(rb, "Reheader")
 
         export_exclusion_intervals(exclude_intervals)
         b = hb.Batch(f"isolation forest {model_id}{args.batch_suffix}", backend=backend)
@@ -776,7 +812,7 @@ def main(args):
             hyperparameters_json=args.hyperparameters_json,
             overwrite=args.overwrite,
         )
-        b.run()
+        run_batch(b, "Isolation forest")
 
     if args.load_iforest or args.load_only:
         ht = merge_iforest_result(
@@ -787,6 +823,7 @@ def main(args):
             n_partitions=args.n_partitions,
             header_path=args.header_path,
             array_elements_required=args.array_elements_required,
+            is_split=not args.test_on_v4,
         )
         reconcile_scored_sites(
             sites_only_vcf=sites_only_vcf,
@@ -809,8 +846,18 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--test",
-        help="Filter to chr22 and use a small scatter count for testing.",
+        help="Filter to --test-chrom and use a small scatter count for testing.",
         action="store_true",
+    )
+    parser.add_argument(
+        "--test-chrom",
+        help=(
+            "Contig(s) to score under --test/--test-on-v4. Must match the contigs in "
+            "the test info VCF."
+        ),
+        type=str,
+        nargs="+",
+        default=["chr22"],
     )
     parser.add_argument(
         "--test-on-v4",

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -447,20 +447,24 @@ def reheader_v4_sites_job(
     gcp_billing_project: str,
 ) -> Job:
     """
-    Header-only reheader of a v4 sites VCF, declaring the AS float features ``Number=A``.
+    Reheader a v4 sites VCF for the isolation forest and strip fields Hail can't import.
 
-    The published v4 info VCF declares the AS annotations ``Number=.``; GATK's isolation
-    forest needs ``Number=A`` to enter allele-specific mode. This streams the VCF and
-    rewrites only the matching ``##INFO`` header lines, keeping records on ``contigs``
-    and passing them through unchanged, so special fields (e.g. AS_SB_TABLE) keep their
-    original encoding (no Hail round-trip / field re-typing). The contig filter keeps the
-    test chr22-only (so the reheader output and the reconcile import stay small).
+    Streams the VCF: rewrites the AS-float ``##INFO`` header lines to ``Number=A`` (GATK
+    needs this to enter allele-specific mode), keeps records on ``contigs``, and passes
+    kept fields through untouched (no re-typing).
+
+    .. note::
+
+        AS_SB_TABLE / AS_QUALapprox / AS_VarDP are stripped: their v4 encoding breaks
+        Hail's ``import_vcf`` in the load step and they are not needed for the iforest
+        result. Stopgap for the v4 test; revisit if a real run needs them (see the
+        reformatting TODO in ``import_variant_qc_vcf``).
 
     :param b: Batch to add the job to.
     :param raw_vcf: gs:// path to the v4 sites VCF (requester-pays).
     :param out_root: Output prefix; writes ``{out_root}.vcf.gz`` and ``.vcf.gz.tbi``.
-    :param contigs: Contigs to keep (records on other contigs are dropped).
-    :param image: Image providing gsutil, bgzip, and tabix.
+    :param contigs: Contigs to keep.
+    :param image: Image providing gsutil, bcftools, and tabix.
     :param gcp_billing_project: GCP project for requester-pays reads.
     :return: Job with output ResourceGroup ``out``.
     """
@@ -474,12 +478,13 @@ def reheader_v4_sites_job(
     )
     as_fields = "|".join(INFO_FEATURES)
     keep_contig = " || ".join(f'$1=="{c}"' for c in contigs)
+    strip_fields = "INFO/AS_SB_TABLE,INFO/AS_QUALapprox,INFO/AS_VarDP"
     j.command(
         f"""set -euo pipefail
         gsutil -u {gcp_billing_project} cat {raw_vcf} | zcat \\
           | sed -E 's/(##INFO=<ID=({as_fields}),Number=)\\./\\1A/' \\
           | awk -F'\\t' '/^#/ || {keep_contig}' \\
-          | bgzip > {j.out['vcf.gz']}
+          | bcftools annotate -x {strip_fields} -Oz -o {j.out['vcf.gz']} -
         tabix -p vcf {j.out['vcf.gz']}
         """
     )

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -507,11 +507,13 @@ def export_v4_test_sites_vcf(contigs: List[str], out_path: str) -> None:
     )
     ht = get_reformatted_info_fields(ht, info_method="quasi")
     ht = ht.select(info=ht.site_info.annotate(**ht.quasi_info))
-    # split_info_annotation leaves the AS_ fields as scalars and AS_SB_TABLE as a flat
-    # array, both of which break adjust_vcf_incompatible_types' pipe-delimiting.
-    # AS_SB_TABLE is not an iforest feature, so drop it and skip pipe-delimiting.
-    if "AS_SB_TABLE" in ht.info:
-        ht = ht.annotate(info=ht.info.drop("AS_SB_TABLE"))
+    # Drop the strand-bias tables: neither is an iforest feature. AS_SB_TABLE breaks
+    # adjust_vcf_incompatible_types' pipe-delimiting on split input, and GATK rewrites
+    # SB's header to its reserved Number=1,Type=Float while still emitting the
+    # 4-element array, which then fails to import from the scored VCF.
+    drop_fields = [f for f in ("AS_SB_TABLE", "SB") if f in ht.info]
+    if drop_fields:
+        ht = ht.annotate(info=ht.info.drop(*drop_fields))
     ht = adjust_vcf_incompatible_types(ht, pipe_delimited_annotations=[])
     # Declare the features Number=A so GATK runs in allele-specific mode; Hail would
     # write Number=1 for these split scalars. See `_annotation_args`.

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -1,0 +1,682 @@
+"""Script to run the GATK isolation forest variant QC model on an AS-annotated sites VCF.
+
+SNPs and INDELs are modeled separately (GATK ``--mode``): for each variant type the
+workflow runs ExtractVariantAnnotations -> TrainVariantAnnotationsModel (PYTHON_IFOREST)
+-> ScoreVariantAnnotations (scattered over intervals). The two per-mode scored VCFs are
+merged into a single result HT in the ``--load-iforest`` step.
+"""
+
+import argparse
+import logging
+from typing import List, Optional
+
+import hail as hl
+import hailtop.batch as hb
+from gnomad.resources.grch38.reference_data import telomeres_and_centromeres
+from gnomad.utils.file_utils import file_exists
+from hailtop.batch.job import Job
+
+from gnomad_qc.v5.resources.annotations import get_true_positive_vcf_path, info_vcf_path
+from gnomad_qc.v5.resources.basics import _init_hail
+from gnomad_qc.v5.resources.constants import BATCH_TMP_BUCKET
+from gnomad_qc.v5.resources.variant_qc import (
+    IF_FEATURES,
+    get_iforest_run_prefix,
+    get_variant_qc_result,
+)
+from gnomad_qc.v5.variant_qc.import_variant_qc_vcf import import_variant_qc_vcf
+
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger = logging.getLogger("isolation_forest")
+logger.setLevel(logging.INFO)
+
+DEFAULT_GATK_IMAGE = "us.gcr.io/broad-gatk/gatk:4.6.1.0"
+"""GATK image. 4.6.1.0 ships the conda env (scikit-learn, dill) needed for PYTHON_IFOREST."""
+
+CALLING_CONTIGS = [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"]
+"""Contigs to score (autosomes and sex chromosomes)."""
+
+# Public GATK resource VCFs (broad-references); used as labeled training/calibration
+# sets. SNP and INDEL modes use different truth resources.
+REFERENCE_RESOURCES = {
+    "ref_fasta": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta",
+    "dbsnp": "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+    "hapmap": "gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz",
+    "omni": "gs://gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz",
+    "one_thousand_genomes": "gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
+    "mills": "gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+    "axiom_poly": "gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz",
+}
+
+
+def _resource_args(mode: str, singletons_vcf: Optional[str]) -> str:
+    """
+    Build the GATK ``--resource`` args (labeled training/calibration sets) for a mode.
+
+    :param mode: Variant type mode, 'SNP' or 'INDEL'.
+    :param singletons_vcf: Optional true-positive (transmitted/sibling singletons) VCF.
+    :return: Space-joined GATK resource argument string.
+    """
+    if mode == "SNP":
+        resources = ["hapmap", "omni", "one_thousand_genomes", "dbsnp"]
+    else:
+        resources = ["mills", "axiom_poly", "dbsnp"]
+
+    args = [
+        f"--resource:{r},training=true,calibration=true {REFERENCE_RESOURCES[r]}"
+        for r in resources
+    ]
+    if singletons_vcf:
+        args.append(
+            f"--resource:singletons,training=true,calibration=true {singletons_vcf}"
+        )
+    return " ".join(args)
+
+
+def _annotation_args(features: List[str]) -> str:
+    """Build the GATK ``-A`` annotation args from a feature list."""
+    return " ".join(f"-A {f}" for f in features)
+
+
+def extract_variant_annotations_job(
+    b: hb.Batch,
+    mode: str,
+    sites_only_vcf: str,
+    features: List[str],
+    resource_args: str,
+    out_root: str,
+    gatk_image: str,
+    gcp_billing_project: str,
+) -> Job:
+    """
+    Run GATK ExtractVariantAnnotations for one variant type mode.
+
+    :param b: Batch to add the job to.
+    :param mode: Variant type mode, 'SNP' or 'INDEL'.
+    :param sites_only_vcf: AS-annotated sites-only input VCF.
+    :param features: Features to extract for this mode.
+    :param resource_args: GATK ``--resource`` args for the labeled sets.
+    :param out_root: Output prefix (files written as ``{out_root}.*``).
+    :param gatk_image: GATK docker image.
+    :param gcp_billing_project: GCP billing project for requester-pays buckets.
+    :return: Job with output ResourceGroup ``extract``.
+    """
+    j = b.new_job(f"GATK: ExtractVariantAnnotations {mode}")
+    j.image(gatk_image)
+    j.cpu(4)
+    j.memory("standard")
+    j.storage("100G")
+    j.declare_resource_group(
+        extract={
+            "annot.hdf5": "{root}.annot.hdf5",
+            "vcf.gz": "{root}.vcf.gz",
+            "vcf.gz.tbi": "{root}.vcf.gz.tbi",
+        }
+    )
+    j.command(
+        f"""set -euo pipefail
+        gatk --java-options "-Xmx6G" ExtractVariantAnnotations \\
+            -V {sites_only_vcf} \\
+            -O {j.extract} \\
+            --mode {mode} \\
+            {_annotation_args(features)} \\
+            --use-allele-specific-annotations \\
+            --gcs-project-for-requester-pays {gcp_billing_project} \\
+            {resource_args}
+        """
+    )
+    b.write_output(j.extract, out_root)
+    return j
+
+
+def train_variant_annotations_model_job(
+    b: hb.Batch,
+    mode: str,
+    annotations_hdf5: hb.ResourceFile,
+    out_root: str,
+    gatk_image: str,
+    gcp_billing_project: str,
+    hyperparameters_json: Optional[str] = None,
+) -> Job:
+    """
+    Run GATK TrainVariantAnnotationsModel (PYTHON_IFOREST) for one variant type mode.
+
+    :param b: Batch to add the job to.
+    :param mode: Variant type mode, 'SNP' or 'INDEL'.
+    :param annotations_hdf5: Extracted annotations HDF5 from the extract step.
+    :param out_root: Output prefix (files written as ``{out_root}.{mode}.*``).
+    :param gatk_image: GATK docker image.
+    :param gcp_billing_project: GCP billing project for requester-pays buckets.
+    :param hyperparameters_json: Optional model hyperparameters JSON path.
+    :return: Job with output ResourceGroup ``model``.
+    """
+    # GATK writes model files with a lowercase variant-type infix (e.g.
+    # .snp.scorer.pkl).
+    m = mode.lower()
+    j = b.new_job(f"GATK: TrainVariantAnnotationsModel {mode}")
+    j.image(gatk_image)
+    j.cpu(4)
+    j.memory("standard")
+    j.storage("100G")
+    j.declare_resource_group(
+        model={
+            f"{m}.scorer.pkl": f"{{root}}.{m}.scorer.pkl",
+            f"{m}.trainingScores.hdf5": f"{{root}}.{m}.trainingScores.hdf5",
+            f"{m}.calibrationScores.hdf5": f"{{root}}.{m}.calibrationScores.hdf5",
+        }
+    )
+    hp_arg = (
+        f" --hyperparameters-json {hyperparameters_json}"
+        if hyperparameters_json
+        else ""
+    )
+    j.command(
+        f"""set -euo pipefail
+        gatk --java-options "-Xmx6G" TrainVariantAnnotationsModel \\
+            --annotations-hdf5 {annotations_hdf5} \\
+            -O {j.model} \\
+            --mode {mode} \\
+            --model-backend PYTHON_IFOREST \\
+            --gcs-project-for-requester-pays {gcp_billing_project}{hp_arg}
+        """
+    )
+    b.write_output(j.model, out_root)
+    return j
+
+
+def split_intervals_job(
+    b: hb.Batch,
+    calling_intervals_arg: str,
+    exclude_intervals: str,
+    scatter_count: int,
+    gatk_image: str,
+    gcp_billing_project: str,
+) -> Job:
+    """
+    Split the calling contigs into ``scatter_count`` intervals, excluding telomeres/centromeres.
+
+    :param b: Batch to add the job to.
+    :param calling_intervals_arg: GATK ``-L`` args covering the calling contigs.
+    :param exclude_intervals: Path to an intervals file to exclude (``-XL``).
+    :param scatter_count: Number of interval shards to produce.
+    :param gatk_image: GATK docker image.
+    :param gcp_billing_project: GCP billing project for requester-pays buckets.
+    :return: Job with output ResourceGroup ``intervals``.
+    """
+    j = b.new_job(f"GATK: SplitIntervals ({scatter_count})")
+    j.image(gatk_image)
+    j.memory("standard")
+    j.storage("16G")
+    j.declare_resource_group(
+        intervals={
+            f"interval_{idx}": f"{{root}}/{str(idx).zfill(4)}-scattered.interval_list"
+            for idx in range(scatter_count)
+        }
+    )
+    j.command(
+        f"""set -euo pipefail
+        gatk --java-options "-Xms3g" SplitIntervals \\
+            -R {REFERENCE_RESOURCES['ref_fasta']} \\
+            {calling_intervals_arg} \\
+            -XL {exclude_intervals} \\
+            -O {j.intervals} \\
+            -scatter {scatter_count} \\
+            --interval-merging-rule OVERLAPPING_ONLY \\
+            -mode INTERVAL_SUBDIVISION \\
+            --gcs-project-for-requester-pays {gcp_billing_project}
+        """
+    )
+    return j
+
+
+def score_variant_annotations_job(
+    b: hb.Batch,
+    mode: str,
+    sites_only_vcf: str,
+    features: List[str],
+    extracted_vcf: hb.ResourceFile,
+    model: hb.ResourceGroup,
+    resource_args: str,
+    interval: hb.ResourceFile,
+    out_root: str,
+    gatk_image: str,
+    gcp_billing_project: str,
+) -> Job:
+    """
+    Run GATK ScoreVariantAnnotations for one variant type mode over one interval.
+
+    :param b: Batch to add the job to.
+    :param mode: Variant type mode, 'SNP' or 'INDEL'.
+    :param sites_only_vcf: AS-annotated sites-only input VCF.
+    :param features: Features for this mode (must match the trained model).
+    :param extracted_vcf: Extracted training/calibration VCF from the extract step.
+    :param model: Trained model ResourceGroup (its root is the ``--model-prefix``).
+    :param resource_args: GATK ``--resource`` args for the labeled sets.
+    :param interval: Interval file to restrict scoring to.
+    :param out_root: Output prefix (files written as ``{out_root}.*``).
+    :param gatk_image: GATK docker image.
+    :param gcp_billing_project: GCP billing project for requester-pays buckets.
+    :return: Job with output ResourceGroup ``output_score``.
+    """
+    j = b.new_job(f"GATK: ScoreVariantAnnotations {mode}")
+    j.image(gatk_image)
+    j.cpu(4)
+    j.memory("standard")
+    j.storage("100G")
+    j.declare_resource_group(
+        output_score={
+            "vcf.gz": "{root}.vcf.gz",
+            "vcf.gz.tbi": "{root}.vcf.gz.tbi",
+            "annot.hdf5": "{root}.annot.hdf5",
+            "scores.hdf5": "{root}.scores.hdf5",
+        }
+    )
+    j.command(
+        f"""set -euo pipefail
+        gatk --java-options "-Xmx6G" ScoreVariantAnnotations \\
+            -V {sites_only_vcf} \\
+            -O {j.output_score} \\
+            --mode {mode} \\
+            {_annotation_args(features)} \\
+            --resource:extracted,extracted=true {extracted_vcf} \\
+            --model-prefix {model} \\
+            --model-backend PYTHON_IFOREST \\
+            --use-allele-specific-annotations \\
+            -L {interval} \\
+            --gcs-project-for-requester-pays {gcp_billing_project} \\
+            {resource_args}
+        """
+    )
+    b.write_output(j.output_score, out_root)
+    return j
+
+
+def isolation_forest_workflow(
+    b: hb.Batch,
+    sites_only_vcf: str,
+    run_prefix: str,
+    out_vcf_name: str,
+    singletons_vcf: Optional[str],
+    calling_intervals_arg: str,
+    exclude_intervals: str,
+    scatter_count: int,
+    gatk_image: str,
+    gcp_billing_project: str,
+    hyperparameters_json: Optional[str] = None,
+    overwrite: bool = False,
+) -> None:
+    """
+    Add the per-mode extract/train/score jobs (SNP and INDEL) to the Batch.
+
+    Extract and train outputs are reused if they already exist (unless ``overwrite``).
+
+    :param b: Batch to add jobs to.
+    :param sites_only_vcf: AS-annotated sites-only input VCF.
+    :param run_prefix: GCS prefix for this run's GATK outputs.
+    :param out_vcf_name: Base name for scored VCF shards.
+    :param singletons_vcf: Optional true-positive singletons VCF.
+    :param calling_intervals_arg: GATK ``-L`` args for the calling contigs.
+    :param exclude_intervals: Path to the telomere/centromere exclusion intervals file.
+    :param scatter_count: Number of interval shards for scoring.
+    :param gatk_image: GATK docker image.
+    :param gcp_billing_project: GCP billing project for requester-pays buckets.
+    :param hyperparameters_json: Optional model hyperparameters JSON path.
+    :param overwrite: Whether to rerun extract/train even if outputs exist.
+    :return: None.
+    """
+    intervals = split_intervals_job(
+        b=b,
+        calling_intervals_arg=calling_intervals_arg,
+        exclude_intervals=exclude_intervals,
+        scatter_count=scatter_count,
+        gatk_image=gatk_image,
+        gcp_billing_project=gcp_billing_project,
+    ).intervals
+
+    # GATK requires an uppercase --mode; IF_FEATURES is keyed 'snv'/'indel'.
+    for mode, feature_key in [("SNP", "snv"), ("INDEL", "indel")]:
+        m = mode.lower()
+        features = IF_FEATURES[feature_key]
+        resource_args = _resource_args(mode, singletons_vcf)
+        extract_root = f"{run_prefix}/extract/{m}/extract"
+        model_root = f"{run_prefix}/model/{m}/model"
+
+        # Reuse extract outputs if present.
+        if not overwrite and file_exists(f"{extract_root}.annot.hdf5"):
+            logger.info("Reusing existing %s extract outputs.", mode)
+            annotations_hdf5 = b.read_input(f"{extract_root}.annot.hdf5")
+            extracted_vcf = b.read_input_group(
+                **{
+                    "vcf.gz": f"{extract_root}.vcf.gz",
+                    "vcf.gz.tbi": f"{extract_root}.vcf.gz.tbi",
+                }
+            )["vcf.gz"]
+        else:
+            extract_j = extract_variant_annotations_job(
+                b=b,
+                mode=mode,
+                sites_only_vcf=sites_only_vcf,
+                features=features,
+                resource_args=resource_args,
+                out_root=extract_root,
+                gatk_image=gatk_image,
+                gcp_billing_project=gcp_billing_project,
+            )
+            annotations_hdf5 = extract_j.extract["annot.hdf5"]
+            extracted_vcf = extract_j.extract["vcf.gz"]
+
+        # Reuse trained model if present.
+        if not overwrite and file_exists(f"{model_root}.{m}.scorer.pkl"):
+            logger.info("Reusing existing %s model.", mode)
+            model = b.read_input_group(
+                **{
+                    f"{m}.scorer.pkl": f"{model_root}.{m}.scorer.pkl",
+                    f"{m}.trainingScores.hdf5": f"{model_root}.{m}.trainingScores.hdf5",
+                    f"{m}.calibrationScores.hdf5": f"{model_root}.{m}.calibrationScores.hdf5",
+                }
+            )
+        else:
+            model = train_variant_annotations_model_job(
+                b=b,
+                mode=mode,
+                annotations_hdf5=annotations_hdf5,
+                out_root=model_root,
+                gatk_image=gatk_image,
+                gcp_billing_project=gcp_billing_project,
+                hyperparameters_json=hyperparameters_json,
+            ).model
+
+        for idx in range(scatter_count):
+            score_variant_annotations_job(
+                b=b,
+                mode=mode,
+                sites_only_vcf=sites_only_vcf,
+                features=features,
+                extracted_vcf=extracted_vcf,
+                model=model,
+                resource_args=resource_args,
+                interval=intervals[f"interval_{idx}"],
+                out_root=f"{run_prefix}/score/{m}/{out_vcf_name}{idx}",
+                gatk_image=gatk_image,
+                gcp_billing_project=gcp_billing_project,
+            )
+
+
+def export_exclusion_intervals() -> str:
+    """
+    Export telomere/centromere intervals to a GATK-readable intervals file.
+
+    :return: Path to the exported ``chr:start-end`` intervals file.
+    """
+    ht = telomeres_and_centromeres.ht()
+    interval = ht.interval
+    ht = ht.key_by(
+        interval=interval.start.contig
+        + ":"
+        + hl.str(interval.start.position)
+        + "-"
+        + hl.str(interval.end.position)
+    ).select()
+    path = hl.utils.new_temp_file("telomeres_centromeres", "intervals")
+    ht.export(path, header=False)
+    return path
+
+
+def merge_iforest_result(
+    run_prefix: str,
+    out_vcf_name: str,
+    model_id: str,
+    n_partitions: int,
+    header_path: Optional[str],
+    array_elements_required: bool,
+) -> hl.Table:
+    """
+    Merge the per-mode scored VCFs into a single variant QC result HT.
+
+    The SNP-pass VCF contributes SNP alleles and the INDEL-pass VCF contributes all
+    non-SNP alleles, so the union covers every scored allele exactly once.
+
+    :param run_prefix: GCS prefix for this run's GATK outputs.
+    :param out_vcf_name: Base name used for scored VCF shards.
+    :param model_id: Isolation forest model ID (starts with ``if_``).
+    :param n_partitions: Number of partitions for the imported HTs.
+    :param header_path: Optional VCF header file for import.
+    :param array_elements_required: Value passed to hl.import_vcf.
+    :return: Merged variant QC result HT.
+    """
+    snp_ht = import_variant_qc_vcf(
+        f"{run_prefix}/score/snp/{out_vcf_name}*.vcf.gz",
+        model_id,
+        n_partitions,
+        header_path,
+        array_elements_required,
+        deduplicate_check=True,
+    )[0]
+    indel_ht = import_variant_qc_vcf(
+        f"{run_prefix}/score/indel/{out_vcf_name}*.vcf.gz",
+        model_id,
+        n_partitions,
+        header_path,
+        array_elements_required,
+        deduplicate_check=True,
+    )[0]
+
+    snp_ht = snp_ht.filter(hl.is_snp(snp_ht.alleles[0], snp_ht.alleles[1]))
+    indel_ht = indel_ht.filter(~hl.is_snp(indel_ht.alleles[0], indel_ht.alleles[1]))
+    ht = snp_ht.union(indel_ht)
+    return ht.annotate_globals(
+        model_id=model_id,
+        snp_features=IF_FEATURES["snv"],
+        indel_features=IF_FEATURES["indel"],
+    )
+
+
+def main(args):
+    """Run the isolation forest variant QC workflow."""
+    environment = args.environment
+    _init_hail("isolation_forest", environment)
+
+    test = args.test
+    model_id = args.model_id
+    scatter_count = 10 if test else args.scatter_count
+    contigs = ["chr22"] if test else CALLING_CONTIGS
+    calling_intervals_arg = " ".join(f"-L {c}" for c in contigs)
+
+    true_positive_type = None
+    if args.transmitted_singletons and args.sibling_singletons:
+        true_positive_type = "transmitted_singleton.sibling_singleton"
+    elif args.transmitted_singletons:
+        true_positive_type = "transmitted_singleton"
+    elif args.sibling_singletons:
+        true_positive_type = "sibling_singleton"
+    # --test-on-v4 swaps inputs to v4 resources to validate the Batch pipeline while v5
+    # data is unavailable; outputs still route via --environment.
+    if args.test_on_v4:
+        from gnomad_qc.v4.resources.annotations import (
+            get_true_positive_vcf_path as v4_get_true_positive_vcf_path,
+        )
+        from gnomad_qc.v4.resources.annotations import info_vcf_path as v4_info_vcf_path
+
+        sites_only_vcf = v4_info_vcf_path(info_method="quasi")
+        singletons_vcf = (
+            v4_get_true_positive_vcf_path(
+                adj=args.adj, true_positive_type=true_positive_type
+            )
+            if true_positive_type
+            else None
+        )
+        run_prefix = f"gs://{BATCH_TMP_BUCKET}/if_v4_test/{model_id}"
+        result_ht_path = f"{run_prefix}/gnomad.exomes.v4.0.{model_id}.result.ht"
+    else:
+        sites_only_vcf = info_vcf_path(test=test, environment=environment)
+        singletons_vcf = (
+            get_true_positive_vcf_path(
+                adj=args.adj,
+                true_positive_type=true_positive_type,
+                test=test,
+                environment=environment,
+            )
+            if true_positive_type
+            else None
+        )
+        run_prefix = get_iforest_run_prefix(
+            model_id, test=test, environment=environment
+        )
+        result_ht_path = get_variant_qc_result(
+            model_id, test=test, split=True, environment=environment
+        ).path
+
+    if not args.load_only:
+        exclude_intervals = export_exclusion_intervals()
+        backend = hb.ServiceBackend(
+            billing_project=args.batch_billing_project,
+            remote_tmpdir=f"gs://{BATCH_TMP_BUCKET}/",
+        )
+        b = hb.Batch(f"isolation forest {model_id}{args.batch_suffix}", backend=backend)
+        isolation_forest_workflow(
+            b=b,
+            sites_only_vcf=sites_only_vcf,
+            run_prefix=run_prefix,
+            out_vcf_name=args.out_vcf_name,
+            singletons_vcf=singletons_vcf,
+            calling_intervals_arg=calling_intervals_arg,
+            exclude_intervals=exclude_intervals,
+            scatter_count=scatter_count,
+            gatk_image=args.gatk_image,
+            gcp_billing_project=args.gcp_billing_project,
+            hyperparameters_json=args.hyperparameters_json,
+            overwrite=args.overwrite,
+        )
+        b.run()
+
+    if args.load_iforest:
+        ht = merge_iforest_result(
+            run_prefix=run_prefix,
+            out_vcf_name=args.out_vcf_name,
+            model_id=model_id,
+            n_partitions=args.n_partitions,
+            header_path=args.header_path,
+            array_elements_required=args.array_elements_required,
+        )
+        ht.write(result_ht_path, overwrite=args.overwrite)
+
+
+def get_script_argument_parser() -> argparse.ArgumentParser:
+    """Get script argument parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o",
+        "--overwrite",
+        help="Whether to overwrite existing outputs.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test",
+        help="Filter to chr22 and use a small scatter count for testing.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test-on-v4",
+        help="Use gnomAD v4 sites/true-positive VCFs as inputs (v5 data unavailable).",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--environment",
+        help="Compute environment.",
+        default="batch",
+        type=str,
+        choices=["rwb", "batch", "dataproc"],
+    )
+    parser.add_argument(
+        "--model-id",
+        help="Model ID for the isolation forest run. Must start with 'if_'.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--out-vcf-name",
+        help="Base name for scored VCF shards.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--batch-billing-project",
+        help="Hail Batch billing project.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--gcp-billing-project",
+        help="GCP billing project for requester-pays buckets.",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--gatk-image",
+        help="GATK docker image.",
+        default=DEFAULT_GATK_IMAGE,
+        type=str,
+    )
+    parser.add_argument(
+        "--scatter-count",
+        help="Number of intervals to scatter scoring across.",
+        default=100,
+        type=int,
+    )
+    parser.add_argument(
+        "--transmitted-singletons",
+        help="Include transmitted singletons as a training/calibration set.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--sibling-singletons",
+        help="Include sibling singletons as a training/calibration set.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--adj",
+        help="Use adj genotypes for the true-positive singletons VCF.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--hyperparameters-json",
+        help="Optional GATK model hyperparameters JSON path.",
+        type=str,
+    )
+    parser.add_argument(
+        "--batch-suffix",
+        help="String to append to the Batch name.",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "--load-iforest",
+        help="Merge the scored VCFs into a variant QC result HT.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--load-only",
+        help="Skip the GATK Batch and only run the load step.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--n-partitions",
+        help="Number of partitions for the result HT.",
+        default=5000,
+        type=int,
+    )
+    parser.add_argument(
+        "--header-path",
+        help="Optional header file to use when importing the scored VCFs.",
+    )
+    parser.add_argument(
+        "--array-elements-required",
+        help="Set array_elements_required=True when importing the scored VCFs.",
+        action="store_true",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_script_argument_parser()
+    main(parser.parse_args())

--- a/gnomad_qc/v5/variant_qc/isolation_forest.py
+++ b/gnomad_qc/v5/variant_qc/isolation_forest.py
@@ -272,6 +272,7 @@ def score_variant_annotations_job(
     model: hb.ResourceGroup,
     resource_args: str,
     interval: hb.ResourceFile,
+    idx: int,
     out_root: str,
     gatk_image: str,
     gcp_billing_project: str,
@@ -287,6 +288,7 @@ def score_variant_annotations_job(
     :param model: Trained model ResourceGroup (its root is the ``--model-prefix``).
     :param resource_args: GATK ``--resource`` args for the labeled sets.
     :param interval: Interval file to restrict scoring to.
+    :param idx: Shard index, used to identify the job in the Batch.
     :param out_root: Output prefix (files written as ``{out_root}.*``).
     :param gatk_image: GATK docker image.
     :param gcp_billing_project: GCP billing project for requester-pays buckets.
@@ -301,7 +303,7 @@ def score_variant_annotations_job(
         emission exactly-once across shards. It also makes ``-XL`` start-based, which
         is the definition `reconcile_scored_sites` uses.
     """
-    j = b.new_job(f"GATK: ScoreVariantAnnotations {mode}")
+    j = b.new_job(f"GATK: ScoreVariantAnnotations {mode} {idx}")
     j.image(gatk_image)
     j.cpu(4)
     j.memory("standard")
@@ -449,6 +451,7 @@ def isolation_forest_workflow(
                 model=model,
                 resource_args=resource_args,
                 interval=intervals[f"interval_{idx}"],
+                idx=idx,
                 out_root=score_root,
                 gatk_image=gatk_image,
                 gcp_billing_project=gcp_billing_project,


### PR DESCRIPTION
Add isolation forest (IF) code for v5 using v4 VQSR and [IF](https://github.com/broadinstitute/gnomad_qc/blob/archive/v4/isolation_forest/gnomad_qc/v4/variant_qc/isolation_forest.py) code as reference

Test commands:
```
python v5/variant_qc/isolation_forest.py --test-on-v4 --environment batch --export-v4-test-vcf --export-only --out-vcf-name if_quasi_raw_ts_ss --model-id if_quasi_raw_ts_ss --batch-billing-project gnomad-production --gcp-billing-project broad-mpg-gnomad --app-name if_quasi_raw_ts_ss_v4test_chr22_export --driver-memory highmem --driver-cores 8 --overwrite
```
```
python v5/variant_qc/isolation_forest.py --test-on-v4 --environment batch --out-vcf-name if_quasi_raw_ts_ss --model-id if_quasi_raw_ts_ss --transmitted-singletons --sibling-singletons --batch-billing-project gnomad-production --gcp-billing-project broad-mpg-gnomad --batch-suffix v4test --app-name if_quasi_raw_ts_ss_v4test_chr22_score_load --load-iforest --overwrite --driver-memory highmem --driver-cores 8
```
Feel free to overwrite test outputs during review


Overview from claude:

### What's here
- **`v5/variant_qc/isolation_forest.py`** — per-mode (SNP/INDEL) `ExtractVariantAnnotations` → `TrainVariantAnnotationsModel` (`PYTHON_IFOREST`) → `ScoreVariantAnnotations` scattered over intervals, merged into one result HT.
- **`v5/variant_qc/import_variant_qc_vcf.py`** — port of the v4 scored-VCF → HT loader.
- **`v5/resources/variant_qc.py`** — `VARIANT_QC_FEATURES`, `get_variant_qc_result`, `get_iforest_run_prefix`.
- **`v5/annotations/generate_variant_qc_annotations.py`** — declare the AS features `Number=A` in the info VCF export; add `--test-chrom`.

### Notes for review
- SNPs and indels get **separate models and separate feature lists**: GATK trains per `--mode` and consumes only the numeric annotation matrix, so it can't learn variant type the way the v4 RF does. Indels drop `AS_MQ`.
- GATK 4.5.0.0 dropped `--use-allele-specific-annotations` and now infers AS mode from `Number=A` in the header — hence the info VCF export change (Hail writes `Number=1` for these split scalars).
- Scoring uses `--variant-output-filtering STARTS_IN` so each record is emitted by exactly one shard.
- `reconcile_scored_sites` fails the load if any input variant in the scored region is absent or unscored.
- `--test-on-v4` exercises the pipeline in Batch on v4 exomes chr22 while v5 data isn't ready; outputs go to `batch-tmp` under explicitly v4-labeled paths, never the v5 tree.