### PR TITLE
Kl/aou vds sample artifact jsons

### DIFF
--- a/gnomad_qc/v5/annotations/compute_coverage.py
+++ b/gnomad_qc/v5/annotations/compute_coverage.py
@@ -135,7 +135,10 @@ def get_group_membership_ht(
             ),
         )
 
-    return ht
+    # Coalesce: this is a small per-sample lookup (~365k rows) that otherwise
+    # inherits ~330 partitions from the meta HT and fans every downstream
+    # read/collect into ~330 tasks.
+    return ht.naive_coalesce(10)
 
 
 def validate_vds(vds: hl.vds.VariantDataset) -> None:

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -547,14 +547,32 @@ def get_aou_vds(
 
     if release_only or high_quality_only or annotate_meta or add_project_prefix:
         # Import here to avoid circular imports.
-        from gnomad_qc.v5.resources.meta import get_sample_id_collisions, meta
+        from gnomad_qc.v5.resources.meta import (
+            get_sample_id_collisions,
+            load_aou_sample_artifact_json,
+            meta,
+        )
 
         meta_ht = meta(data_type="genomes", environment=environment).ht()
 
         logger.warning(
             "Adding 'aou_' prefix to samples that had ID collisions with gnomAD samples..."
         )
-        sample_collisions = get_sample_id_collisions(environment=environment).ht()
+        # Prefer the permanent precomputed JSON (write_aou_vds_sample_jsons)
+        # over rescanning the sample-collisions Table.
+        collisions = load_aou_sample_artifact_json(
+            "sample_id_collisions.json", test=test, environment=environment
+        )
+        if collisions is not None:
+            logger.info(
+                "Using precomputed sample_id_collisions.json (%d sample IDs).",
+                len(collisions),
+            )
+            sample_collisions = set(collisions)
+        else:
+            sample_collisions = get_sample_id_collisions(
+                environment=environment
+            ).ht()
         vmt = add_project_prefix_to_sample_collisions(
             t=vmt, sample_collisions=sample_collisions, project="aou"
         )
@@ -588,15 +606,36 @@ def get_aou_vds(
 
     vds = hl.vds.VariantDataset(rmt, vmt)
 
+    # For the release and high-quality filters, prefer the permanent precomputed
+    # JSONs (write_aou_vds_sample_jsons) over the meta-table scans. The JSON IDs
+    # are post-prefix, matching the VDS sample IDs at this point.
     if release_only:
         logger.info("Filtering VDS to release samples only...")
-        filter_expr = meta_ht.release
-        vds = hl.vds.filter_samples(vds, meta_ht.filter(filter_expr))
+        release_samples = load_aou_sample_artifact_json(
+            "release_samples.json", test=test, environment=environment
+        )
+        if release_samples is not None:
+            logger.info(
+                "Using precomputed release_samples.json (%d sample IDs).",
+                len(release_samples),
+            )
+            vds = hl.vds.filter_samples(vds, release_samples)
+        else:
+            vds = hl.vds.filter_samples(vds, meta_ht.filter(meta_ht.release))
 
     if high_quality_only:
         logger.info("Filtering VDS to high quality samples only...")
-        filter_expr = meta_ht.high_quality
-        vds = hl.vds.filter_samples(vds, meta_ht.filter(filter_expr))
+        hq_samples = load_aou_sample_artifact_json(
+            "high_quality_samples.json", test=test, environment=environment
+        )
+        if hq_samples is not None:
+            logger.info(
+                "Using precomputed high_quality_samples.json (%d sample IDs).",
+                len(hq_samples),
+            )
+            vds = hl.vds.filter_samples(vds, hq_samples)
+        else:
+            vds = hl.vds.filter_samples(vds, meta_ht.filter(meta_ht.high_quality))
 
     if filter_samples:
         logger.info(
@@ -890,7 +929,7 @@ def get_samples_to_exclude(
 
 def add_project_prefix_to_sample_collisions(
     t: Union[hl.Table, hl.MatrixTable],
-    sample_collisions: hl.Table,
+    sample_collisions: Union[hl.Table, Set[str]],
     project: Optional[str] = None,
     sample_id_field: str = "s",
 ) -> hl.Table:
@@ -898,7 +937,10 @@ def add_project_prefix_to_sample_collisions(
     Add project prefix to sample IDs that exist in multiple projects.
 
     :param t: Table/MatrixTable to add project prefix to sample IDs.
-    :param sample_collisions: Table of sample IDs that exist in multiple projects.
+    :param sample_collisions: Table of sample IDs that exist in multiple projects, or
+        an already-collected set of those IDs. Collecting from a Table launches a full
+        scan of it, so callers applying the same collisions to several tables should
+        collect once and pass the set.
     :param project: Optional project name to prepend to sample collisions. If not set, will use 'ht.project' annotation. Default is None.
     :param sample_id_field: Field name for sample IDs in the table.
     :return: Table with project prefix added to sample IDs.
@@ -906,7 +948,12 @@ def add_project_prefix_to_sample_collisions(
     logger.info(
         "Adding project prefix to sample IDs that exists in multiple projects..."
     )
-    collisions = sample_collisions.aggregate(hl.agg.collect_as_set(sample_collisions.s))
+    if isinstance(sample_collisions, hl.Table):
+        collisions = sample_collisions.aggregate(
+            hl.agg.collect_as_set(sample_collisions.s)
+        )
+    else:
+        collisions = sample_collisions
 
     if project:
         prefix_expr = hl.literal(project)

--- a/gnomad_qc/v5/resources/basics.py
+++ b/gnomad_qc/v5/resources/basics.py
@@ -570,9 +570,7 @@ def get_aou_vds(
             )
             sample_collisions = set(collisions)
         else:
-            sample_collisions = get_sample_id_collisions(
-                environment=environment
-            ).ht()
+            sample_collisions = get_sample_id_collisions(environment=environment).ht()
         vmt = add_project_prefix_to_sample_collisions(
             t=vmt, sample_collisions=sample_collisions, project="aou"
         )

--- a/gnomad_qc/v5/resources/meta.py
+++ b/gnomad_qc/v5/resources/meta.py
@@ -1,20 +1,32 @@
 """Script containing metadata related resources."""
 
+import json
+import logging
+from typing import Optional
+
+import hail as hl
+import hailtop.fs as hfs
 from gnomad.resources.resource_utils import (
     ExpressionResource,
     TableResource,
     VersionedTableResource,
 )
+from gnomad.utils.file_utils import file_exists
 
 from gnomad_qc.v5.resources.basics import (
     _SAMPLE_DATA_ENVIRONMENTS,
+    _check_resource_existence,
     _get_base_bucket,
     _validate_environment,
+    qc_temp_prefix,
 )
 from gnomad_qc.v5.resources.constants import (
     CURRENT_PROJECT_META_VERSION,
     CURRENT_SAMPLE_QC_VERSION,
 )
+
+logger = logging.getLogger("meta_resources")
+logger.setLevel(logging.INFO)
 
 
 def get_project_meta(environment: str = "batch") -> VersionedTableResource:
@@ -53,6 +65,144 @@ def get_sample_id_collisions(environment: str = "batch") -> TableResource:
     )
     return TableResource(
         path=f"gs://{bucket}/v5.0/metadata/gnomad.v5.0.sample_id_collisions.ht"
+    )
+
+
+def aou_sample_artifact_path(
+    name: str,
+    test: bool = False,
+    environment: str = "batch",
+    version: str = CURRENT_PROJECT_META_VERSION,
+) -> str:
+    """
+    Return the permanent path to a run-invariant AoU sample-level artifact.
+
+    Artifacts are small precomputed files read at VDS load (or by pipeline
+    workers) instead of rescanning the ~330-partition sample metadata tables:
+    the VDS-loading JSONs written by `write_aou_vds_sample_jsons`
+    (``sample_id_collisions.json``, ``high_quality_samples.json``,
+    ``release_samples.json``) and pipeline-specific Hail Tables such as the
+    frequency pipeline's ``meta_small.ht`` and ``gm_coalesced[_reduce].ht``.
+
+    Full-scope artifacts are permanent; unlike `_meta_root_path`, their root
+    resolves to the writable bucket in the "batch" environment (artifacts are
+    both written and read from batch). Test-scope artifacts are disposable and
+    live in the 4-day temp bucket, per repo convention.
+
+    :param name: Artifact file name (with extension).
+    :param test: If True, return the test-scoped path (10-sample test VDS runs),
+        in the 4-day temp bucket.
+    :param environment: Environment to use. Default is "batch". Must be one of
+        "rwb" or "batch".
+    :param version: gnomAD version.
+    :return: GCS path to the artifact.
+    """
+    _validate_environment(environment, _SAMPLE_DATA_ENVIRONMENTS)
+    if test:
+        # Test artifacts are disposable: 4-day temp bucket, per repo convention.
+        return (
+            f"{qc_temp_prefix(version=version, environment=environment, days=4)}"
+            f"aou_sample_artifacts_test/{name}"
+        )
+    return (
+        f"gs://{_get_base_bucket(environment)}/v{version}/metadata/genomes/"
+        f"aou_sample_artifacts_full/{name}"
+    )
+
+
+def load_aou_sample_artifact_json(
+    name: str,
+    test: bool = False,
+    environment: str = "batch",
+) -> Optional[list]:
+    """
+    Return the parsed JSON sample artifact, or None when it has not been written.
+
+    :param name: Artifact file name (with extension).
+    :param test: If True, read the test-scoped path.
+    :param environment: Environment to use. Default is "batch". Must be one of
+        "rwb" or "batch".
+    :return: Parsed JSON value, or None if the file is absent.
+    """
+    path = aou_sample_artifact_path(name, test=test, environment=environment)
+    if not file_exists(path):
+        return None
+    with hfs.open(path) as f:
+        return json.load(f)
+
+
+def write_aou_vds_sample_jsons(
+    environment: str = "batch",
+    test: bool = False,
+    overwrite: bool = False,
+) -> None:
+    """
+    Write the permanent sample artifact JSONs used to load the AoU VDS.
+
+    Writes three artifacts so that VDS loads read small files instead of each
+    rescanning the ~330-partition sample metadata tables:
+
+    - ``sample_id_collisions.json``: pre-prefix sample IDs that collide with
+      gnomAD samples (from the sample-collisions Table).
+    - ``high_quality_samples.json``: post-prefix high-quality sample IDs,
+      collected with the exact ``meta_ht.high_quality`` filter that
+      ``get_aou_vds(high_quality_only=True)`` applies, so the two cannot drift.
+    - ``release_samples.json``: post-prefix release sample IDs, collected with
+      the exact ``meta_ht.release`` filter that ``get_aou_vds(release_only=True)``
+      applies.
+
+    `get_aou_vds` prefers these files and falls back to the original scans for
+    any that are absent.
+
+    :param environment: Environment to use. Default is "batch". Must be one of
+        "rwb" or "batch".
+    :param test: If True, write the test-scoped paths (4-day temp bucket).
+    :param overwrite: Whether to replace existing artifacts; without it, a rerun
+        fails instead of silently rewriting them. Default is False.
+    """
+    paths = {
+        name: aou_sample_artifact_path(name, test=test, environment=environment)
+        for name in (
+            "sample_id_collisions.json",
+            "high_quality_samples.json",
+            "release_samples.json",
+        )
+    }
+    _check_resource_existence(
+        environment=environment,
+        output_step_resources={
+            "--write-vds-sample-artifact-jsons": list(paths.values())
+        },
+        overwrite=overwrite,
+    )
+
+    sc_ht = get_sample_id_collisions(environment=environment).ht()
+    collisions = sorted(sc_ht.aggregate(hl.agg.collect_as_set(sc_ht.s)))
+    with hfs.open(paths["sample_id_collisions.json"], "w") as f:
+        json.dump(collisions, f)
+    logger.info(
+        "Wrote %d collision sample IDs: %s",
+        len(collisions),
+        paths["sample_id_collisions.json"],
+    )
+
+    meta_ht = meta(data_type="genomes", environment=environment).ht()
+    hq_samples = meta_ht.filter(meta_ht.high_quality).s.collect()
+    with hfs.open(paths["high_quality_samples.json"], "w") as f:
+        json.dump(hq_samples, f)
+    logger.info(
+        "Wrote %d high-quality sample IDs: %s",
+        len(hq_samples),
+        paths["high_quality_samples.json"],
+    )
+
+    release_samples = meta_ht.filter(meta_ht.release).s.collect()
+    with hfs.open(paths["release_samples.json"], "w") as f:
+        json.dump(release_samples, f)
+    logger.info(
+        "Wrote %d release sample IDs: %s",
+        len(release_samples),
+        paths["release_samples.json"],
     )
 
 

--- a/gnomad_qc/v5/resources/meta.py
+++ b/gnomad_qc/v5/resources/meta.py
@@ -81,8 +81,7 @@ def aou_sample_artifact_path(
     workers) instead of rescanning the ~330-partition sample metadata tables:
     the VDS-loading JSONs written by `write_aou_vds_sample_jsons`
     (``sample_id_collisions.json``, ``high_quality_samples.json``,
-    ``release_samples.json``) and pipeline-specific Hail Tables such as the
-    frequency pipeline's ``meta_small.ht`` and ``gm_coalesced[_reduce].ht``.
+    ``release_samples.json``).
 
     Full-scope artifacts are permanent; unlike `_meta_root_path`, their root
     resolves to the writable bucket in the "batch" environment (artifacts are

--- a/gnomad_qc/v5/sample_qc/create_sample_qc_metadata_ht.py
+++ b/gnomad_qc/v5/sample_qc/create_sample_qc_metadata_ht.py
@@ -498,7 +498,6 @@ def main(args):
             logger.info("Writing permanent VDS-loading sample artifact JSONs...")
             write_aou_vds_sample_jsons(
                 environment=environment,
-                test=args.test,
                 overwrite=args.overwrite,
             )
             return
@@ -615,14 +614,6 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
             "~330-partition sample tables. Runs standalone (skips the meta HT "
             "build); rerun it whenever the meta HT is rewritten. Requires "
             "--overwrite to replace existing artifacts."
-        ),
-        action="store_true",
-    )
-    parser.add_argument(
-        "--test",
-        help=(
-            "With --write-vds-sample-artifact-jsons, write the test-scoped "
-            "artifact paths (used when loading the 10-sample test VDS)."
         ),
         action="store_true",
     )

--- a/gnomad_qc/v5/sample_qc/create_sample_qc_metadata_ht.py
+++ b/gnomad_qc/v5/sample_qc/create_sample_qc_metadata_ht.py
@@ -24,7 +24,12 @@ from gnomad_qc.v5.resources.basics import (
     get_logging_path,
     get_samples_to_exclude,
 )
-from gnomad_qc.v5.resources.meta import get_project_meta, get_sample_id_collisions, meta
+from gnomad_qc.v5.resources.meta import (
+    get_project_meta,
+    get_sample_id_collisions,
+    meta,
+    write_aou_vds_sample_jsons,
+)
 from gnomad_qc.v5.resources.sample_qc import (
     finalized_outlier_filtering,
     get_gen_anc_ht,
@@ -489,6 +494,15 @@ def main(args):
     _init_hail("create_sample_meta", environment)
 
     try:
+        if args.write_vds_sample_artifact_jsons:
+            logger.info("Writing permanent VDS-loading sample artifact JSONs...")
+            write_aou_vds_sample_jsons(
+                environment=environment,
+                test=args.test,
+                overwrite=args.overwrite,
+            )
+            return
+
         check_resource_existence(
             output_step_resources={
                 "sample_qc_meta": [meta(environment=environment).path],
@@ -590,6 +604,27 @@ def get_script_argument_parser() -> argparse.ArgumentParser:
         help="Environment where script will run.",
         choices=["rwb", "batch"],
         default="rwb",
+    )
+    parser.add_argument(
+        "--write-vds-sample-artifact-jsons",
+        help=(
+            "Write the permanent VDS-loading sample artifact JSONs "
+            "(sample_id_collisions.json, high_quality_samples.json, and "
+            "release_samples.json) from the finished meta HT, so every "
+            "get_aou_vds call reads small JSONs instead of rescanning the "
+            "~330-partition sample tables. Runs standalone (skips the meta HT "
+            "build); rerun it whenever the meta HT is rewritten. Requires "
+            "--overwrite to replace existing artifacts."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--test",
+        help=(
+            "With --write-vds-sample-artifact-jsons, write the test-scoped "
+            "artifact paths (used when loading the 10-sample test VDS)."
+        ),
+        action="store_true",
     )
     return parser
 


### PR DESCRIPTION
Loading the AoU VDS rescans the ~330-partition sample metadata tables on every call; this PR snapshots those sample sets once as small permanent JSONs.

meta.py: aou_sample_artifact_path (permanent bucket for full scope, 4-day temp for test), load_aou_sample_artifact_json, and write_aou_vds_sample_jsons (sample_id_collisions.json, high_quality_samples.json, release_samples.json; reruns need --overwrite).
basics.py: get_aou_vds prefers the JSONs for collision prefixing and the release/high-quality filters, falling back to the original scans when absent. 
create_sample_qc_metadata_ht.py: standalone --write-vds-sample-artifact-jsons step (plus --test) — lives with the meta HT builder; rerun whenever the meta HT is rewritten.
compute_coverage.py: get_group_membership_ht returns the ~365k-row lookup coalesced to 10 partitions, fixing the ~330-task fan-out at the source.
