### PR TITLE
Update adj for AoU data to use GQ20

### DIFF
--- a/gnomad_qc/v5/annotations/annotation_utils.py
+++ b/gnomad_qc/v5/annotations/annotation_utils.py
@@ -4,6 +4,7 @@ import logging
 from typing import Union
 
 import hail as hl
+from gnomad.utils.annotations import get_adj_expr as get_gnomad_adj_expr
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger("annotation_utils")
@@ -12,22 +13,33 @@ logger.setLevel(logging.INFO)
 
 # AoU-specific adj annotation utilities.
 # Adapted from https://github.com/broadinstitute/gatk/pull/8772/files.
-# After discussion, we decided to use GQ 30 threshold for both haploid and diploid genotypes.
-# See thread: https://atgu.slack.com/archives/CRA2TKTV0/p1762443074200349
+#
+# The AoU VDS has no DP entry field, so DP is approximated as sum(LAD). Hom-ref calls
+# (reference blocks, which carry GQ but no LAD) are filtered on GQ only. All other
+# calls use the usual gnomAD cutoffs: GQ, DP (as sum(LAD)), and AB for het calls.
+# After discussion, we decided to use a GQ 20 threshold for both haploid and diploid
+# genotypes. See thread: https://atgu.slack.com/archives/CRA2TKTV0/p1787333884174549
 def annotate_adj_no_dp(
     mt: hl.MatrixTable,
-    adj_gq: int = 30,
+    adj_gq: int = 20,
+    adj_dp: int = 10,
     adj_ab: float = 0.2,
+    haploid_adj_dp: int = 5,
 ) -> hl.MatrixTable:
     """
     Annotate genotypes with adj criteria.
 
-    Defaults are similar to gnomAD values, but GQ >= 20 changed to GQ >= 30 to make up for lack of DP filter
-    (raised GQ threshold to 30 to match DP 10 threshold in gnomAD defaults).
+    Defaults correspond to gnomAD values. DP is approximated as the sum of the allele
+    depths and is only applied to non-hom-ref calls; hom-ref calls are filtered on GQ
+    only. See the module comment for details.
 
     :param mt: Input MatrixTable.
-    :param adj_gq: Minimum GQ. Default is 30.
-    :param adj_ab: Minimum allele balance. Default is 0.2.
+    :param adj_gq: Minimum GQ. Default is 20.
+    :param adj_dp: Minimum DP (sum of allele depths) for non-hom-ref calls. Default is
+        10.
+    :param adj_ab: Minimum allele balance for het calls. Default is 0.2.
+    :param haploid_adj_dp: Minimum DP (sum of allele depths) for haploid non-ref
+        calls. Default is 5.
     :return: MatrixTable with adj annotation.
     """
     if "LGT" in mt.entry and "LAD" in mt.entry:
@@ -38,7 +50,9 @@ def annotate_adj_no_dp(
         gt_expr = mt.GT
         ad_expr = mt.AD
     return mt.annotate_entries(
-        adj=get_adj_expr(gt_expr, mt.GQ, ad_expr, adj_gq, adj_ab)
+        adj=get_adj_expr(
+            gt_expr, mt.GQ, ad_expr, adj_gq, adj_dp, adj_ab, haploid_adj_dp
+        )
     )
 
 
@@ -46,13 +60,17 @@ def get_adj_expr(
     gt_expr: hl.expr.CallExpression,
     gq_expr: Union[hl.expr.Int32Expression, hl.expr.Int64Expression],
     ad_expr: hl.expr.ArrayNumericExpression,
-    adj_gq: int = 30,
+    adj_gq: int = 20,
+    adj_dp: int = 10,
     adj_ab: float = 0.2,
+    haploid_adj_dp: int = 5,
 ) -> hl.expr.BooleanExpression:
     """
     Get adj genotype annotation.
 
-    Defaults are similar to gnomAD values, but GQ >= 20 changed to GQ >= 30 to make up for lack of DP filter.
+    Defaults correspond to gnomAD values. Hom-ref calls are filtered on GQ only. All
+    other calls use the standard gnomAD adj criteria (GQ, DP, and AB for het calls)
+    with DP approximated as the sum of `ad_expr`.
 
     .. note::
 
@@ -61,17 +79,25 @@ def get_adj_expr(
     :param gt_expr: Genotype expression.
     :param gq_expr: GQ expression.
     :param ad_expr: Allele depth expression.
-    :param adj_gq: Minimum GQ. Default is 30.
-    :param adj_ab: Minimum allele balance. Default is 0.2.
+    :param adj_gq: Minimum GQ. Default is 20.
+    :param adj_dp: Minimum DP (sum of allele depths) for non-hom-ref calls. Default is
+        10.
+    :param adj_ab: Minimum allele balance for het calls. Default is 0.2.
+    :param haploid_adj_dp: Minimum DP (sum of allele depths) for haploid non-ref
+        calls. Default is 5.
     :return: Expression for adj genotype annotation.
     """
-    total_ad = hl.sum(ad_expr)
-    return (gq_expr >= adj_gq) & (
-        hl.case()
-        .when(~gt_expr.is_het(), True)
-        .when(gt_expr.is_het_ref(), ad_expr[gt_expr[1]] / total_ad >= adj_ab)
-        .default(
-            (ad_expr[gt_expr[0]] / total_ad >= adj_ab)
-            & (ad_expr[gt_expr[1]] / total_ad >= adj_ab)
-        )
+    return hl.if_else(
+        gt_expr.is_hom_ref(),
+        gq_expr >= adj_gq,
+        get_gnomad_adj_expr(
+            gt_expr,
+            gq_expr,
+            hl.sum(ad_expr),
+            ad_expr,
+            adj_gq=adj_gq,
+            adj_dp=adj_dp,
+            adj_ab=adj_ab,
+            haploid_adj_dp=haploid_adj_dp,
+        ),
     )

--- a/gnomad_qc/v5/annotations/annotation_utils.py
+++ b/gnomad_qc/v5/annotations/annotation_utils.py
@@ -1,6 +1,7 @@
 """AoU-specific annotation utilities."""
 
 import logging
+from typing import Union
 
 import hail as hl
 from gnomad.utils.annotations import get_adj_expr as get_gnomad_adj_expr
@@ -92,7 +93,7 @@ def annotate_adj_no_dp(
 
 def get_adj_expr(
     gt_expr: hl.expr.CallExpression,
-    gq_expr: hl.expr.Int32Expression | hl.expr.Int64Expression,
+    gq_expr: Union[hl.expr.Int32Expression, hl.expr.Int64Expression],
     ad_expr: hl.expr.ArrayNumericExpression,
     adj_gq: int = 20,
     adj_dp: int = 10,

--- a/gnomad_qc/v5/annotations/annotation_utils.py
+++ b/gnomad_qc/v5/annotations/annotation_utils.py
@@ -1,7 +1,6 @@
 """AoU-specific annotation utilities."""
 
 import logging
-from typing import Union
 
 import hail as hl
 from gnomad.utils.annotations import get_adj_expr as get_gnomad_adj_expr
@@ -33,6 +32,17 @@ def annotate_adj_no_dp(
     depths and is only applied to non-hom-ref calls; hom-ref calls are filtered on GQ
     only. See the module comment for details.
 
+    Accepts three entry layouts:
+
+        - ``LGT`` and ``LAD`` (VDS variant data): full adj criteria.
+        - ``GT`` and ``AD`` (split or dense data): full adj criteria.
+        - ``GT`` without allele depths (VDS reference data, e.g. the AoU reference
+          blocks with only ``GT``, ``GQ``, ``END`` and ``LEN``): every call must be
+          hom-ref and adj is ``GQ >= adj_gq``. A non-hom-ref call raises at runtime
+          rather than being silently marked non-adj.
+
+    ``GQ`` is required in all three cases.
+
     :param mt: Input MatrixTable.
     :param adj_gq: Minimum GQ. Default is 20.
     :param adj_dp: Minimum DP (sum of allele depths) for non-hom-ref calls. Default is
@@ -42,23 +52,45 @@ def annotate_adj_no_dp(
         calls. Default is 5.
     :return: MatrixTable with adj annotation.
     """
-    if "LGT" in mt.entry and "LAD" in mt.entry:
-        gt_expr = mt.LGT
-        ad_expr = mt.LAD
-    else:
-        assert "GT" in mt.entry and "AD" in mt.entry
-        gt_expr = mt.GT
-        ad_expr = mt.AD
-    return mt.annotate_entries(
-        adj=get_adj_expr(
-            gt_expr, mt.GQ, ad_expr, adj_gq, adj_dp, adj_ab, haploid_adj_dp
+    entry_fields = set(mt.entry)
+    if "GQ" not in entry_fields:
+        raise ValueError("annotate_adj_no_dp requires a 'GQ' entry field.")
+
+    if "LGT" in entry_fields and "LAD" in entry_fields:
+        adj_expr = get_adj_expr(
+            mt.LGT, mt.GQ, mt.LAD, adj_gq, adj_dp, adj_ab, haploid_adj_dp
         )
-    )
+    elif "GT" in entry_fields and "AD" in entry_fields:
+        adj_expr = get_adj_expr(
+            mt.GT, mt.GQ, mt.AD, adj_gq, adj_dp, adj_ab, haploid_adj_dp
+        )
+    elif "GT" in entry_fields:
+        # Reference data: hom-ref blocks that carry GQ but no allele depths, so
+        # adj is GQ only. A missing genotype (e.g. after a sex-ploidy adjustment)
+        # gets a missing adj, matching get_adj_expr. Error on a non-hom-ref call
+        # rather than silently marking it non-adj.
+        adj_expr = (
+            hl.case()
+            .when(hl.is_missing(mt.GT), hl.missing(hl.tbool))
+            .when(mt.GT.is_hom_ref(), mt.GQ >= adj_gq)
+            .or_error(
+                "Found a non-hom-ref genotype in a MatrixTable with no AD or LAD "
+                "entry field. Allele depths are required to compute adj for "
+                "non-hom-ref calls."
+            )
+        )
+    else:
+        raise ValueError(
+            "annotate_adj_no_dp requires 'LGT' and 'LAD', 'GT' and 'AD', or 'GT' "
+            "alone (hom-ref reference data) in the entry fields."
+        )
+
+    return mt.annotate_entries(adj=adj_expr)
 
 
 def get_adj_expr(
     gt_expr: hl.expr.CallExpression,
-    gq_expr: Union[hl.expr.Int32Expression, hl.expr.Int64Expression],
+    gq_expr: hl.expr.Int32Expression | hl.expr.Int64Expression,
     ad_expr: hl.expr.ArrayNumericExpression,
     adj_gq: int = 20,
     adj_dp: int = 10,

--- a/gnomad_qc/v5/annotations/annotation_utils.py
+++ b/gnomad_qc/v5/annotations/annotation_utils.py
@@ -47,11 +47,11 @@ def annotate_adj_no_dp(
 
     :param mt: Input MatrixTable.
     :param adj_gq: Minimum GQ. Default is 20.
-    :param adj_dp: Minimum DP (sum of allele depths) for non-hom-ref calls. Default is
-        10.
+    :param adj_dp: Minimum DP (sum of allele depths) for calls with allele depths.
+        Default is 10.
     :param adj_ab: Minimum allele balance for het calls. Default is 0.2.
-    :param haploid_adj_dp: Minimum DP (sum of allele depths) for haploid non-ref
-        calls. Default is 5.
+    :param haploid_adj_dp: Minimum DP (sum of allele depths) for haploid calls with
+        allele depths. Default is 5.
     :return: MatrixTable with adj annotation.
     """
     entry_fields = set(mt.entry)

--- a/gnomad_qc/v5/annotations/annotation_utils.py
+++ b/gnomad_qc/v5/annotations/annotation_utils.py
@@ -14,8 +14,10 @@ logger.setLevel(logging.INFO)
 # Adapted from https://github.com/broadinstitute/gatk/pull/8772/files.
 #
 # The AoU VDS has no DP entry field, so DP is approximated as sum(LAD). Hom-ref calls
-# (reference blocks, which carry GQ but no LAD) are filtered on GQ only. All other
-# calls use the usual gnomAD cutoffs: GQ, DP (as sum(LAD)), and AB for het calls.
+# with no allele depths (reference blocks, which carry GQ but no LAD) are filtered on
+# GQ only. All other calls, including hom-ref calls that do carry allele depths (e.g.
+# calls downcoded to hom-ref by split_multi), use the usual gnomAD cutoffs: GQ, DP (as
+# sum(LAD)), and AB for het calls.
 # After discussion, we decided to use a GQ 20 threshold for both haploid and diploid
 # genotypes. See thread: https://atgu.slack.com/archives/CRA2TKTV0/p1787333884174549
 def annotate_adj_no_dp(
@@ -29,8 +31,8 @@ def annotate_adj_no_dp(
     Annotate genotypes with adj criteria.
 
     Defaults correspond to gnomAD values. DP is approximated as the sum of the allele
-    depths and is only applied to non-hom-ref calls; hom-ref calls are filtered on GQ
-    only. See the module comment for details.
+    depths. Hom-ref calls with no allele depths (reference blocks) are filtered on GQ
+    only; every other call uses the gnomAD cutoffs. See the module comment for details.
 
     Accepts three entry layouts:
 
@@ -100,9 +102,10 @@ def get_adj_expr(
     """
     Get adj genotype annotation.
 
-    Defaults correspond to gnomAD values. Hom-ref calls are filtered on GQ only. All
-    other calls use the standard gnomAD adj criteria (GQ, DP, and AB for het calls)
-    with DP approximated as the sum of `ad_expr`.
+    Defaults correspond to gnomAD values. Hom-ref calls with a missing `ad_expr`
+    (reference blocks) are filtered on GQ only. All other calls, including hom-ref
+    calls with defined allele depths, use the standard gnomAD adj criteria (GQ, DP,
+    and AB for het calls) with DP approximated as the sum of `ad_expr`.
 
     .. note::
 
@@ -112,15 +115,15 @@ def get_adj_expr(
     :param gq_expr: GQ expression.
     :param ad_expr: Allele depth expression.
     :param adj_gq: Minimum GQ. Default is 20.
-    :param adj_dp: Minimum DP (sum of allele depths) for non-hom-ref calls. Default is
-        10.
+    :param adj_dp: Minimum DP (sum of allele depths) for calls with allele depths.
+        Default is 10.
     :param adj_ab: Minimum allele balance for het calls. Default is 0.2.
-    :param haploid_adj_dp: Minimum DP (sum of allele depths) for haploid non-ref
-        calls. Default is 5.
+    :param haploid_adj_dp: Minimum DP (sum of allele depths) for haploid calls with
+        allele depths. Default is 5.
     :return: Expression for adj genotype annotation.
     """
     return hl.if_else(
-        gt_expr.is_hom_ref(),
+        gt_expr.is_hom_ref() & hl.is_missing(ad_expr),
         gq_expr >= adj_gq,
         get_gnomad_adj_expr(
             gt_expr,


### PR DESCRIPTION
After reviewing the AoU bam DP and GQ, we determined there was no reason to up the adj GQ threshold to 30 for AoU. This uses GQ>20 for ref calls (All will pass) and uses gnomAD's threshold for variant data.